### PR TITLE
Creating the first set of scaffolding for worker controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 coverage.*
 *.coverprofile
 profile.cov
+/test.log
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
@@ -30,3 +31,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Executables produced by temporal repo
+/temporal-managed-workers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*     @temporalio/compute

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+############################# Main targets #############################
+# Rebuild binaries (used by Dockerfile).
+bins: temporal-managed-workers
+
+# Install all tools, run all possible checks and tests (long but comprehensive).
+all: clean bins test
+
+# Delete all build artifacts
+clean: clean-bins clean-test-output
+########################################################################
+
+.PHONY: bins clean
+
+##### Variables ######
+
+COLOR := "\e[1;36m%s\e[0m\n"
+RED :=   "\e[1;31m%s\e[0m\n"
+
+ALL_SRC         := $(shell find . -name "*.go")
+ALL_SRC         += go.mod
+
+##### Binaries #####
+clean-bins:
+	@printf $(COLOR) "Delete old binaries..."
+	@rm -f temporal-managed-workers
+
+temporal-managed-workers: $(ALL_SRC)
+	@printf $(COLOR) "Build temporal-managed-workers with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
+	CGO_ENABLED=$(CGO_ENABLED) go build $(BUILD_TAG_FLAG) -o temporal-managed-workers ./cmd/worker
+
+##### Tests #####
+clean-test-output:
+	@printf $(COLOR) "Delete test output..."
+	@rm -rf $(TEST_OUTPUT_ROOT)
+	@go clean -testcache
+
+unit-test: clean-test-output
+	@printf $(COLOR) "Run unit tests..."
+	@CGO_ENABLED=$(CGO_ENABLED) go test $(UNIT_TEST_DIRS) $(COMPILED_TEST_ARGS) 2>&1 | tee -a test.log
+	@! grep -q "^--- FAIL" test.log
+
+test: unit-test
+
+##### Run server #####
+start: start-sqlite
+
+start-sqlite: temporal-managed-workers
+	./temporal-managed-workers --config-file config/development-sqlite.yaml --allow-no-auth start
+
+start-sqlite-file: temporal-managed-workers
+	./temporal-managed-workers --config-file config/development-sqlite-file.yaml --allow-no-auth start

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	_ "time/tzdata" // embed tzdata as a fallback
+
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/managed-workers/wci"
+	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/build"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"      // needed to load mysql plugin
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // needed to load postgresql plugin
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"     // needed to load sqlite plugin
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/temporal"
+)
+
+// main entry point for the temporal server
+func main() {
+	app := buildCLI()
+	_ = app.Run(os.Args)
+}
+
+// buildCLI is the main entry point for the temporal server
+func buildCLI() *cli.App {
+	app := cli.NewApp()
+	app.Name = "temporal-managed-workers"
+	app.Usage = "Temporal Managed workers - worker"
+	app.Version = headers.ServerVersion
+	app.ArgsUsage = " "
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "config-file",
+			Usage:   "path to config file (absolute or relative to current working directory)",
+			EnvVars: []string{config.EnvKeyConfigFile},
+		},
+		&cli.BoolFlag{
+			Name:    "allow-no-auth",
+			Usage:   "allow no authorizer",
+			EnvVars: []string{config.EnvKeyAllowNoAuth},
+		},
+	}
+
+	app.Commands = []*cli.Command{
+		{
+			Name:      "start",
+			Usage:     "Start Managed Temporal Workers support services",
+			ArgsUsage: " ",
+			Flags:     []cli.Flag{},
+			Before: func(c *cli.Context) error {
+				if c.Args().Len() > 0 {
+					return cli.Exit("ERROR: start command doesn't support arguments.", 1)
+				}
+				return nil
+			},
+			Action: func(c *cli.Context) error {
+				allowNoAuth := c.Bool("allow-no-auth")
+
+				var cfg *config.Config
+				var err error
+
+				switch {
+				case c.IsSet("config-file"):
+					cfg, err = config.Load(config.WithConfigFile(c.String("config-file")))
+				default:
+					cfg, err = config.Load(config.WithEmbedded())
+				}
+
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to load configuration: %v.", err), 1)
+				}
+
+				logger := log.NewZapLogger(log.BuildZapLogger(cfg.Log))
+				logger.Info("Build info.",
+					tag.NewTimeTag("git-time", build.InfoData.GitTime),
+					tag.NewStringTag("git-revision", build.InfoData.GitRevision),
+					tag.NewBoolTag("git-modified", build.InfoData.GitModified),
+					tag.NewStringTag("go-arch", build.InfoData.GoArch),
+					tag.NewStringTag("go-os", build.InfoData.GoOs),
+					tag.NewStringTag("go-version", build.InfoData.GoVersion),
+					tag.NewBoolTag("cgo-enabled", build.InfoData.CgoEnabled),
+					tag.NewStringTag("server-version", headers.ServerVersion),
+					tag.NewBoolTag("debug-mode", debug.Enabled),
+				)
+
+				var dynamicConfigClient dynamicconfig.Client
+				if cfg.DynamicConfigClient != nil {
+					dynamicConfigClient, err = dynamicconfig.NewFileBasedClient(cfg.DynamicConfigClient, logger, temporal.InterruptCh())
+					if err != nil {
+						return cli.Exit(fmt.Sprintf("Unable to create dynamic config client. Error: %v", err), 1)
+					}
+				} else {
+					dynamicConfigClient = dynamicconfig.NewNoopClient()
+					logger.Info("Dynamic config client is not configured. Using noop client.")
+				}
+
+				authorizer, err := authorization.GetAuthorizerFromConfig(
+					&cfg.Global.Authorization,
+				)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to instantiate authorizer. Error: %v", err), 1)
+				}
+				if authorization.IsNoopAuthorizer(authorizer) && !allowNoAuth {
+					logger.Warn(
+						"Not using any authorizer and flag `--allow-no-auth` not detected. " +
+							"Future versions will require using the flag `--allow-no-auth` " +
+							"if you do not want to set an authorizer.",
+					)
+				}
+
+				// Authorization mappers: claim and audience
+				claimMapper, err := authorization.GetClaimMapperFromConfig(&cfg.Global.Authorization, logger)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to instantiate claim mapper: %v.", err), 1)
+				}
+
+				audienceMapper, err := authorization.GetAudienceMapperFromConfig(&cfg.Global.Authorization)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to instantiate audience mapper: %v.", err), 1)
+				}
+
+				s, err := temporal.NewServer(
+					temporal.ForServices([]string{}),
+					temporal.WithExternalService(primitives.WorkerControllerService, wci.Module),
+					temporal.WithConfig(cfg),
+					temporal.WithDynamicConfigClient(dynamicConfigClient),
+					temporal.WithLogger(logger),
+					temporal.InterruptOn(temporal.InterruptCh()),
+					temporal.WithAuthorizer(authorizer),
+					temporal.WithClaimMapper(func(cfg *config.Config) authorization.ClaimMapper {
+						return claimMapper
+					}),
+					temporal.WithAudienceGetter(func(cfg *config.Config) authorization.JWTAudienceMapper {
+						return audienceMapper
+					}),
+				)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to create server. Error: %v.", err), 1)
+				}
+
+				err = s.Start()
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to start server. Error: %v", err), 1)
+				}
+				return cli.Exit("All services are stopped.", 0)
+			},
+		},
+	}
+	return app
+}

