### PR TITLE
Add first iteration of WCI client

### DIFF
--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -1,0 +1,488 @@
+// Package client contains the client to interact with Worker Controller Instance workflows
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonpb "go.temporal.io/api/common/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/testing/testhooks"
+	"go.temporal.io/server/common/worker_versioning"
+)
+
+const (
+	WorkerControllerPerNSWorkerTaskQueue = "temporal-sys-worker-controller-per-ns-tq"
+
+	// minSignalIntervalNoSyncMatch is the minimum time between SignalWorkflowExecution calls per (namespace, workflow ID) for no-sync matches.
+	minSignalIntervalNoSyncMatch = 500 * time.Millisecond
+	// minSignalIntervalSyncMatch is the minimum time between SignalWorkflowExecution calls per (namespace, workflow ID) for sync matches.
+	minSignalIntervalSyncMatch = 1 * time.Minute
+)
+
+type (
+	Client interface {
+		WorkerControllerInstanceExists(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			version *deploymentpb.WorkerDeploymentVersion,
+		) (bool, error)
+
+		DescribeWorkerControllerInstance(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			version *deploymentpb.WorkerDeploymentVersion,
+		) (*iface.QueryDescribeWorkerControllerInstanceResponse, []byte, error)
+
+		ListWorkerControllerInstances(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			pageSize int,
+			nextPageToken []byte,
+		) ([]*WorkerControllerInstanceSummary, []byte, error)
+
+		UpdateWorkerControllerInstance(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			version *deploymentpb.WorkerDeploymentVersion,
+			conflictToken []byte,
+			identity string,
+			computeProviderDetails *iface.ComputeProviderDetails,
+			scalingConfiguration *iface.ScalingConfiguration,
+		) error
+
+		DeleteWorkerControllerInstance(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			version *deploymentpb.WorkerDeploymentVersion,
+			identity string,
+		) error
+
+		SignalTaskAddEvent(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			version *deploymentpb.WorkerDeploymentVersion,
+			request *iface.SignalTaskAddRequest,
+		) error
+	}
+
+	WorkerControllerInstanceSummary struct {
+		DeploymentName string
+		BuildId        string
+		CreateTime     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+	}
+
+	ComputeProviderDetails = iface.ComputeProviderDetails
+	ComputeProviderType    = iface.ComputeProviderType
+
+	clientImpl struct {
+		logger                       log.Logger
+		controllerTaskQueueName      string
+		historyClient                historyservice.HistoryServiceClient
+		visibilityManager            manager.VisibilityManager
+		maxIDLengthLimit             dynamicconfig.IntPropertyFn
+		visibilityMaxPageSize        dynamicconfig.IntPropertyFnWithNamespaceFilter
+		maxWorkerControllerInstances dynamicconfig.IntPropertyFnWithNamespaceFilter
+		testHooks                    testhooks.TestHooks
+		metricsHandler               metrics.Handler
+	}
+)
+
+var (
+	errUpdateInProgress       = errors.New("update in progress")
+	errWorkflowHistoryTooLong = errors.New("workflow history too long")
+)
+
+var retryPolicy = backoff.NewExponentialRetryPolicy(100 * time.Millisecond).WithExpirationInterval(1 * time.Minute)
+
+var _ Client = (*clientImpl)(nil)
+
+func (d *clientImpl) DescribeWorkerControllerInstance(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+) (_ *iface.QueryDescribeWorkerControllerInstanceResponse, conflictToken []byte, retErr error) {
+	//revive:disable-next-line:defer
+	defer d.convertAndRecordError("DescribeWorkerControllerInstance", version, &retErr)()
+
+	// validating params
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentNameFieldName, version.DeploymentName, d.maxIDLengthLimit()); err != nil {
+		return nil, nil, err
+	}
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentBuildIDFieldName, version.BuildId, d.maxIDLengthLimit()); err != nil {
+		return nil, nil, err
+	}
+
+	res, err := queryWorkflowWithRetry(ctx, d.historyClient, namespaceEntry, version, iface.QueryDescribeWorkerControllerInstance)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var queryResponse iface.QueryDescribeWorkerControllerInstanceResponse
+	err = sdk.PreferProtoDataConverter.FromPayloads(res.GetResponse().GetQueryResult(), &queryResponse)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &queryResponse, queryResponse.ConflictToken, nil
+}
+
+func (d *clientImpl) WorkerControllerInstanceExists(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+) (bool, error) {
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(version)
+	return workflowIsRunning(ctx, d.historyClient, namespaceEntry, workflowID)
+}
+
+func (d *clientImpl) ListWorkerControllerInstances(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	pageSize int,
+	nextPageToken []byte,
+) (_ []*WorkerControllerInstanceSummary, _ []byte, retError error) {
+	//revive:disable-next-line:defer
+	defer d.convertAndRecordError("ListWorkerControllerInstances", nil, &retError)()
+
+	if pageSize == 0 {
+		pageSize = d.visibilityMaxPageSize(namespaceEntry.Name().String())
+	}
+
+	persistenceResp, err := d.visibilityManager.ListWorkflowExecutions(
+		ctx,
+		&manager.ListWorkflowExecutionsRequestV2{
+			NamespaceID:   namespaceEntry.ID(),
+			Namespace:     namespaceEntry.Name(),
+			PageSize:      pageSize,
+			NextPageToken: nextPageToken,
+			Query:         iface.WorkerControllerInstanceVisibilityBaseListQuery,
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	workerControllerInstanceSummaries := make([]*WorkerControllerInstanceSummary, 0, len(persistenceResp.Executions))
+	for _, ex := range persistenceResp.Executions {
+		var workerControllerInstanceInfo *iface.WorkerControllerInstanceMemo
+		if ex.GetMemo() != nil {
+			workerControllerInstanceInfo, err = iface.DecodeWorkerControllerInstanceMemo(ex.GetMemo())
+			if err != nil {
+				// it's ok to just drop these entries to keep the overall system working as otherwise
+				// a single bad workflow would break the overall experience.
+				d.logger.Error("unable to decode worker controller instance memo", tag.Error(err), tag.WorkflowNamespace(namespaceEntry.Name().String()), tag.WorkflowID(ex.GetExecution().GetWorkflowId()))
+				continue
+			}
+		} else {
+			// There is a race condition where the Worker Controller Instance workflow exists, but has not yet
+			// upserted the memo. If that is the case, we handle it here.
+			version := GetDeploymentNameBuildIdFromWorkflowID(ex.GetExecution().GetWorkflowId())
+			workerControllerInstanceInfo = &iface.WorkerControllerInstanceMemo{
+				DeploymentName: version.DeploymentName,
+				BuildId:        version.BuildId,
+				CreateTime:     ex.GetStartTime(),
+			}
+		}
+
+		workerControllerInstanceSummaries = append(workerControllerInstanceSummaries, &WorkerControllerInstanceSummary{
+			DeploymentName: workerControllerInstanceInfo.DeploymentName,
+			BuildId:        workerControllerInstanceInfo.BuildId,
+			CreateTime:     workerControllerInstanceInfo.CreateTime,
+		})
+	}
+
+	return workerControllerInstanceSummaries, persistenceResp.NextPageToken, nil
+}
+
+func (d *clientImpl) UpdateWorkerControllerInstance(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+	conflictToken []byte,
+	identity string,
+	computeProviderDetails *iface.ComputeProviderDetails,
+	scalingConfiguration *iface.ScalingConfiguration,
+) (retErr error) {
+	//revive:disable-next-line:defer
+	defer d.convertAndRecordError("UpdateWorkerControllerInstance", version, &retErr, namespaceEntry.Name(), identity)()
+
+	// validating params
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentNameFieldName, version.DeploymentName, d.maxIDLengthLimit()); err != nil {
+		return err
+	}
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentBuildIDFieldName, version.BuildId, d.maxIDLengthLimit()); err != nil {
+		return err
+	}
+	if computeProviderDetails == nil && scalingConfiguration == nil {
+		return serviceerror.NewInvalidArgumentf("Either ComputeProvider or ScalingConfiguration need to be provided")
+	}
+	if computeProviderDetails != nil {
+		if !iface.ValidComputeProviderType(string(computeProviderDetails.ProviderType)) {
+			return serviceerror.NewInvalidArgumentf("invalid compute provider type '%s'", computeProviderDetails.ProviderType)
+		}
+	}
+	if err := d.checkInstanceCount(ctx, namespaceEntry, version); err != nil {
+		return err
+	}
+
+	requestID := uuid.NewString()
+	updateReq := &iface.UpdateWorkerControllerInstanceRequest{
+		Identity:               identity,
+		ConflictToken:          conflictToken,
+		ComputeProviderDetails: computeProviderDetails,
+		ScalingConfiguration:   scalingConfiguration,
+	}
+
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(version)
+	startInput := iface.WorkerControllerInstanceWorkflowArgs{
+		NamespaceName:  namespaceEntry.Name().String(),
+		NamespaceId:    namespaceEntry.ID().String(),
+		DeploymentName: version.DeploymentName,
+		BuildId:        version.BuildId,
+	}
+
+	outcome, err := updateWorkflowWithStart(
+		ctx,
+		d.historyClient,
+		namespaceEntry,
+		d.controllerTaskQueueName,
+		iface.WorkerControllerInstanceWorkflowType,
+		workflowID,
+		startInput,
+		iface.UpdateWorkerControllerInstance,
+		updateReq,
+		identity,
+		requestID,
+	)
+	if err != nil {
+		return err
+	}
+
+	if failure := outcome.GetFailure(); failure != nil {
+		if appFailureInfo := failure.GetApplicationFailureInfo(); appFailureInfo != nil {
+			if appFailureInfo.Type == "InvalidArgument" {
+				return serviceerror.NewInvalidArgument(failure.Message)
+			}
+		}
+		return serviceerror.NewInternal(failure.Message)
+	}
+	return nil
+}
+
+func (d *clientImpl) DeleteWorkerControllerInstance(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+	identity string,
+) (retErr error) {
+	//revive:disable-next-line:defer
+	defer d.convertAndRecordError("DeleteWorkerControllerInstance", version, &retErr, namespaceEntry.Name(), identity)()
+
+	// validating params
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentNameFieldName, version.DeploymentName, d.maxIDLengthLimit()); err != nil {
+		return err
+	}
+	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentBuildIDFieldName, version.BuildId, d.maxIDLengthLimit()); err != nil {
+		return err
+	}
+
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(version)
+
+	requestID := uuid.NewString()
+	updatePayload, err := sdk.PreferProtoDataConverter.ToPayloads(&iface.DeleteWorkerControllerInstanceRequest{
+		Identity: identity,
+	})
+	if err != nil {
+		return err
+	}
+
+	outcome, err := updateWorkflow(
+		ctx,
+		d.historyClient,
+		namespaceEntry,
+		workflowID,
+		&updatepb.Request{
+			Input: &updatepb.Input{Name: iface.DeleteWorkerControllerInstance, Args: updatePayload},
+			Meta:  &updatepb.Meta{UpdateId: requestID, Identity: identity},
+		},
+	)
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			return nil
+		}
+		return err
+	}
+
+	if failure := outcome.GetFailure(); failure != nil {
+		return serviceerror.NewInternal(failure.Message)
+	}
+	return nil
+}
+
+func (d *clientImpl) SignalTaskAddEvent(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+	request *iface.SignalTaskAddRequest,
+) error {
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(version)
+
+	signalPayload, err := sdk.PreferProtoDataConverter.ToPayloads(request)
+	if err != nil {
+		return err
+	}
+
+	if _, err := d.historyClient.SignalWorkflowExecution(ctx, &historyservice.SignalWorkflowExecutionRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
+			Namespace: namespaceEntry.Name().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+			},
+			SignalName: iface.SignalTaskAdd,
+			Input:      signalPayload,
+		},
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *clientImpl) convertAndRecordError(operation string, version *deploymentpb.WorkerDeploymentVersion, retErr *error, args ...any) func() {
+	start := time.Now()
+	return func() {
+		elapsed := time.Since(start)
+
+		// TODO: add metrics recording here
+
+		if version == nil {
+			version = &deploymentpb.WorkerDeploymentVersion{}
+		}
+
+		if *retErr != nil {
+			if isFailedPreconditionOrNotFound(*retErr) {
+				d.logger.Debug("worker controller client failure due to a failed precondition or not found error",
+					tag.Error(*retErr),
+					tag.Operation(operation),
+					tag.Deployment(version.DeploymentName),
+					tag.BuildId(version.BuildId),
+					tag.NewDurationTag("elapsed", elapsed),
+					tag.NewAnyTag("args", args),
+				)
+			} else {
+				if isRetryableUpdateError(*retErr) || isRetryableQueryError(*retErr) {
+					d.logger.Debug("worker controller client throttling due to retryable error",
+						tag.Error(*retErr),
+						tag.Operation(operation),
+						tag.Deployment(version.DeploymentName),
+						tag.BuildId(version.BuildId),
+						tag.NewDurationTag("elapsed", elapsed),
+						tag.NewAnyTag("args", args),
+					)
+
+					var errResourceExhausted *serviceerror.ResourceExhausted
+					if !errors.As(*retErr, &errResourceExhausted) || errResourceExhausted.Cause != enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS {
+						// if it's not a limits error, we don't want to expose the underlying cause to the user
+						*retErr = &serviceerror.ResourceExhausted{
+							Message: fmt.Sprintf(ErrTooManyRequests, version.DeploymentName, version.BuildId),
+							Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE,
+							// These errors are caused by workflow throughput limits, so BUSY_WORKFLOW is the most appropriate cause.
+							// This cause is not sent back to the user.
+							Cause: enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW,
+						}
+					}
+				} else if errors.Is(*retErr, context.DeadlineExceeded) ||
+					errors.Is(*retErr, context.Canceled) ||
+					common.IsContextDeadlineExceededErr(*retErr) ||
+					common.IsContextCanceledErr(*retErr) {
+					d.logger.Debug("worker controller client timeout or cancellation",
+						tag.Error(*retErr),
+						tag.Operation(operation),
+						tag.Deployment(version.DeploymentName),
+						tag.BuildId(version.BuildId),
+						tag.NewDurationTag("elapsed", elapsed),
+						tag.NewAnyTag("args", args),
+					)
+				} else if isInvalidArgumentError(*retErr) {
+					// nothing to do
+				} else {
+					d.logger.Error("worker controller client unexpected error",
+						tag.Error(*retErr),
+						tag.Operation(operation),
+						tag.Deployment(version.DeploymentName),
+						tag.BuildId(version.BuildId),
+						tag.NewDurationTag("elapsed", elapsed),
+						tag.NewAnyTag("args", args),
+					)
+				}
+			}
+		} else {
+			d.logger.Debug("worker controller client success",
+				tag.Operation(operation),
+				tag.Deployment(version.DeploymentName),
+				tag.BuildId(version.BuildId),
+				tag.NewDurationTag("elapsed", elapsed),
+				tag.NewAnyTag("args", args),
+			)
+		}
+	}
+}
+
+func (d *clientImpl) checkInstanceCount(ctx context.Context, namespaceEntry *namespace.Namespace, version *deploymentpb.WorkerDeploymentVersion) error {
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(version)
+
+	exists, err := workflowIsRunning(ctx, d.historyClient, namespaceEntry, workflowID)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		// New deployment, make sure we're not exceeding the limit
+		//
+		// We are accepting that there is a race condition between this check
+		// and the subsequent creation because the strictness of the enforcement
+		// is not critical - we just need a base upper bound to defend against
+		// run-away creation
+		count, err := countWorkerControllerInstances(ctx, d.visibilityManager, namespaceEntry)
+		if err != nil {
+			return err
+		}
+		limit := d.maxWorkerControllerInstances(namespaceEntry.Name().String())
+		if count >= int64(limit) {
+			return &serviceerror.ResourceExhausted{
+				Message: fmt.Sprintf("reached maximum worker controller instances in namespace (%d)", limit),
+				Scope:   enumspb.RESOURCE_EXHAUSTED_SCOPE_NAMESPACE,
+				Cause:   enumspb.RESOURCE_EXHAUSTED_CAUSE_WORKER_DEPLOYMENT_LIMITS,
+			}
+		}
+	}
+	return nil
+}
+
+// validateWorkerControllerInstanceWFParams is a helper that verifies if the fields used for generating
+// Worker Controller Instance related workflowID's are valid
+func validateWorkerControllerInstanceWFParams(fieldName string, field string, maxIDLengthLimit int) error {
+	return worker_versioning.ValidateDeploymentVersionFields(fieldName, field, maxIDLengthLimit)
+}