--- a/config/development-sqlite-file.yaml
+++ b/config/development-sqlite-file.yaml
@@ -1,0 +1,151 @@
+log:
+  stdout: true
+  level: info
+
+persistence:
+  defaultStore: sqlite-default
+  visibilityStore: sqlite-visibility
+  numHistoryShards: 1
+  datastores:
+    sqlite-default:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "sqlite"
+        databaseName: "../temporal/default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          cache: "private"
+          setup: true
+          journal_mode: wal
+          synchronous: 2
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+
+    sqlite-visibility:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "sqlite"
+        databaseName: "../temporal/default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          cache: "private"
+          setup: true
+          journal_mode: wal
+          synchronous: 2
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+global:
+  membership:
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7937
+  metrics:
+    prometheus:
+      #      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+      #      framework: "opentelemetry"
+      framework: "tally"
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
+
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      membershipPort: 6933
+      bindOnLocalHost: true
+      httpPort: 7243
+
+  matching:
+    rpc:
+      grpcPort: 7235
+      membershipPort: 6935
+      bindOnLocalHost: true
+
+  history:
+    rpc:
+      grpcPort: 7234
+      membershipPort: 6934
+      bindOnLocalHost: true
+
+  worker:
+    rpc:
+      grpcPort: 7239
+      membershipPort: 6939
+      bindOnLocalHost: true
+
+  worker-controller:
+    rpc:
+      grpcPort: 7240
+      membershipPort: 6940
+      bindOnLocalHost: true
+
+clusterMetadata:
+  enableGlobalNamespace: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 1
+      rpcName: "frontend"
+      rpcAddress: "localhost:7233"
+      httpAddress: "localhost:7243"
+
+dcRedirectionPolicy:
+  policy: "noop"
+
+archival:
+  history:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+namespaceDefaults:
+  archival:
+    history:
+      state: "disabled"
+      URI: "file:///tmp/temporal_archival/development"
+    visibility:
+      state: "disabled"
+      URI: "file:///tmp/temporal_vis_archival/development"
+
+publicClient:
+    hostPort: "127.0.0.1:7233"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development-sql.yaml"
+  pollInterval: "10s"

--- a/config/development-sqlite.yaml
+++ b/config/development-sqlite.yaml
@@ -1,0 +1,147 @@
+log:
+  stdout: true
+  level: info
+
+persistence:
+  defaultStore: sqlite-default
+  visibilityStore: sqlite-visibility
+  numHistoryShards: 1
+  datastores:
+    sqlite-default:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "sqlite"
+        databaseName: "default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          mode: "memory"
+          cache: "private"
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+
+    sqlite-visibility:
+      sql:
+        user: ""
+        password: ""
+        pluginName: "sqlite"
+        databaseName: "default"
+        connectAddr: "localhost"
+        connectProtocol: "tcp"
+        connectAttributes:
+          mode: "memory"
+          cache: "private"
+        maxConns: 1
+        maxIdleConns: 1
+        maxConnLifetime: "1h"
+        tls:
+          enabled: false
+          caFile: ""
+          certFile: ""
+          keyFile: ""
+          enableHostVerification: false
+          serverName: ""
+global:
+  membership:
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7937
+  metrics:
+    prometheus:
+#      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+#      framework: "opentelemetry"
+      framework: "tally"
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
+
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      membershipPort: 6933
+      bindOnLocalHost: true
+      httpPort: 7243
+
+  matching:
+    rpc:
+      grpcPort: 7235
+      membershipPort: 6935
+      bindOnLocalHost: true
+
+  history:
+    rpc:
+      grpcPort: 7234
+      membershipPort: 6934
+      bindOnLocalHost: true
+
+  worker:
+    rpc:
+      grpcPort: 7239
+      membershipPort: 6939
+      bindOnLocalHost: true
+
+  worker-controller:
+    rpc:
+      grpcPort: 7240
+      membershipPort: 6940
+      bindOnLocalHost: true
+
+clusterMetadata:
+  enableGlobalNamespace: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 1
+      rpcName: "frontend"
+      rpcAddress: "localhost:7233"
+      httpAddress: "localhost:7243"
+
+dcRedirectionPolicy:
+  policy: "noop"
+
+archival:
+  history:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+namespaceDefaults:
+  archival:
+    history:
+      state: "disabled"
+      URI: "file:///tmp/temporal_archival/development"
+    visibility:
+      state: "disabled"
+      URI: "file:///tmp/temporal_vis_archival/development"
+
+publicClient:
+    hostPort: "127.0.0.1:7233"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development-sql.yaml"
+  pollInterval: "10s"

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,0 +1,1 @@
+development-sqlite.yaml

--- a/config/dynamicconfig/README.md
+++ b/config/dynamicconfig/README.md
@@ -1,0 +1,40 @@
+Use `development-*.yaml` file to override the default dynamic config value (they are specified
+when creating the service config).
+
+Each key can have zero or more values and each value can have zero or more constraints.
+There are only three types of constraint:
+- `namespace: string`
+- `taskQueueName: string`
+- `taskType: int` (1:Workflow, 2:Activity)
+
+A value will be selected and returned if all its has exactly the same constraints
+as the ones specified in query filters (including the number of constraints).
+
+Please use the following format:
+```yaml
+testGetBoolPropertyKey:
+  - value: false
+  - value: true
+    constraints:
+      namespace: "global-samples-namespace"
+  - value: false
+    constraints:
+      namespace: "samples-namespace"
+testGetDurationPropertyKey:
+  - value: "1m"
+    constraints:
+      namespace: "samples-namespace"
+      taskQueueName: "longIdleTimeTaskqueue"
+testGetFloat64PropertyKey:
+  - value: 12.0
+    constraints:
+      namespace: "samples-namespace"
+testGetMapPropertyKey:
+  - value:
+      key1: 1
+      key2: "value 2"
+      key3:
+        - false
+        - key4: true
+          key5: 2.0
+```

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -1,0 +1,59 @@
+#history.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.throttledLogRPS:
+#- value: 20
+#  constraints: {}
+#history.defaultActivityRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+#history.defaultWorkflowRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+# system.secondaryVisibilityWritingMode:
+#  - value: "off"
+#    constraints: {}
+# system.enableReadFromSecondaryVisibility:
+#  - value: false
+#    constraints: {}
+#system.enableParentClosePolicyWorker:
+#  - value: true
+frontend.workerVersioningDataAPIs:
+  - value: true
+frontend.workerVersioningWorkflowAPIs:
+  - value: true
+system.enableDeployments:
+  - value: true
+system.enableDeploymentVersions:
+  - value: true
+frontend.workerVersioningRuleAPIs:
+  - value: true
+system.enableNexus:
+  - value: true
+component.nexusoperations.callback.endpoint.template:
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
+component.callbacks.allowedAddresses:
+  - value:
+      - Pattern: "*"
+        AllowInsecure: true
+matching.queryWorkflowTaskTimeoutLogRate:
+  - value: 1.0
+history.ReplicationEnableUpdateWithNewTaskMerge:
+  - value: true
+history.hostLevelCacheMaxSize:
+  - value: 8192
+history.enableTransitionHistory:
+  - value: true
+history.enableChasm:
+  - value: true
+activity.enableStandalone:
+  - value: true

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -1,0 +1,77 @@
+#history.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.throttledLogRPS:
+#- value: 20
+#  constraints: {}
+#history.defaultActivityRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+#history.defaultWorkflowRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+#system.secondaryVisibilityWritingMode:
+#  - value: "off"
+#    constraints: {}
+#system.enableReadFromSecondaryVisibility:
+#  - value: false
+#    constraints: {}
+#system.enableParentClosePolicyWorker:
+#  - value: true
+
+### Worker Versioning Replay Test configs
+### uncomment and set the right deploymentWorkflowVersion
+#
+#matching.deploymentWorkflowVersion:
+# - value: 2 # put the integer value of the workflow version you want to target (enum DeploymentWorkflowVersion)
+#matching.PollerHistoryTTL:
+# - value: 1s
+#matching.wv.VersionDrainageStatusVisibilityGracePeriod:
+# - value: 5s
+#matching.wv.VersionDrainageStatusRefreshInterval:
+# - value: 5s
+#
+### END of Worker Versioning Replay Test configs
+
+limit.maxIDLength:
+  - value: 255
+    constraints: {}
+frontend.workerVersioningDataAPIs:
+  - value: true
+frontend.workerVersioningWorkflowAPIs:
+  - value: true
+frontend.workerVersioningRuleAPIs:
+  - value: true
+system.enableDeploymentVersions:
+  - value: true
+system.enableDeployments:
+  - value: true
+system.enableNexus:
+  - value: true
+component.nexusoperations.callback.endpoint.template:
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
+component.callbacks.allowedAddresses:
+  - value:
+      - Pattern: "*"
+        AllowInsecure: true
+matching.queryWorkflowTaskTimeoutLogRate:
+  - value: 1.0
+history.ReplicationEnableUpdateWithNewTaskMerge:
+  - value: true
+history.hostLevelCacheMaxSize:
+  - value: 8192
+history.enableTransitionHistory:
+  - value: true
+history.enableChasm:
+  - value: true
+activity.enableStandalone:
+  - value: true

--- a/config/dynamicconfig/development-xdc.yaml
+++ b/config/dynamicconfig/development-xdc.yaml
@@ -1,0 +1,53 @@
+#history.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.persistenceMaxQPS:
+#- value: 3000
+#  constraints: {}
+#frontend.throttledLogRPS:
+#- value: 20
+#  constraints: {}
+#history.defaultActivityRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+#history.defaultWorkflowRetryPolicy:
+#- value:
+#    InitialIntervalInSeconds: 1
+#    MaximumIntervalCoefficient: 100.0
+#    BackoffCoefficient: 2.0
+#    MaximumAttempts: 0
+#system.secondaryVisibilityWritingMode:
+#  - value: "off"
+#    constraints: {}
+#system.enableReadFromSecondaryVisibility:
+#  - value: false
+#    constraints: {}
+#system.enableParentClosePolicyWorker:
+#  - value: true
+frontend.workerVersioningDataAPIs:
+  - value: true
+frontend.workerVersioningWorkflowAPIs:
+  - value: true
+system.enableNexus:
+  - value: true
+component.nexusoperations.callback.endpoint.template:
+  - value: http://localhost:7243/namespaces/{{.NamespaceName}}/nexus/callback
+component.callbacks.allowedAddresses:
+  - value:
+      - Pattern: "*"
+        AllowInsecure: true
+matching.queryWorkflowTaskTimeoutLogRate:
+  - value: 1.0
+history.ReplicationEnableUpdateWithNewTaskMerge:
+  - value: true
+history.enableTransitionHistory:
+  - value: true
+history.EnableReplicationTaskTieredProcessing:
+  - value: true
+history.enableChasm:
+  - value: true
+activity.enableStandalone:
+  - value: true

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go.temporal.io/managed-workers
+
+go 1.25.6