--- a/wci/client/errors.go
+++ b/wci/client/errors.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"errors"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/service/history/api"
+	"go.temporal.io/server/service/history/consts"
+	update2 "go.temporal.io/server/service/history/workflow/update"
+)
+
+const (
+	ErrTooManyRequests                  = "too many requests issued to Worker Deployment Version '%s' '%s'. Please try again later"
+	ErrWorkerControllerInstanceNotFound = "no Worker Deployment found with name '%s' %s; does your Worker Deployment have pollers?"
+)
+
+func isFailedPreconditionOrNotFound(err error) bool {
+	var failedPreconditionError *serviceerror.FailedPrecondition
+	var notFound *serviceerror.NotFound
+	return errors.As(err, &failedPreconditionError) || errors.As(err, &notFound)
+}
+
+func isRetryableQueryError(err error) bool {
+	var internalErr *serviceerror.Internal
+	return api.IsRetryableError(err) && !errors.As(err, &internalErr)
+}
+
+func isInvalidArgumentError(err error) bool {
+	var internalErr *serviceerror.InvalidArgument
+	return errors.As(err, &internalErr)
+}
+
+func isRetryableUpdateError(err error) bool {
+	if errors.Is(err, errUpdateInProgress) || errors.Is(err, errWorkflowHistoryTooLong) ||
+		err.Error() == consts.ErrWorkflowClosing.Error() || err.Error() == update2.AbortedByServerErr.Error() {
+		return true
+	}
+
+	var errResourceExhausted *serviceerror.ResourceExhausted
+	if errors.As(err, &errResourceExhausted) &&
+		(errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT ||
+			errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW) {
+		// We're hitting the max concurrent update limit for the wf. Retrying will eventually succeed.
+		return true
+	}
+
+	var errWfNotReady *serviceerror.WorkflowNotReady
+	if errors.As(err, &errWfNotReady) {
+		// Update edge cases, can retry.
+		return true
+	}
+
+	// All updates that are admitted as the workflow is closing due to CaN are considered retryable.
+	// The ErrWorkflowClosing and ResourceExhausted could be nested.
+	var errMultiOps *serviceerror.MultiOperationExecution
+	if errors.As(err, &errMultiOps) {
+		for _, e := range errMultiOps.OperationErrors() {
+			if e == nil {
+				continue
+			}
+			if errors.As(e, &errResourceExhausted) &&
+				(errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_CONCURRENT_LIMIT ||
+					errResourceExhausted.Cause == enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW) {
+				// We're hitting the max concurrent update limit for the wf. Retrying will eventually succeed.
+				return true
+			}
+			if e.Error() == consts.ErrWorkflowClosing.Error() || e.Error() == update2.AbortedByServerErr.Error() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func convertUpdateFailure(updateRes *workflowservice.UpdateWorkflowExecutionResponse) error {
+	if updateRes == nil {
+		return serviceerror.NewInternal("failed to update deployment workflow")
+	}
+
+	if updateRes.Stage != enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
+		// update not completed, try again
+		return errUpdateInProgress
+	}
+
+	if outcome := updateRes.GetOutcome(); outcome != nil {
+		if failure := outcome.GetFailure(); failure != nil {
+			if afi := failure.GetApplicationFailureInfo(); afi != nil {
+				if afi.GetType() == iface.ErrLongHistory {
+					// Retryable
+					return errWorkflowHistoryTooLong
+				} else if afi.GetType() == iface.ErrInstanceDeleted {
+					// Non-retryable
+					return serviceerror.NewNotFoundf("Worker Deployment not found")
+				} else if afi.GetType() == iface.ErrFailedPrecondition {
+					return serviceerror.NewFailedPrecondition(failure.GetMessage())
+				}
+			}
+		} else if outcome.GetSuccess() == nil {
+			return serviceerror.NewInternal("outcome missing success and failure")
+		}
+	} else {
+		return serviceerror.NewInternal("outcome missing")
+	}
+
+	// caller should handle all other update failures by inspecting outcome.GetFailure()
+	return nil
+}

--- a/wci/client/fx.go
+++ b/wci/client/fx.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"go.uber.org/fx"
+
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/testing/testhooks"
+	"go.temporal.io/server/service/matching/hooks"
+)
+
+var Module = fx.Options(
+	fx.Provide(ClientProvider),
+)
+
+type (
+	fxOut struct {
+		fx.Out
+
+		Client          Client
+		TaskHookFactory hooks.TaskHookFactory `group:"TaskHookFactories"`
+	}
+)
+
+func ClientProvider(
+	logger log.Logger,
+	historyClient resource.HistoryClient,
+	visibilityManager manager.VisibilityManager,
+	dc *dynamicconfig.Collection,
+	testHooks testhooks.TestHooks,
+	metricsHandler metrics.Handler,
+) fxOut {
+	client := &clientImpl{
+		logger:                       logger,
+		controllerTaskQueueName:      WorkerControllerPerNSWorkerTaskQueue,
+		historyClient:                historyClient,
+		visibilityManager:            visibilityManager,
+		maxIDLengthLimit:             dynamicconfig.MaxIDLengthLimit.Get(dc),
+		visibilityMaxPageSize:        dynamicconfig.FrontendVisibilityMaxPageSize.Get(dc),
+		maxWorkerControllerInstances: WorkerControllerMaxInstances.Get(dc),
+		testHooks:                    testHooks,
+		metricsHandler:               metricsHandler,
+	}
+	taskHookFactory := &taskHookFactoryImpl{
+		logger:         logger,
+		client:         client,
+		metricsHandler: metricsHandler,
+	}
+
+	return fxOut{Client: client, TaskHookFactory: taskHookFactory}
+}

--- a/wci/client/hook.go
+++ b/wci/client/hook.go
@@ -1,0 +1,147 @@
+package client
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.temporal.io/api/enums/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/matching/hooks"
+)
+
+type (
+	taskHookFactoryImpl struct {
+		logger         log.Logger
+		client         Client
+		metricsHandler metrics.Handler
+	}
+
+	signalBatchDetails struct {
+		timestamp        time.Time
+		syncMatchCount   int
+		noSyncMatchCount int
+	}
+
+	taskHookImpl struct {
+		logger         log.Logger
+		client         Client
+		metricsHandler metrics.Handler
+
+		namespace     *namespace.Namespace
+		taskQueueName string
+		taskQueueType enumspb.TaskQueueType
+
+		lastSignalMu      sync.Mutex
+		lastSignalDetails map[string]*signalBatchDetails
+	}
+)
+
+var (
+	_ hooks.TaskHookFactory = (*taskHookFactoryImpl)(nil)
+	_ hooks.TaskHook        = (*taskHookImpl)(nil)
+)
+
+func (thf *taskHookFactoryImpl) Create(details *hooks.TaskHookFactoryCreateDetails) hooks.TaskHook {
+	if details == nil || details.Namespace == nil || details.Partition.Kind() == enums.TASK_QUEUE_KIND_STICKY {
+		return nil
+	}
+
+	return &taskHookImpl{
+		logger:         thf.logger,
+		client:         thf.client,
+		metricsHandler: thf.metricsHandler,
+
+		namespace:     details.Namespace,
+		taskQueueName: details.Partition.TaskQueue().Name(),
+		taskQueueType: details.Partition.TaskQueue().TaskType(),
+
+		lastSignalDetails: map[string]*signalBatchDetails{},
+	}
+}
+
+func (th *taskHookImpl) Start() {
+}
+
+func (th *taskHookImpl) Stop() {
+}
+
+func (th *taskHookImpl) ProcessTaskAdd(ctx context.Context, event *hooks.TaskAddHookDetails) {
+	if event == nil || event.DeploymentVersion == nil {
+		return
+	}
+	workflowID := GenerateWorkerControllerInstanceWorkflowID(event.DeploymentVersion)
+
+	// batch signals per WCI in minSignalInterval* time buckets
+	syncMatchBatchCount, noSyncMatchBatchCount, skip := th.batchMatchSignals(ctx, workflowID, event.IsSyncMatch)
+	if skip {
+		return
+	}
+
+	exists, err := th.client.WorkerControllerInstanceExists(ctx, th.namespace, event.DeploymentVersion)
+	if err != nil {
+		th.logger.Error("Failed to check for existence of worker controller instance workflow", tag.Error(err), tag.WorkflowID(workflowID))
+		iface.WorkerControllerInstanceProcessTaskMatchErrorCount.With(th.metricsHandler).Record(1)
+		return
+	}
+	if !exists {
+		return
+	}
+
+	request := &iface.SignalTaskAddRequest{
+		TaskQueueName:               th.taskQueueName,
+		TaskQueueType:               th.taskQueueType,
+		IsSyncMatch:                 event.IsSyncMatch,
+		NoSyncMatchSignalsSinceLast: noSyncMatchBatchCount,
+		SyncMatchSignalsSinceLast:   syncMatchBatchCount,
+	}
+
+	if err := th.client.SignalTaskAddEvent(ctx, th.namespace, event.DeploymentVersion, request); err != nil {
+		th.logger.Error("Failed to signal task add event", tag.Error(err), tag.WorkflowID(workflowID))
+		iface.WorkerControllerInstanceProcessTaskMatchErrorCount.With(th.metricsHandler).Record(1)
+
+	}
+}
+
+func (th *taskHookImpl) batchMatchSignals(_ context.Context, workflowID string, isSyncMatch bool) (int, int, bool) {
+	now := time.Now()
+
+	th.lastSignalMu.Lock()
+	defer th.lastSignalMu.Unlock()
+
+	last, ok := th.lastSignalDetails[workflowID]
+	if !ok || last == nil {
+		last = &signalBatchDetails{
+			timestamp:        time.Unix(0, 0),
+			syncMatchCount:   0,
+			noSyncMatchCount: 0,
+		}
+	}
+
+	if isSyncMatch {
+		last.syncMatchCount++
+	} else {
+		last.noSyncMatchCount++
+	}
+
+	sendBy := last.timestamp.Add(minSignalIntervalSyncMatch)
+	if last.noSyncMatchCount > 0 {
+		sendBy = last.timestamp.Add(minSignalIntervalNoSyncMatch)
+	}
+
+	if sendBy.Before(now) {
+		th.lastSignalDetails[workflowID] = &signalBatchDetails{
+			timestamp:        now,
+			syncMatchCount:   0,
+			noSyncMatchCount: 0,
+		}
+		return last.syncMatchCount, last.noSyncMatchCount, false
+	}
+	th.lastSignalDetails[workflowID] = last
+	return last.syncMatchCount, last.noSyncMatchCount, true
+}