--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -1,0 +1,21 @@
+package client
+
+import "go.temporal.io/server/common/dynamicconfig"
+
+var (
+	WorkerControllerEnabled = dynamicconfig.NewNamespaceBoolSetting(
+		"workercontroller.enabled",
+		false,
+		`WorkerControllerEnabled is a "feature enable" flag. When enabled it allows clients to configure compute providers.`,
+	)
+	WorkerControllerMaxInstances = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.maxInstances",
+		100,
+		`WorkerControllerMaxInstances represents the maximum number of worker controller instances that can be registered in a single namespace`,
+	)
+	WorkerControllerInstanceWorkflowVersion = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.instanceWorkflowVersion",
+		0,
+		`WorkerControllerInstanceWorkflowVersion controls what version of the logic should the manager workflows use.`,
+	)
+)

--- a/wci/client/id.go
+++ b/wci/client/id.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"strings"
+
+	deploymentpb "go.temporal.io/api/deployment/v1"
+)
+
+const (
+	WorkerControllerInstanceDelimiter        = ":"
+	WorkerControllerInstanceWorkflowIDPrefix = "temporal-sys-worker-controller-instance"
+)
+
+// GenerateWorkerControllerInstanceWorkflowID is a helper that generates a system accepted
+// workflowID which are used in our Worker Controller Instance workflows
+func GenerateWorkerControllerInstanceWorkflowID(version *deploymentpb.WorkerDeploymentVersion) string {
+	return WorkerControllerInstanceWorkflowIDPrefix + WorkerControllerInstanceDelimiter + version.DeploymentName + WorkerControllerInstanceDelimiter + version.BuildId
+}
+
+// GetDeploymentNameBuildIdFromWorkflowID parses the system accepted workflowID of a Worker Controller Instance workflow
+// into its parts
+func GetDeploymentNameBuildIdFromWorkflowID(workflowId string) *deploymentpb.WorkerDeploymentVersion {
+	parts := strings.Split(workflowId, WorkerControllerInstanceDelimiter)
+	if len(parts) >= 3 {
+		return &deploymentpb.WorkerDeploymentVersion{DeploymentName: parts[1], BuildId: parts[2]}
+	} else {
+		return &deploymentpb.WorkerDeploymentVersion{DeploymentName: parts[0], BuildId: ""}
+	}
+}

--- a/wci/component.go
+++ b/wci/component.go
@@ -1,0 +1,45 @@
+package wci
+
+import (
+	"go.temporal.io/managed-workers/wci/client"
+	instancewf "go.temporal.io/managed-workers/wci/workflow"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
+	workercommon "go.temporal.io/server/service/worker/common"
+	"go.uber.org/fx"
+)
+
+type (
+	workerComponent struct {
+		dynamicConfig *dynamicconfig.Collection
+	}
+
+	fxComponentResult struct {
+		fx.Out
+		Component workercommon.PerNSWorkerComponent `group:"perNamespaceWorkerComponent"`
+	}
+)
+
+func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
+	return &workercommon.PerNSDedicatedWorkerOptions{
+		Enabled: true,
+	}
+}
+
+func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Namespace, details workercommon.RegistrationDetails) func() {
+	versionWorkflow := func(ctx workflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) error {
+		workflowVersionGetter := func() instancewf.WorkerControllerInstanceWorkflowVersion {
+			return instancewf.WorkerControllerInstanceWorkflowVersion(client.WorkerControllerInstanceWorkflowVersion.Get(s.dynamicConfig)(ns.Name().String()))
+		}
+		maxVersionsGetter := func() int {
+			return client.WorkerControllerMaxInstances.Get(s.dynamicConfig)(ns.Name().String())
+		}
+		return instancewf.Workflow(ctx, workflowVersionGetter, maxVersionsGetter, args)
+	}
+	registry.RegisterWorkflowWithOptions(versionWorkflow, workflow.RegisterOptions{Name: iface.WorkerControllerInstanceWorkflowType})
+
+	return nil
+}

--- a/wci/config.go
+++ b/wci/config.go
@@ -1,0 +1,31 @@
+package wci
+
+import (
+	"go.temporal.io/managed-workers/wci/client"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/service/worker"
+)
+
+type (
+	// Config contains all the service config for worker
+	Config struct {
+		worker.Config
+
+		PerNamespaceMaxWorkerControllerInstances            dynamicconfig.TypedPropertyFnWithNamespaceFilter[int]
+		PerNamespaceWorkerControllerInstanceWorkflowVersion dynamicconfig.TypedPropertyFnWithNamespaceFilter[int]
+	}
+)
+
+// NewConfig builds the new Config for worker service
+func NewConfig(
+	dc *dynamicconfig.Collection,
+	persistenceConfig *config.Persistence,
+) *Config {
+	return &Config{
+		Config: *worker.NewConfig(dc, persistenceConfig),
+
+		PerNamespaceMaxWorkerControllerInstances:            client.WorkerControllerMaxInstances.Get(dc),
+		PerNamespaceWorkerControllerInstanceWorkflowVersion: client.WorkerControllerInstanceWorkflowVersion.Get(dc),
+	}
+}

--- a/wci/fx.go
+++ b/wci/fx.go
@@ -1,0 +1,141 @@
+// Package wci contains the implementation for the worker controller instances
+package wci
+
+import (
+	"os"
+
+	"go.temporal.io/managed-workers/wci/client"
+	"go.temporal.io/server/chasm"
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/persistence/visibility"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/service"
+	"go.temporal.io/server/service/worker"
+	"go.temporal.io/server/service/worker/migration"
+	"go.uber.org/fx"
+)
+
+var Module = fx.Options(
+	migration.Module,
+	resource.Module,
+	fx.Provide(HostInfoProvider),
+	fx.Provide(VisibilityManagerProvider),
+	fx.Provide(ThrottledLoggerRpsFnProvider),
+	fx.Provide(ConfigProvider),
+	fx.Provide(WorkerConfigProvider),
+	fx.Provide(PersistenceRateLimitingParamsProvider),
+	service.PersistenceLazyLoadedServiceResolverModule,
+	fx.Provide(ServiceResolverProvider),
+	fx.Provide(ComponentProvider),
+	fx.Supply(fx.Annotate(util.Ptr(client.WorkerControllerPerNSWorkerTaskQueue), fx.ResultTags(`name:"per_ns_task_queue_name"`))),
+	fx.Provide(NewService),
+	fx.Provide(worker.NewPerNamespaceWorkerManager),
+	fx.Invoke(ServiceLifetimeHooks),
+)
+
+func HostInfoProvider() (membership.HostInfo, error) {
+	hn, err := os.Hostname()
+	return membership.NewHostInfoFromAddress(hn), err
+}
+
+func ThrottledLoggerRpsFnProvider(serviceConfig *Config) resource.ThrottledLoggerRpsFn {
+	return func() float64 { return float64(serviceConfig.ThrottledLogRPS()) }
+}
+
+func ServiceResolverProvider(
+	membershipMonitor membership.Monitor,
+) (membership.ServiceResolver, error) {
+	return membershipMonitor.GetResolver(primitives.WorkerControllerService)
+}
+
+func ConfigProvider(
+	dc *dynamicconfig.Collection,
+	persistenceConfig *config.Persistence,
+) *Config {
+	return NewConfig(
+		dc,
+		persistenceConfig,
+	)
+}
+
+func WorkerConfigProvider(config *Config) *worker.Config {
+	return &config.Config
+}
+
+func ComponentProvider(dc *dynamicconfig.Collection) fxComponentResult {
+	return fxComponentResult{
+		Component: &workerComponent{dynamicConfig: dc},
+	}
+}
+
+func PersistenceRateLimitingParamsProvider(
+	serviceConfig *Config,
+	persistenceLazyLoadedServiceResolver service.PersistenceLazyLoadedServiceResolver,
+	logger log.SnTaggedLogger,
+) service.PersistenceRateLimitingParams {
+	return service.NewPersistenceRateLimitingParams(
+		serviceConfig.PersistenceMaxQPS,
+		serviceConfig.PersistenceGlobalMaxQPS,
+		serviceConfig.PersistenceNamespaceMaxQPS,
+		serviceConfig.PersistenceGlobalNamespaceMaxQPS,
+		serviceConfig.PersistencePerShardNamespaceMaxQPS,
+		serviceConfig.OperatorRPSRatio,
+		serviceConfig.PersistenceQPSBurstRatio,
+		serviceConfig.PersistenceDynamicRateLimitingParams,
+		persistenceLazyLoadedServiceResolver,
+		logger,
+	)
+}
+
+func VisibilityManagerProvider(
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+	persistenceConfig *config.Persistence,
+	customVisibilityStoreFactory visibility.VisibilityStoreFactory,
+	serviceConfig *Config,
+	persistenceServiceResolver resolver.ServiceResolver,
+	searchAttributesMapperProvider searchattribute.MapperProvider,
+	saProvider searchattribute.Provider,
+	namespaceRegistry namespace.Registry,
+	chasmRegistry *chasm.Registry,
+	serializer serialization.Serializer,
+) (manager.VisibilityManager, error) {
+	return visibility.NewManager(
+		*persistenceConfig,
+		persistenceServiceResolver,
+		customVisibilityStoreFactory,
+		nil, // worker visibility never write
+		saProvider,
+		searchAttributesMapperProvider,
+		namespaceRegistry,
+		chasmRegistry,
+		serviceConfig.VisibilityPersistenceMaxReadQPS,
+		serviceConfig.VisibilityPersistenceMaxWriteQPS,
+		serviceConfig.OperatorRPSRatio,
+		serviceConfig.VisibilityPersistenceSlowQueryThreshold,
+		serviceConfig.EnableReadFromSecondaryVisibility,
+		serviceConfig.VisibilityEnableShadowReadMode,
+		dynamicconfig.GetStringPropertyFn(visibility.SecondaryVisibilityWritingModeOff), // worker visibility never write
+		serviceConfig.VisibilityDisableOrderByClause,
+		serviceConfig.VisibilityEnableManualPagination,
+		serviceConfig.VisibilityEnableUnifiedQueryConverter,
+		metricsHandler,
+		logger,
+		serializer,
+	)
+}
+
+func ServiceLifetimeHooks(lc fx.Lifecycle, svc *Service) {
+	lc.Append(fx.StartStopHook(svc.Start, svc.Stop))
+}