--- a/wci/client/workflow_interaction.go
+++ b/wci/client/workflow_interaction.go
@@ -1,0 +1,267 @@
+package client
+
+import (
+	"context"
+	"errors"
+
+	commonpb "go.temporal.io/api/common/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	querypb "go.temporal.io/api/query/v1"
+	"go.temporal.io/api/serviceerror"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/common/searchattribute/sadefs"
+)
+
+func queryWorkflowWithRetry(
+	ctx context.Context,
+	historyClient historyservice.HistoryServiceClient,
+	namespaceEntry *namespace.Namespace,
+	version *deploymentpb.WorkerDeploymentVersion,
+	queryName string,
+) (*historyservice.QueryWorkflowResponse, error) {
+	req := &historyservice.QueryWorkflowRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		Request: &workflowservice.QueryWorkflowRequest{
+			Namespace: namespaceEntry.Name().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: GenerateWorkerControllerInstanceWorkflowID(version),
+			},
+			Query: &querypb.WorkflowQuery{QueryType: queryName},
+		},
+	}
+
+	var res *historyservice.QueryWorkflowResponse
+	var err error
+	err = backoff.ThrottleRetryContext(ctx, func(ctx context.Context) error {
+		res, err = historyClient.QueryWorkflow(ctx, req)
+		return err
+	}, retryPolicy, isRetryableQueryError)
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			return nil, serviceerror.NewNotFoundf(ErrWorkerControllerInstanceNotFound, version.DeploymentName, version.BuildId)
+		}
+		var queryFailed *serviceerror.QueryFailed
+		if errors.As(err, &queryFailed) && queryFailed.Error() == iface.ErrInstanceDeleted {
+			return nil, serviceerror.NewNotFoundf(ErrWorkerControllerInstanceNotFound, version.DeploymentName, version.BuildId)
+		}
+		return nil, err
+	}
+
+	if rej := res.GetResponse().GetQueryRejected(); rej != nil {
+		// This should not happen
+		return nil, serviceerror.NewInternalf("describe worker controller instance query rejected with status %s", rej.GetStatus())
+	}
+
+	if res.GetResponse().GetQueryResult() == nil {
+		return nil, serviceerror.NewInternal("Did not receive worker controller instance info")
+	}
+	return res, err
+}
+
+func updateWorkflow(
+	ctx context.Context,
+	historyClient historyservice.HistoryServiceClient,
+	namespaceEntry *namespace.Namespace,
+	workflowID string,
+	updateRequest *updatepb.Request,
+) (*updatepb.Outcome, error) {
+	updateReq := &historyservice.UpdateWorkflowExecutionRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		Request: &workflowservice.UpdateWorkflowExecutionRequest{
+			Namespace: namespaceEntry.Name().String(),
+			WorkflowExecution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+			},
+			Request:    updateRequest,
+			WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+		},
+	}
+
+	var outcome *updatepb.Outcome
+	err := backoff.ThrottleRetryContext(ctx, func(ctx context.Context) error {
+		// historyClient retries internally on retryable rpc errors, we just have to retry on
+		// successful but un-completed responses.
+		res, err := historyClient.UpdateWorkflowExecution(ctx, updateReq)
+		if err != nil {
+			return err
+		}
+
+		if err := convertUpdateFailure(res.GetResponse()); err != nil {
+			return err
+		}
+
+		outcome = res.GetResponse().GetOutcome()
+		return nil
+	}, retryPolicy, isRetryableUpdateError)
+
+	return outcome, err
+}
+
+func updateWorkflowWithStart(
+	ctx context.Context,
+	historyClient historyservice.HistoryServiceClient,
+	namespaceEntry *namespace.Namespace,
+	taskQueueName string,
+	workflowType string,
+	workflowID string,
+	startInput interface{},
+	updateType string,
+	updateArg interface{},
+	identity string,
+	requestID string,
+) (*updatepb.Outcome, error) {
+	startPayload, err := sdk.PreferProtoDataConverter.ToPayloads(startInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start workflow execution, if it hasn't already
+	startReq := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:                requestID,
+		Namespace:                namespaceEntry.Name().String(),
+		WorkflowId:               workflowID,
+		WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+		TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+		Input:                    startPayload,
+		WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+		WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				sadefs.TemporalNamespaceDivision: payload.EncodeString(iface.WorkerControllerInstanceNamespaceDivision),
+			},
+		},
+		Identity: identity,
+	}
+
+	updatePayload, err := sdk.PreferProtoDataConverter.ToPayloads(updateArg)
+	if err != nil {
+		return nil, err
+	}
+
+	updateReq := &workflowservice.UpdateWorkflowExecutionRequest{
+		Namespace: namespaceEntry.Name().String(),
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: workflowID,
+		},
+		Request: &updatepb.Request{
+			Input: &updatepb.Input{Name: updateType, Args: updatePayload},
+			Meta:  &updatepb.Meta{UpdateId: requestID, Identity: identity},
+		},
+		WaitPolicy: &updatepb.WaitPolicy{LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED},
+	}
+
+	// This is an atomic operation; if one operation fails, both will.
+	multiOpReq := &historyservice.ExecuteMultiOperationRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		WorkflowId:  workflowID,
+		Operations: []*historyservice.ExecuteMultiOperationRequest_Operation{
+			{
+				Operation: &historyservice.ExecuteMultiOperationRequest_Operation_StartWorkflow{
+					StartWorkflow: &historyservice.StartWorkflowExecutionRequest{
+						NamespaceId:  namespaceEntry.ID().String(),
+						StartRequest: startReq,
+					},
+				},
+			},
+			{
+				Operation: &historyservice.ExecuteMultiOperationRequest_Operation_UpdateWorkflow{
+					UpdateWorkflow: &historyservice.UpdateWorkflowExecutionRequest{
+						NamespaceId: namespaceEntry.ID().String(),
+						Request:     updateReq,
+					},
+				},
+			},
+		},
+	}
+
+	var outcome *updatepb.Outcome
+	err = backoff.ThrottleRetryContext(ctx, func(ctx context.Context) error {
+		// historyClient retries internally on retryable rpc errors, we just have to retry on
+		// successful but un-completed responses.
+		res, err := historyClient.ExecuteMultiOperation(ctx, multiOpReq)
+		if err != nil {
+			return err
+		}
+
+		// we should get exactly one of each of these
+		var startRes *historyservice.StartWorkflowExecutionResponse
+		var updateRes *workflowservice.UpdateWorkflowExecutionResponse
+		for _, response := range res.Responses {
+			if sr := response.GetStartWorkflow(); sr != nil {
+				startRes = sr
+			} else if ur := response.GetUpdateWorkflow(); ur != nil {
+				if ur.GetResponse() != nil {
+					updateRes = ur.GetResponse()
+				}
+			}
+		}
+		if startRes == nil {
+			return serviceerror.NewInternal("failed to start deployment workflow")
+		}
+
+		if err := convertUpdateFailure(updateRes); err != nil {
+			return err
+		}
+
+		outcome = updateRes.GetOutcome()
+		return nil
+	}, retryPolicy, isRetryableUpdateError)
+
+	return outcome, err
+}
+
+func workflowIsRunning(
+	ctx context.Context,
+	historyClient historyservice.HistoryServiceClient,
+	namespaceEntry *namespace.Namespace,
+	workflowID string,
+) (bool, error) {
+	res, err := historyClient.DescribeWorkflowExecution(ctx, &historyservice.DescribeWorkflowExecutionRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		Request: &workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: namespaceEntry.Name().String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+			},
+		},
+	})
+	if err != nil {
+		var notFound *serviceerror.NotFound
+		if errors.As(err, &notFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return res.GetWorkflowExecutionInfo().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, nil
+}
+
+func countWorkerControllerInstances(
+	ctx context.Context,
+	visibilityManager manager.VisibilityManager,
+	namespaceEntry *namespace.Namespace,
+) (count int64, retError error) {
+	persistenceResp, err := visibilityManager.CountWorkflowExecutions(
+		ctx,
+		&manager.CountWorkflowExecutionsRequest{
+			NamespaceID: namespaceEntry.ID(),
+			Namespace:   namespaceEntry.Name(),
+			Query:       iface.WorkerControllerInstanceVisibilityBaseListQuery,
+		},
+	)
+	if err != nil {
+		return 0, err
+	}
+	return persistenceResp.Count, nil
+}

--- a/wci/workflow/iface/metrics.go
+++ b/wci/workflow/iface/metrics.go
@@ -3,6 +3,7 @@ package iface
 import "go.temporal.io/server/common/metrics"
 
 var (
-	WorkerControllerInstanceCreated              = metrics.NewCounterDef("worker_controller_instance_created")
-	WorkerControllerInstanceVisibilityQueryCount = metrics.NewCounterDef("worker_controller_instance_visibility_query_count")
+	WorkerControllerInstanceCreated                    = metrics.NewCounterDef("worker_controller_instance_created")
+	WorkerControllerInstanceVisibilityQueryCount       = metrics.NewCounterDef("worker_controller_instance_visibility_query_count")
+	WorkerControllerInstanceProcessTaskMatchErrorCount = metrics.NewCounterDef("worker_controller_instance_task_match_error_count")
 )

--- a/wci/workflow/iface/wf_iface.go
+++ b/wci/workflow/iface/wf_iface.go
@@ -6,11 +6,12 @@ import (
 	"errors"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute/sadefs"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -30,6 +31,9 @@ const (
 	UpdateWorkerControllerInstance = "update-worker-controller-instance"
 	DeleteWorkerControllerInstance = "delete-worker-controller-instance"
 
+	// Signals
+	SignalTaskAdd = "task-add-signal"
+
 	// Errors
 	ErrInstanceDeleted    = "worker deployment deleted" // returned in the race condition that the deployment is deleted but the workflow is not yet closed.
 	ErrLongHistory        = "errLongHistory"            // update is not accepted until CaN happens. client should retry
@@ -47,59 +51,109 @@ var WorkerControllerInstanceVisibilityBaseListQuery = fmt.Sprintf(
 )
 
 type (
+	ComputeProviderType  string
+	ScalingAlgorithmType string
+
 	ComputeProviderDetails struct {
-		ProviderType     string
-		ProviderSettings map[string]string
+		ProviderType     ComputeProviderType `json:"provider_type,omitempty"`
+		ProviderSettings map[string]string   `json:"provider_settings,omitempty"`
+	}
+
+	ScalingConfiguration struct {
+		ScalingAlgorithm ScalingAlgorithmType `json:"scaling_algorithm,omitempty"`
+	}
+
+	QueueTypeScalingMetrics struct {
+		LastWorkerStart int64 `json:"last_worker_start,omitempty"`
+
+		LastQueueDepth     int64   `json:"last_queue_depth"`
+		LastArrivalRate    float32 `json:"last_arrival_rate"`
+		LastProcessingRate float32 `json:"last_processing_rate"`
 	}
 
 	WorkerControllerInstanceWorkflowArgs struct {
-		NamespaceName  string `protobuf:"bytes,1,opt,name=namespace_name,json=namespaceName,proto3" json:"namespace_name,omitempty"`
-		NamespaceId    string `protobuf:"bytes,2,opt,name=namespace_id,json=namespaceId,proto3" json:"namespace_id,omitempty"`
-		DeploymentName string `protobuf:"bytes,3,opt,name=deployment_name,json=deploymentName,proto3" json:"deployment_name,omitempty"`
-		BuildID        string
-
-		State *WorkerControllerInstanceLocalState
+		NamespaceName  string                              `json:"namespace_name,omitempty"`
+		NamespaceId    string                              `json:"namespace_id,omitempty"`
+		DeploymentName string                              `json:"deployment_name,omitempty"`
+		BuildId        string                              `json:"build_id,omitempty"`
+		State          *WorkerControllerInstanceLocalState `json:"state"`
 	}
 
 	WorkerControllerInstanceLocalState struct {
-		ComputeProviderDetails *ComputeProviderDetails
+		ComputeProviderDetails *ComputeProviderDetails `json:"compute_provider,omitempty"`
+		ScalingConfiguration   *ScalingConfiguration   `json:"scaling_configuration,omitempty"`
 
-		ConflictToken        []byte
-		CreateTime           *timestamppb.Timestamp
-		LastModifierIdentity string
+		ScalingState map[string]any `json:"scaling_state"`
+
+		ConflictToken        []byte                 `json:"conflict_token,omitempty"`
+		CreateTime           *timestamppb.Timestamp `json:"create_time,omitempty"`
+		LastModifierIdentity string                 `json:"last_modifier_identity,omitempty"`
 	}
 
-	QueryDescribeWorkerControllInstanceResponse struct {
-		DeploymentName string
-		BuildId        string
-		CreateTime     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+	QueryDescribeWorkerControllerInstanceResponse struct {
+		DeploymentName string                 `json:"deployment_name,omitempty"`
+		BuildId        string                 `json:"build_id,omitempty"`
+		CreateTime     *timestamppb.Timestamp `json:"create_time,omitempty"`
 
-		ComputeProviderDetails *ComputeProviderDetails
+		ComputeProviderDetails *ComputeProviderDetails `json:"compute_provider,omitempty"`
+		ScalingConfiguration   *ScalingConfiguration   `json:"scaling_configuration,omitempty"`
 
-		ConflictToken        []byte `protobuf:"bytes,4,opt,name=conflict_token,json=conflictToken,proto3" json:"conflict_token,omitempty"`
-		LastModifierIdentity string `protobuf:"bytes,5,opt,name=last_modifier_identity,json=lastModifierIdentity,proto3" json:"last_modifier_identity,omitempty"`
+		ConflictToken        []byte `json:"conflict_token,omitempty"`
+		LastModifierIdentity string `json:"last_modifier_identity,omitempty"`
 	}
 
 	UpdateWorkerControllerInstanceRequest struct {
-		Identity      string
-		ConflictToken []byte
+		Identity      string `json:"identity,omitempty"`
+		ConflictToken []byte `json:"conflict_token,omitempty"`
 
-		ComputeProviderDetails *ComputeProviderDetails
+		ComputeProviderDetails *ComputeProviderDetails `json:"compute_provider,omitempty"`
+		ScalingConfiguration   *ScalingConfiguration   `json:"scaling_configuration,omitempty"`
 	}
 
 	UpdateWorkerControllerInstanceResponse struct{}
 
 	DeleteWorkerControllerInstanceRequest struct {
-		Identity string
+		Identity string `json:"identity,omitempty"`
 	}
 	DeleteWorkerControllerInstanceResponse struct{}
 
+	SignalTaskAddRequest struct {
+		TaskQueueName string                `json:"task_queue_name"`
+		TaskQueueType enumspb.TaskQueueType `json:"task_queue_type"`
+
+		IsSyncMatch                 bool `json:"is_sync_match"`
+		SyncMatchSignalsSinceLast   int  `json:"sync_match_signals_batched,omitempty"`
+		NoSyncMatchSignalsSinceLast int  `json:"no_sync_match_signals_batched,omitempty"`
+	}
+
 	WorkerControllerInstanceMemo struct {
-		DeploymentName string
-		BuildId        string
-		CreateTime     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3" json:"create_time,omitempty"`
+		DeploymentName string                 `json:"deployment_name,omitempty"`
+		BuildId        string                 `json:"build_id,omitempty"`
+		CreateTime     *timestamppb.Timestamp `json:"create_time,omitempty"`
 	}
 )
+
+const (
+	ComputeProviderTypeAwsLambda  ComputeProviderType = "aws-lambda"
+	ComputeProviderTypeKnative    ComputeProviderType = "knative"
+	ComputeProviderTypeSubprocess ComputeProviderType = "subprocess"
+
+	ScalingAlgorithmNoSync ScalingAlgorithmType = "no-sync"
+)
+
+var validComputeProviderTypes = map[string]ComputeProviderType{
+	string(ComputeProviderTypeAwsLambda):  ComputeProviderTypeAwsLambda,
+	string(ComputeProviderTypeKnative):    ComputeProviderTypeKnative,
+	string(ComputeProviderTypeSubprocess): ComputeProviderTypeSubprocess,
+}
+
+// ValidComputeProviderType returns the ComputeProviderType for s if s is a valid enum value, and an error otherwise.
+func ValidComputeProviderType(s string) bool {
+	if _, ok := validComputeProviderTypes[s]; ok {
+		return true
+	}
+	return false
+}
 
 func DecodeWorkerControllerInstanceMemo(memo *commonpb.Memo) (*WorkerControllerInstanceMemo, error) {
 	if memo == nil || memo.Fields == nil {

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -94,15 +94,16 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	}
 	d.metrics.Counter(iface.WorkerControllerInstanceCreated.Name()).Inc(1)
 
-	err := workflow.SetQueryHandler(ctx, iface.QueryDescribeWorkerControllerInstance, func() (*iface.QueryDescribeWorkerControllInstanceResponse, error) {
+	err := workflow.SetQueryHandler(ctx, iface.QueryDescribeWorkerControllerInstance, func() (*iface.QueryDescribeWorkerControllerInstanceResponse, error) {
 		if d.deleteInstance {
 			return nil, errors.New(iface.ErrInstanceDeleted)
 		}
-		return &iface.QueryDescribeWorkerControllInstanceResponse{
+		return &iface.QueryDescribeWorkerControllerInstanceResponse{
 			DeploymentName: d.DeploymentName,
-			BuildId:        d.BuildID,
+			BuildId:        d.BuildId,
 
 			ComputeProviderDetails: d.State.ComputeProviderDetails,
+			ScalingConfiguration:   d.State.ScalingConfiguration,
 
 			ConflictToken:        d.State.ConflictToken,
 			CreateTime:           d.State.CreateTime,
@@ -152,8 +153,8 @@ func (d *WorkflowRunner) validateUpdateInstance(args *iface.UpdateWorkerControll
 	if err := d.ensureNotDeleted(); err != nil {
 		return err
 	}
-	if args.ComputeProviderDetails == nil {
-		return temporal.NewApplicationError("missing compute provider details", iface.ErrFailedPrecondition)
+	if args.ComputeProviderDetails == nil && args.ScalingConfiguration == nil {
+		return temporal.NewApplicationError("either compute provider details or scaling configuration need to be set", iface.ErrFailedPrecondition)
 	}
 	if args.ConflictToken != nil && !bytes.Equal(args.ConflictToken, d.State.ConflictToken) {
 		return temporal.NewApplicationError("conflict token mismatch", iface.ErrFailedPrecondition)
@@ -239,7 +240,7 @@ func (d *WorkflowRunner) updateMemo(ctx workflow.Context) error {
 	return workflow.UpsertMemo(ctx, map[string]any{
 		iface.WorkerControllerInstanceMemoField: &iface.WorkerControllerInstanceMemo{
 			DeploymentName: d.DeploymentName,
-			BuildId:        d.BuildID,
+			BuildId:        d.BuildId,
 			CreateTime:     d.State.CreateTime,
 		},
 	})


### PR DESCRIPTION
## What was changed
This adds the WCI client that will be consumed by the Frontend and Matching services to implement the WCI-related APIs.

## Why?
Matching and Frontend service shouldn't know about the implementation details of WCI so this abstracts it

Re https://temporalio.atlassian.net/browse/COM-6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow update/query behavior and introduces new signal emission from matching events, which can impact workflow throughput and error handling if misconfigured or noisy.
> 
> **Overview**
> Adds a new `wci/client` package that encapsulates interacting with Worker Controller Instance workflows via query/list/update/delete operations, including atomic *update-with-start* behavior, retry/throttling logic, and namespace-level instance limit enforcement.
> 
> Extends the WCI workflow interface to include typed compute provider/scaling configuration fields and a `SignalTaskMatch` payload, and wires the client as a `TaskMatchListener` that batches task-match signals and emits new error metrics when signaling fails. Also updates the WCI workflow’s query/memo and update validation to include the new scaling configuration and `BuildId` field naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e518b6e3f3d264bd4df5b3c345cefc55af23321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->