--- a/wci/service.go
+++ b/wci/service.go
@@ -1,0 +1,145 @@
+package wci
+
+import (
+	"context"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/service/worker"
+)
+
+type (
+	Service struct {
+		logger                          log.Logger
+		clusterMetadata                 cluster.Metadata
+		metadataManager                 persistence.MetadataManager
+		membershipMonitor               membership.Monitor
+		hostInfo                        membership.HostInfo
+		historyClient                   resource.HistoryClient
+		namespaceRegistry               namespace.Registry
+		workerControllerServiceResolver membership.ServiceResolver
+		visibilityManager               manager.VisibilityManager
+
+		metricsHandler metrics.Handler
+
+		sdkClientFactory sdk.ClientFactory
+		config           *Config
+
+		matchingClient matchingservice.MatchingServiceClient
+
+		perNamespaceWorkerManager *worker.PerNamespaceWorkerManager
+	}
+)
+
+func NewService(
+	logger log.SnTaggedLogger,
+	serviceConfig *Config,
+	sdkClientFactory sdk.ClientFactory,
+	clusterMetadata cluster.Metadata,
+	namespaceRegistry namespace.Registry,
+	membershipMonitor membership.Monitor,
+	hostInfoProvider membership.HostInfoProvider,
+	metricsHandler metrics.Handler,
+	historyClient resource.HistoryClient,
+	visibilityManager manager.VisibilityManager,
+	matchingClient resource.MatchingClient,
+	metadataManager persistence.MetadataManager,
+	perNamespaceWorkerManager *worker.PerNamespaceWorkerManager,
+) (*Service, error) {
+	workerControllerServiceResolver, err := membershipMonitor.GetResolver(primitives.WorkerControllerService)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Service{
+		config:                          serviceConfig,
+		sdkClientFactory:                sdkClientFactory,
+		logger:                          logger,
+		clusterMetadata:                 clusterMetadata,
+		metadataManager:                 metadataManager,
+		namespaceRegistry:               namespaceRegistry,
+		membershipMonitor:               membershipMonitor,
+		hostInfo:                        hostInfoProvider.HostInfo(),
+		metricsHandler:                  metricsHandler,
+		historyClient:                   historyClient,
+		workerControllerServiceResolver: workerControllerServiceResolver,
+		visibilityManager:               visibilityManager,
+
+		matchingClient: matchingClient,
+
+		perNamespaceWorkerManager: perNamespaceWorkerManager,
+	}
+	return s, nil
+}
+
+func (s *Service) Start() {
+	s.logger.Info(
+		"worker-controller starting",
+		tag.ComponentWorkerController,
+	)
+
+	metrics.RestartCount.With(s.metricsHandler).Record(1)
+
+	s.clusterMetadata.Start()
+	s.namespaceRegistry.Start()
+	s.membershipMonitor.Start()
+
+	s.ensureSystemNamespaceExists(context.TODO())
+
+	s.perNamespaceWorkerManager.Start(
+		// TODO: get these from fx instead of passing through Start
+		s.hostInfo,
+		s.workerControllerServiceResolver,
+	)
+
+	s.logger.Info(
+		"worker-controller service started",
+		tag.ComponentWorkerController,
+		tag.Address(s.hostInfo.GetAddress()),
+	)
+}
+
+// Stop is called to stop the service
+func (s *Service) Stop() {
+	s.perNamespaceWorkerManager.Stop()
+	s.namespaceRegistry.Stop()
+	s.clusterMetadata.Stop()
+	s.visibilityManager.Close()
+
+	s.logger.Info(
+		"worker-controller service stopped",
+		tag.ComponentWorkerController,
+		tag.Address(s.hostInfo.GetAddress()),
+	)
+}
+
+func (s *Service) ensureSystemNamespaceExists(
+	ctx context.Context,
+) {
+	_, err := s.metadataManager.GetNamespace(ctx, &persistence.GetNamespaceRequest{Name: primitives.SystemLocalNamespace})
+	switch err.(type) {
+	case nil:
+		// noop
+	case *serviceerror.NamespaceNotFound:
+		s.logger.Fatal(
+			"temporal-system namespace does not exist",
+			tag.Error(err),
+		)
+	default:
+		s.logger.Fatal(
+			"failed to verify if temporal system namespace exists",
+			tag.Error(err),
+		)
+	}
+}

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -1,0 +1,9 @@
+package workflow
+
+import "go.temporal.io/server/common/namespace"
+
+type (
+	Activities struct {
+		namespace *namespace.Namespace
+	}
+)

--- a/wci/workflow/iface/metrics.go
+++ b/wci/workflow/iface/metrics.go
@@ -1,0 +1,8 @@
+package iface
+
+import "go.temporal.io/server/common/metrics"
+
+var (
+	WorkerControllerInstanceCreated              = metrics.NewCounterDef("worker_controller_instance_created")
+	WorkerControllerInstanceVisibilityQueryCount = metrics.NewCounterDef("worker_controller_instance_visibility_query_count")
+)

--- a/wci/workflow/iface/wf_iface.go
+++ b/wci/workflow/iface/wf_iface.go
@@ -1,0 +1,115 @@
+// Package iface contains the interface definitions to interact with the WCI workflows
+// these are internal to the project. External callers should use the Client
+package iface
+
+import (
+	"errors"
+	"fmt"
+
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// Workflow types
+	WorkerControllerInstanceWorkflowType = "temporal-sys-worker-controller-instance-workflow"
+
+	// Namespace division
+	WorkerControllerInstanceNamespaceDivision = "TemporalWorkerControllerInstance"
+
+	// Queries
+	QueryDescribeWorkerControllerInstance = "describe-wci"
+
+	// Memos
+	WorkerControllerInstanceMemoField = "WorkerControllerInstanceMemo"
+
+	// Updates
+	UpdateWorkerControllerInstance = "update-worker-controller-instance"
+	DeleteWorkerControllerInstance = "delete-worker-controller-instance"
+
+	// Errors
+	ErrInstanceDeleted    = "worker deployment deleted" // returned in the race condition that the deployment is deleted but the workflow is not yet closed.
+	ErrLongHistory        = "errLongHistory"            // update is not accepted until CaN happens. client should retry
+	ErrFailedPrecondition = "FailedPrecondition"
+)
+
+var WorkerControllerInstanceVisibilityBaseListQuery = fmt.Sprintf(
+	"%s = '%s' AND %s = '%s' AND %s = '%s'",
+	sadefs.WorkflowType,
+	WorkerControllerInstanceWorkflowType,
+	sadefs.TemporalNamespaceDivision,
+	WorkerControllerInstanceNamespaceDivision,
+	sadefs.ExecutionStatus,
+	enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String(),
+)
+
+type (
+	ComputeProviderDetails struct {
+		ProviderType     string
+		ProviderSettings map[string]string
+	}
+
+	WorkerControllerInstanceWorkflowArgs struct {
+		NamespaceName  string `protobuf:"bytes,1,opt,name=namespace_name,json=namespaceName,proto3" json:"namespace_name,omitempty"`
+		NamespaceId    string `protobuf:"bytes,2,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
+		DeploymentName string `protobuf:"bytes,3,opt,name=deployment_name,json=deploymentName,proto3" json:"deployment_name,omitempty"`
+		BuildID        string
+
+		State *WorkerControllerInstanceLocalState
+	}
+
+	WorkerControllerInstanceLocalState struct {
+		ComputeProviderDetails *ComputeProviderDetails
+
+		ConflictToken        []byte
+		CreateTime           *timestamppb.Timestamp
+		LastModifierIdentity string
+	}
+
+	QueryDescribeWorkerControllInstanceResponse struct {
+		DeploymentName string
+		BuildId        string
+		CreateTime     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+
+		ComputeProviderDetails *ComputeProviderDetails
+
+		ConflictToken        []byte `protobuf:"bytes,4,opt,name=conflict_token,json=conflictToken,proto3" json:"conflict_token,omitempty"`
+		LastModifierIdentity string `protobuf:"bytes,5,opt,name=last_modifier_identity,json=lastModifierIdentity,proto3" json:"last_modifier_identity,omitempty"`
+	}
+
+	UpdateWorkerControllerInstanceRequest struct {
+		Identity      string
+		ConflictToken []byte
+
+		ComputeProviderDetails *ComputeProviderDetails
+	}
+
+	UpdateWorkerControllerInstanceResponse struct{}
+
+	DeleteWorkerControllerInstanceRequest struct {
+		Identity string
+	}
+	DeleteWorkerControllerInstanceResponse struct{}
+
+	WorkerControllerInstanceMemo struct {
+		DeploymentName string
+		BuildId        string
+		CreateTime     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+	}
+)
+
+func DecodeWorkerControllerInstanceMemo(memo *commonpb.Memo) (*WorkerControllerInstanceMemo, error) {
+	if memo == nil || memo.Fields == nil {
+		return nil, errors.New("decoding WorkerControllerInstanceMemo failed: Memo or it's fields are nil")
+	}
+
+	var workerControllerInstanceWorkflowMemo WorkerControllerInstanceMemo
+	err := sdk.PreferProtoDataConverter.FromPayload(memo.Fields[WorkerControllerInstanceMemoField], &workerControllerInstanceWorkflowMemo)
+	if err != nil {
+		return nil, err
+	}
+	return &workerControllerInstanceWorkflowMemo, nil
+}

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -1,0 +1,260 @@
+// Package workflow contains the actual workflow of a worker controller instance
+package workflow
+
+import (
+	"bytes"
+	"errors"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	sdkclient "go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type WorkerControllerInstanceWorkflowVersion int64
+
+const (
+	// Versions of workflow logic. When introducing a new version, consider generating a new
+	// history for TestReplays using generate_history.sh.
+
+	// Represents the very first version of the workflow
+	InitialVersion WorkerControllerInstanceWorkflowVersion = iota
+)
+
+type (
+	// SignalHandler encapsulates the signal handling logic
+	SignalHandler struct {
+		signalSelector    workflow.Selector
+		processingSignals int
+	}
+
+	// WorkflowRunner holds the local state while running a worker controller workflow
+	WorkflowRunner struct {
+		*iface.WorkerControllerInstanceWorkflowArgs
+		a             *Activities
+		logger        sdklog.Logger
+		metrics       sdkclient.MetricsHandler
+		lock          workflow.Mutex
+		conflictToken []byte
+
+		deleteInstance   bool
+		unsafeMaxVersion func() int
+
+		// stateChanged is used to track if the state of the workflow has undergone a local state change since the last signal/update.
+		// This prevents a workflow from continuing-as-new if the state has not changed.
+		stateChanged  bool
+		signalHandler *SignalHandler
+		forceCAN      bool
+
+		// workflowVersion is set at workflow start based on the dynamic config of the worker
+		// that completes the first task. It remains constant for the lifetime of the run and
+		// only updates when the workflow performs continue-as-new.
+		workflowVersion WorkerControllerInstanceWorkflowVersion
+	}
+)
+
+// Workflow is implemented in a way such that it always CaNs after some
+// history events are added to it and when it has no pending work to do. This is to keep the
+// history clean so that we have less concern about backwards and forwards compatibility.
+// In steady state (i.e. absence of ongoing updates or signals) the wf should only have
+// a single wft in the history.
+func Workflow(ctx workflow.Context, unsafeWorkflowVersionGetter func() WorkerControllerInstanceWorkflowVersion, unsafeMaxVersion func() int, args *iface.WorkerControllerInstanceWorkflowArgs) error {
+	workflowRunner := &WorkflowRunner{
+		WorkerControllerInstanceWorkflowArgs: args,
+		workflowVersion:                      getWorkflowVersion(ctx, unsafeWorkflowVersionGetter),
+		a:                                    nil,
+		logger:                               sdklog.With(workflow.GetLogger(ctx), "wf-namespace", args.NamespaceName),
+		metrics:                              workflow.GetMetricsHandler(ctx).WithTags(map[string]string{"namespace": args.NamespaceName}),
+		lock:                                 workflow.NewMutex(ctx),
+		unsafeMaxVersion:                     unsafeMaxVersion,
+		signalHandler: &SignalHandler{
+			signalSelector: workflow.NewSelector(ctx),
+		},
+	}
+
+	return workflowRunner.run(ctx)
+}
+
+func (d *WorkflowRunner) run(ctx workflow.Context) error {
+	// make sure we got all fields we want
+	if d.State == nil {
+		d.State = &iface.WorkerControllerInstanceLocalState{}
+	}
+	if d.State.CreateTime == nil {
+		d.State.CreateTime = timestamppb.New(workflow.Now(ctx))
+	}
+	if d.State.ConflictToken == nil {
+		d.State.ConflictToken, _ = workflow.Now(ctx).MarshalBinary()
+	}
+	if err := d.updateMemo(ctx); err != nil {
+		return err
+	}
+	d.metrics.Counter(iface.WorkerControllerInstanceCreated.Name()).Inc(1)
+
+	err := workflow.SetQueryHandler(ctx, iface.QueryDescribeWorkerControllerInstance, func() (*iface.QueryDescribeWorkerControllInstanceResponse, error) {
+		if d.deleteInstance {
+			return nil, errors.New(iface.ErrInstanceDeleted)
+		}
+		return &iface.QueryDescribeWorkerControllInstanceResponse{
+			DeploymentName: d.DeploymentName,
+			BuildId:        d.BuildID,
+
+			ComputeProviderDetails: d.State.ComputeProviderDetails,
+
+			ConflictToken:        d.State.ConflictToken,
+			CreateTime:           d.State.CreateTime,
+			LastModifierIdentity: d.State.LastModifierIdentity,
+		}, nil
+	})
+	if err != nil {
+		d.logger.Info("SetQueryHandler failed for WorkerControllerInstance workflow with error: " + err.Error())
+		return err
+	}
+
+	if err = workflow.SetUpdateHandlerWithOptions(ctx, iface.UpdateWorkerControllerInstance, d.handleUpdateInstance, workflow.UpdateHandlerOptions{Validator: d.validateUpdateInstance}); err != nil {
+		return err
+	}
+	if err = workflow.SetUpdateHandlerWithOptions(ctx, iface.DeleteWorkerControllerInstance, d.handleDeleteInstance, workflow.UpdateHandlerOptions{Validator: d.validateDeleteInstance}); err != nil {
+		return err
+	}
+
+	// Listen to signals in a different goroutine to make business logic clearer
+	// workflow.Go(ctx, d.listenToSignals)
+
+	// Wait until we can continue as new or are cancelled. The workflow will continue-as-new iff
+	// there are no pending updates/signals and the state has changed.
+	err = workflow.Await(ctx, func() bool {
+		return d.deleteInstance || // instance is deleted -> it's ok to drop all signals and updates.
+			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
+			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
+				(d.forceCAN || d.stateChanged))
+	})
+	if err != nil {
+		return err
+	}
+
+	if d.deleteInstance {
+		return nil
+	}
+
+	// We perform a continue-as-new after each update and signal is handled to ensure compatibility
+	// even if the server rolls back to a previous minor version. By continuing-as-new,
+	// we pass the current state as input to the next workflow execution, resulting in a new
+	// workflow history with just two initial events. This minimizes the risk of NDE (Non-Deterministic Execution)
+	// errors during server rollbacks.
+	return workflow.NewContinueAsNewError(ctx, iface.WorkerControllerInstanceWorkflowType, d.WorkerControllerInstanceWorkflowArgs)
+}
+
+func (d *WorkflowRunner) validateUpdateInstance(args *iface.UpdateWorkerControllerInstanceRequest) error {
+	if err := d.ensureNotDeleted(); err != nil {
+		return err
+	}
+	if args.ComputeProviderDetails == nil {
+		return temporal.NewApplicationError("missing compute provider details", iface.ErrFailedPrecondition)
+	}
+	if args.ConflictToken != nil && !bytes.Equal(args.ConflictToken, d.State.ConflictToken) {
+		return temporal.NewApplicationError("conflict token mismatch", iface.ErrFailedPrecondition)
+	}
+	return nil
+}
+
+func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.UpdateWorkerControllerInstanceRequest) (*iface.UpdateWorkerControllerInstanceResponse, error) {
+	if err := d.preUpdateChecks(ctx); err != nil {
+		return nil, err
+	}
+
+	// use lock to enforce only one update at a time
+	err := d.lock.Lock(ctx)
+	if err != nil {
+		d.logger.Error("Could not acquire workflow lock")
+		return nil, serviceerror.NewDeadlineExceeded("Could not acquire workflow lock")
+	}
+	defer func() {
+		// Even if the update doesn't change the state we mark it as dirty because of created history events.
+		d.stateChanged = true
+		d.lock.Unlock()
+	}()
+
+	return &iface.UpdateWorkerControllerInstanceResponse{}, nil
+}
+
+func (d *WorkflowRunner) validateDeleteInstance(args *iface.DeleteWorkerControllerInstanceRequest) error {
+	if err := d.ensureNotDeleted(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.DeleteWorkerControllerInstanceRequest) (*iface.DeleteWorkerControllerInstanceResponse, error) {
+	if err := d.preUpdateChecks(ctx); err != nil {
+		return &iface.DeleteWorkerControllerInstanceResponse{}, err
+	}
+
+	// use lock to enforce only one update at a time
+	err := d.lock.Lock(ctx)
+	if err != nil {
+		d.logger.Error("Could not acquire workflow lock")
+		return &iface.DeleteWorkerControllerInstanceResponse{}, serviceerror.NewDeadlineExceeded("Could not acquire workflow lock")
+	}
+	defer func() {
+		// Even if the update doesn't change the state we mark it as dirty because of created history events.
+		d.stateChanged = true
+		d.lock.Unlock()
+	}()
+
+	d.deleteInstance = true
+
+	return &iface.DeleteWorkerControllerInstanceResponse{}, nil
+}
+
+func (d *WorkflowRunner) hasMinVersion(version WorkerControllerInstanceWorkflowVersion) bool {
+	return d.workflowVersion >= version
+}
+
+func (d *WorkflowRunner) preUpdateChecks(ctx workflow.Context) error {
+	err := d.ensureNotDeleted()
+	if err != nil {
+		return err
+	}
+
+	if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+		// History is too large, do not accept new updates until wf CaNs.
+		// Since this needs workflow context we cannot do it in validators.
+		return temporal.NewApplicationError(iface.ErrLongHistory, iface.ErrLongHistory)
+	}
+	return nil
+}
+
+func (d *WorkflowRunner) ensureNotDeleted() error {
+	if d.deleteInstance {
+		return temporal.NewNonRetryableApplicationError(iface.ErrInstanceDeleted, iface.ErrInstanceDeleted, nil)
+	}
+	return nil
+}
+
+func (d *WorkflowRunner) updateMemo(ctx workflow.Context) error {
+	return workflow.UpsertMemo(ctx, map[string]any{
+		iface.WorkerControllerInstanceMemoField: &iface.WorkerControllerInstanceMemo{
+			DeploymentName: d.DeploymentName,
+			BuildId:        d.BuildID,
+			CreateTime:     d.State.CreateTime,
+		},
+	})
+}
+
+func getWorkflowVersion(ctx workflow.Context, unsafeWorkflowVersionGetter func() WorkerControllerInstanceWorkflowVersion) WorkerControllerInstanceWorkflowVersion {
+	if workflow.GetVersion(ctx, "workflowVersionAdded", workflow.DefaultVersion, 0) >= 0 {
+		var ver WorkerControllerInstanceWorkflowVersion
+		err := workflow.MutableSideEffect(ctx, "workflowVersion",
+			func(_ workflow.Context) any { return unsafeWorkflowVersionGetter() },
+			func(a, b any) bool { return a == b }).
+			Get(&ver)
+		if err == nil {
+			return ver
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## What was changed
This adds the first set of scaffolding for the worker controller. It adds the workflow definition and a worker executable (that re-uses existing server capabilities)

## Why?
We are looking to have the worker controller instances be a separate deployment unit to enable faster iteration.

## Checklist 

Closes https://temporalio.atlassian.net/browse/COM-13