### PR TITLE
Add a set of compute provider implementations

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -2,6 +2,18 @@ package client
 
 import "go.temporal.io/server/common/dynamicconfig"
 
+type (
+	AWSIAMRoleRequest struct {
+		RoleARN         string
+		RoleSessionName string
+		ExternalID      *string
+	}
+
+	GCPIAMServiceAccountRequest struct {
+		ServiceAccountEmail string
+	}
+)
+
 var (
 	WorkerControllerEnabled = dynamicconfig.NewNamespaceBoolSetting(
 		"workercontroller.enabled",
@@ -17,6 +29,16 @@ var (
 		"workercontroller.instanceWorkflowVersion",
 		0,
 		`WorkerControllerInstanceWorkflowVersion controls what version of the logic should the manager workflows use.`,
+	)
+	WorkerControllerAWSIntermediaryRoles = dynamicconfig.NewGlobalTypedSetting(
+		"workercontroller.compute_providers.aws.intermediary_roles",
+		[][]AWSIAMRoleRequest(nil),
+		`WorkerControllerAWSIntermediaryRoles defines the role chain to assume before assuming the per-provider role.`,
+	)
+	WorkerControllerGCPIntermediaryServiceAccounts = dynamicconfig.NewGlobalTypedSetting(
+		"workercontroller.compute_providers.gcp.intermediary_service_accounts",
+		[][]GCPIAMServiceAccountRequest(nil),
+		`WorkerControllerGCPIntermediaryServiceAccounts defines the service account chaining to assume before assuming the per-provider role.`,
 	)
 	WorkerControllerEnabledComputeProviders = dynamicconfig.NewGlobalTypedSetting(
 		"workercontroller.compute_providers.enabled",

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -40,12 +40,11 @@ type (
 
 	InvokeWorkerActivityRequest struct {
 		ComputeConfig *iface.ComputeProviderSpec `json:"compute_config"`
-		Count         int                        `json:"count"`
 	}
 
 	UpdateWorkerSetSizeActivityRequest struct {
 		ComputeConfig *iface.ComputeProviderSpec `json:"compute_config"`
-		UpdatedSize   int                        `json:"updated_size"`
+		UpdatedSize   int32                      `json:"updated_size"`
 	}
 
 	HandleTaskAddSignalActivityRequest struct {
@@ -191,7 +190,7 @@ func (a *Activities) HandleTaskAddSignal(ctx context.Context, req HandleTaskAddS
 		scalingAlgo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, entry)
 		if err != nil {
 			logger.Error("failed to get scaling algorithm", "error", err)
-			return &HandleTaskAddSignalActivityResponse{}, nil
+			return &HandleTaskAddSignalActivityResponse{UpdatedScalingStatus: updatedScalingStatus}, nil
 		}
 
 		scalingStatus := req.ScalingStatus[specKey]
@@ -271,15 +270,6 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 
 	for _, entry := range req.Spec.TaskTypeSpecs {
 		specKey := entry.GetSpecKey()
-
-		scalingAlgo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, entry)
-		if err != nil {
-			logger.Error("failed to get scaling algorithm", "error", err)
-			continue
-		}
-
-		logger.Info("Loaded scaling algo", "scaling_algo", scalingAlgo, "config", scalingConfig)
-
 		scalingStatus := req.ScalingStatus[specKey]
 
 		scalingMetricsSnapshot := metricsSnapshot
@@ -293,11 +283,28 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 			scalingMetricsSnapshot.Nexus = nil
 		}
 
+		scalingAlgo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, entry)
+		if err != nil {
+			logger.Error("failed to get scaling algorithm", "error", err)
+
+			// let's keep the last state so we can try again in the next round
+			// instead of from scratch
+			updatedScalingStatus[specKey] = scalingStatus
+			continue
+		}
+
+		logger.Info("Loaded scaling algo", "scaling_algo", scalingAlgo, "config", scalingConfig)
+
 		response, err := scalingAlgo.ProcessMetricsPoll(ctx, scalingConfig, scalingStatus, scalingMetricsSnapshot)
 		if err != nil {
 			logger.Error("failed to process metrics poll", "error", err)
+
+			// let's keep the last state so we can try again in the next round
+			// instead of from scratch
+			updatedScalingStatus[specKey] = scalingStatus
 			continue
 		}
+
 		updatedScalingStatus[specKey] = response.Status
 		for _, act := range response.Actions {
 			act.SpecKey = specKey

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -1,0 +1,108 @@
+package computeprovider
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+)
+
+// buildAWSConfig loads the default AWS config for the given region, applies any
+// intermediary role chain, then optionally assumes a final role.
+func buildAWSConfig(ctx context.Context, region, roleARN string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
+	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	for _, step := range intermediaryRoles {
+		if len(step) == 0 {
+			continue
+		}
+		req := step[rand.Intn(len(step))]
+		if err := validateRoleARN(req.RoleARN); err != nil {
+			return aws.Config{}, err
+		}
+		if req.RoleSessionName == "" {
+			return aws.Config{}, fmt.Errorf("Empty role session name for intermediary role")
+		}
+
+		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &req)
+		if err != nil {
+			return aws.Config{}, err
+		}
+	}
+	if roleARN != "" {
+		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &client.AWSIAMRoleRequest{
+			RoleARN:         roleARN,
+			RoleSessionName: "managed-workers-aws",
+		})
+		if err != nil {
+			return aws.Config{}, err
+		}
+	}
+	return awsConfig, nil
+}
+
+func assumeRoleWithRequest(ctx context.Context, cfg aws.Config, req *client.AWSIAMRoleRequest) (aws.Config, error) {
+	stsClient := sts.NewFromConfig(cfg)
+
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(req.RoleARN),
+		RoleSessionName: aws.String(req.RoleSessionName),
+	}
+	if req.ExternalID != nil && *req.ExternalID != "" {
+		input.ExternalId = req.ExternalID
+	}
+
+	result, err := stsClient.AssumeRole(ctx, input)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to assume role %s: %w", req.RoleARN, err)
+	}
+
+	if result.Credentials == nil ||
+		result.Credentials.AccessKeyId == nil ||
+		result.Credentials.SecretAccessKey == nil ||
+		result.Credentials.SessionToken == nil {
+		return cfg, fmt.Errorf("AssumeRole for %s returned incomplete credentials", req.RoleARN)
+	}
+
+	cfg.Credentials = credentials.NewStaticCredentialsProvider(
+		*result.Credentials.AccessKeyId,
+		*result.Credentials.SecretAccessKey,
+		*result.Credentials.SessionToken,
+	)
+
+	return cfg, nil
+}
+
+func extractRegionFromARN(arnString string) (string, error) {
+	parsedARN, err := arn.Parse(arnString)
+	if err != nil {
+		return "", err
+	}
+	if parsedARN.Region == "" {
+		return "", fmt.Errorf("region not found in ARN: %s", arnString)
+	}
+	return parsedARN.Region, nil
+}
+
+func validateRoleARN(roleARN string) error {
+	parsedARN, err := arn.Parse(roleARN)
+	if err != nil {
+		return err
+	}
+	if parsedARN.Service != "iam" {
+		return fmt.Errorf("role ARN must be an IAM resource: %s", roleARN)
+	}
+	if !strings.HasPrefix(parsedARN.Resource, "role/") {
+		return fmt.Errorf("role ARN must reference a role: %s", roleARN)
+	}
+	return nil
+}

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -1,0 +1,135 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	configAWSECSCluster = "cluster"
+	configAWSECSService = "service"
+	configAWSECSRegion  = "region"
+	configAWSECSRole    = "role"
+)
+
+type awsECSComputeProvider struct {
+	intermediaryRoles [][]client.AWSIAMRoleRequest
+}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeAWSECS, NewAWSECSComputeProvider)
+}
+
+func NewAWSECSComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	var intermediaryRoles [][]client.AWSIAMRoleRequest
+	if dc != nil {
+		intermediaryRoles = client.WorkerControllerAWSIntermediaryRoles.Get(dc)()
+	}
+
+	return &awsECSComputeProvider{
+		intermediaryRoles: intermediaryRoles,
+	}, nil
+}
+
+func (p *awsECSComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyWorkerSet
+}
+
+func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	out, err := ecsClient.DescribeServices(ctx, &ecs.DescribeServicesInput{
+		Cluster:  aws.String(cluster),
+		Services: []string{service},
+	})
+	if err != nil {
+		return fmt.Errorf("ECS DescribeServices failed: %w", err)
+	}
+	if len(out.Services) == 0 {
+		if len(out.Failures) > 0 && out.Failures[0].Reason != nil {
+			return fmt.Errorf("ECS service %q not found in cluster %q: %s", service, cluster, *out.Failures[0].Reason)
+		}
+		return fmt.Errorf("ECS service %q not found in cluster %q", service, cluster)
+	}
+	svc := out.Services[0]
+	if svc.Status == nil || *svc.Status != "ACTIVE" {
+		return fmt.Errorf("ECS service %q is not ACTIVE", service)
+	}
+	return nil
+}
+
+func (p *awsECSComputeProvider) InvokeWorker(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	return errors.ErrUnsupported
+}
+
+func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, cfg iface.ComputeProviderConfig, size int32) error {
+	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	_, err = ecsClient.UpdateService(ctx, &ecs.UpdateServiceInput{
+		Cluster:      aws.String(cluster),
+		Service:      aws.String(service),
+		DesiredCount: aws.Int32(size),
+	})
+	if err != nil {
+		return fmt.Errorf("ECS UpdateService failed: %w", err)
+	}
+	return nil
+}
+
+// getECSClientAndParams builds AWS config (including intermediary and config role assumption),
+// returns an ECS client, cluster, and service.
+func (p *awsECSComputeProvider) getECSClientAndParams(ctx context.Context, cfg iface.ComputeProviderConfig) (*ecs.Client, string, string, error) {
+	cluster, ok := cfg[configAWSECSCluster].(string)
+	if !ok || cluster == "" {
+		return nil, "", "", fmt.Errorf("ECS cluster ARN or name not found or invalid")
+	}
+
+	service, ok := cfg[configAWSECSService].(string)
+	if !ok || service == "" {
+		return nil, "", "", fmt.Errorf("ECS service name or ARN not found or invalid")
+	}
+
+	// Resolve region: extract from cluster ARN, or fall back to "region" config key.
+	var region string
+	if strings.HasPrefix(cluster, "arn:") {
+		var err error
+		region, err = extractRegionFromARN(cluster)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("failed to extract region from cluster ARN: %w", err)
+		}
+	} else {
+		r, ok := cfg[configAWSECSRegion].(string)
+		if !ok || r == "" {
+			return nil, "", "", fmt.Errorf("region must be specified when cluster is not an ARN")
+		}
+		region = r
+	}
+
+	roleARN, _ := cfg[configAWSECSRole].(string)
+	if roleARN != "" {
+		if err := validateRoleARN(roleARN); err != nil {
+			return nil, "", "", err
+		}
+	}
+
+	awsConfig, err := buildAWSConfig(ctx, region, roleARN, p.intermediaryRoles)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	return ecs.NewFromConfig(awsConfig), cluster, service, nil
+}

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -1,0 +1,108 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	configAWSLambdaARN  = "arn"
+	configAWSLambdaRole = "role"
+)
+
+type awsLambdaComputeProvider struct {
+	intermediaryRoles [][]client.AWSIAMRoleRequest
+}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeAWSLambda, NewAWSLambdaComputeProvider)
+}
+
+func NewAWSLambdaComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	var intermediaryRoles [][]client.AWSIAMRoleRequest
+	if dc != nil {
+		intermediaryRoles = client.WorkerControllerAWSIntermediaryRoles.Get(dc)()
+	}
+
+	return &awsLambdaComputeProvider{
+		intermediaryRoles: intermediaryRoles,
+	}, nil
+}
+
+func (p *awsLambdaComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	if _, err = lambdaClient.GetFunction(ctx, &lambda.GetFunctionInput{
+		FunctionName: aws.String(arn),
+	}); err != nil {
+		return fmt.Errorf("lambda GetFunction failed: %w", err)
+	}
+	return nil
+}
+
+func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	resp, err := lambdaClient.Invoke(ctx, &lambda.InvokeInput{
+		FunctionName:   aws.String(arn),
+		InvocationType: types.InvocationTypeEvent,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to invoke lambda: %w", err)
+	}
+
+	if resp.FunctionError != nil {
+		return fmt.Errorf("failed to invoke lambda: %s", *resp.FunctionError)
+	}
+
+	return nil
+}
+
+func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ iface.ComputeProviderConfig, _ int32) error {
+	return errors.ErrUnsupported
+}
+
+// getLambdaClientAndARN builds AWS config (including intermediary and config role assumption), returns a Lambda client and the function ARN.
+func (p *awsLambdaComputeProvider) getLambdaClientAndARN(ctx context.Context, cfg iface.ComputeProviderConfig) (*lambda.Client, string, error) {
+	arn, ok := cfg[configAWSLambdaARN].(string)
+	if !ok || arn == "" {
+		return nil, "", fmt.Errorf("AWS Lambda Function ARN not found or invalid")
+	}
+
+	region, err := extractRegionFromARN(arn)
+	if err != nil {
+		return nil, "", err
+	}
+
+	roleARN, _ := cfg[configAWSLambdaRole].(string)
+	if roleARN != "" {
+		if err := validateRoleARN(roleARN); err != nil {
+			return nil, "", err
+		}
+	}
+
+	awsConfig, err := buildAWSConfig(ctx, region, roleARN, p.intermediaryRoles)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return lambda.NewFromConfig(awsConfig), arn, nil
+}

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -1,0 +1,137 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+
+	run "cloud.google.com/go/run/apiv2"
+	runpb "cloud.google.com/go/run/apiv2/runpb"
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+const (
+	configGCPCloudRunProject        = "project"
+	configGCPCloudRunRegion         = "region"
+	configGCPCloudRunWorkerPool     = "worker_pool"
+	configGCPCloudRunServiceAccount = "service_account"
+)
+
+type gcpCloudRunComputeProvider struct {
+	intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeGCPCloudRun, NewGCPCloudRunComputeProvider)
+}
+
+func NewGCPCloudRunComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	var intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+	if dc != nil {
+		intermediaryServiceAccounts = client.WorkerControllerGCPIntermediaryServiceAccounts.Get(dc)()
+	}
+
+	return &gcpCloudRunComputeProvider{
+		intermediaryServiceAccounts: intermediaryServiceAccounts,
+	}, nil
+}
+
+func (p *gcpCloudRunComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyWorkerSet
+}
+
+func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, config iface.ComputeProviderConfig) error {
+	client, name, err := p.buildClientAndParams(ctx, config)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	_, err = client.GetWorkerPool(ctx, &runpb.GetWorkerPoolRequest{Name: name})
+	if err != nil {
+		return fmt.Errorf("worker pool %q not found: %w", name, err)
+	}
+	return nil
+}
+
+func (p *gcpCloudRunComputeProvider) InvokeWorker(ctx context.Context, config iface.ComputeProviderConfig) error {
+	return errors.ErrUnsupported
+}
+
+func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, config iface.ComputeProviderConfig, count int32) error {
+	client, name, err := p.buildClientAndParams(ctx, config)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	op, err := client.UpdateWorkerPool(ctx, &runpb.UpdateWorkerPoolRequest{
+		WorkerPool: &runpb.WorkerPool{
+			Name:    name,
+			Scaling: &runpb.WorkerPoolScaling{ManualInstanceCount: &count},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling"}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
+	}
+	if _, err = op.Wait(ctx); err != nil {
+		return fmt.Errorf("failed to wait for worker pool %q update: %w", name, err)
+	}
+	return nil
+}
+
+// buildClientAndParams creates a Cloud Run WorkerPoolsClient and constructs the fully-qualified worker pool name.
+func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, config iface.ComputeProviderConfig) (*run.WorkerPoolsClient, string, error) {
+	project, ok := config[configGCPCloudRunProject].(string)
+	if !ok || project == "" {
+		return nil, "", fmt.Errorf("project not found in config")
+	}
+	region, ok := config[configGCPCloudRunRegion].(string)
+	if !ok || region == "" {
+		return nil, "", fmt.Errorf("region not found in config")
+	}
+	workerPool, ok := config[configGCPCloudRunWorkerPool].(string)
+	if !ok || workerPool == "" {
+		return nil, "", fmt.Errorf("worker_pool not found in config")
+	}
+	name := fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, workerPool)
+
+	var opts []option.ClientOption
+	if serviceAccount, ok := config[configGCPCloudRunServiceAccount].(string); ok && serviceAccount != "" {
+		delegates := []string{}
+		for _, step := range p.intermediaryServiceAccounts {
+			if len(step) == 0 {
+				continue
+			}
+
+			req := step[rand.Intn(len(step))]
+			if req.ServiceAccountEmail == "" {
+				return nil, "", fmt.Errorf("invalid empty intermediary service account email")
+			}
+
+			delegates = append(delegates, req.ServiceAccountEmail)
+		}
+
+		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+			TargetPrincipal: serviceAccount,
+			Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
+			Delegates:       delegates,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create impersonated credentials for %q: %w", serviceAccount, err)
+		}
+		opts = []option.ClientOption{option.WithTokenSource(ts)}
+	}
+
+	client, err := run.NewWorkerPoolsClient(ctx, opts...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create Cloud Run client: %w", err)
+	}
+	return client, name, nil
+}

--- a/wci/workflow/compute_provider/k8s.go
+++ b/wci/workflow/compute_provider/k8s.go
@@ -1,0 +1,124 @@
+//go:build !release
+
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	configK8sNamespace  = "namespace"
+	configK8sDeployment = "deployment"
+	configK8sKubeconfig = "kubeconfig"
+	configK8sContext    = "context"
+)
+
+type k8sComputeProvider struct{}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeK8s, NewK8sComputeProvider)
+}
+
+func NewK8sComputeProvider(_ context.Context, _ *dynamicconfig.Collection) (ComputeProvider, error) {
+	return &k8sComputeProvider{}, nil
+}
+
+func (p *k8sComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyWorkerSet
+}
+
+func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, config iface.ComputeProviderConfig) error {
+	client, namespace, deployment, err := p.buildClientAndParams(config)
+	if err != nil {
+		return err
+	}
+	_, err = client.AppsV1().Deployments(namespace).Get(ctx, deployment, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("deployment %q not found in namespace %q: %w", deployment, namespace, err)
+	}
+	return nil
+}
+
+func (p *k8sComputeProvider) InvokeWorker(ctx context.Context, config iface.ComputeProviderConfig) error {
+	return errors.ErrUnsupported
+}
+
+func (p *k8sComputeProvider) UpdateWorkerSetSize(ctx context.Context, config iface.ComputeProviderConfig, count int32) error {
+	client, namespace, deployment, err := p.buildClientAndParams(config)
+	if err != nil {
+		return err
+	}
+
+	scale, err := client.AppsV1().Deployments(namespace).GetScale(ctx, deployment, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get scale for deployment %q: %w", deployment, err)
+	}
+
+	scale.Spec.Replicas = count
+	_, err = client.AppsV1().Deployments(namespace).UpdateScale(ctx, deployment, scale, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to scale deployment %q to %d: %w", deployment, count, err)
+	}
+	return nil
+}
+
+// buildClientAndParams builds a Kubernetes client and extracts/validates namespace and deployment from config.
+func (p *k8sComputeProvider) buildClientAndParams(config iface.ComputeProviderConfig) (kubernetes.Interface, string, string, error) {
+	namespace, ok := config[configK8sNamespace].(string)
+	if !ok || namespace == "" {
+		return nil, "", "", fmt.Errorf("namespace not found in config")
+	}
+	deployment, ok := config[configK8sDeployment].(string)
+	if !ok || deployment == "" {
+		return nil, "", "", fmt.Errorf("deployment not found in config")
+	}
+
+	restConfig, err := p.buildRestConfig(config)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+	return client, namespace, deployment, nil
+}
+
+// buildRestConfig returns a REST config using kubeconfig content (with optional context) or in-cluster config.
+func (p *k8sComputeProvider) buildRestConfig(config iface.ComputeProviderConfig) (*rest.Config, error) {
+	kubeconfigContent, _ := config[configK8sKubeconfig].(string)
+
+	if kubeconfigContent == "" {
+		restConfig, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build in-cluster config: %w", err)
+		}
+		return restConfig, nil
+	}
+
+	apiConfig, err := clientcmd.Load([]byte(kubeconfigContent))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse kubeconfig content: %w", err)
+	}
+
+	overrides := &clientcmd.ConfigOverrides{}
+	if contextName, ok := config[configK8sContext].(string); ok && contextName != "" {
+		overrides.CurrentContext = contextName
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*apiConfig, overrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build REST config from kubeconfig content: %w", err)
+	}
+	return restConfig, nil
+}

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -35,7 +35,7 @@ type (
 		// UpdateWorkerSetSize updates the size of the managed worker set to the provided 'size' when using
 		// the LaunchStrategy 'worker-set'. An error is returned when the size update fails, but might not
 		// if the triggered instance starts/stops fail. Always returns an error for other launch stratgies.
-		UpdateWorkerSetSize(ctx context.Context, config iface.ComputeProviderConfig, size int) error
+		UpdateWorkerSetSize(ctx context.Context, config iface.ComputeProviderConfig, size int32) error
 	}
 )
 

--- a/wci/workflow/compute_provider/subprocess.go
+++ b/wci/workflow/compute_provider/subprocess.go
@@ -1,0 +1,94 @@
+//go:build !release
+
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	// subprocessTimeoutArg is the argument passed to the timeout(1) command (GNU coreutils).
+	subprocessTimeoutArg = "1m"
+
+	configSubprocessCommand = "command"
+	configSubprocessArgs    = "args"
+)
+
+type subprocessComputeProvider struct{}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeSubprocess, NewSubprocessComputeProvider)
+}
+
+func NewSubprocessComputeProvider(_ context.Context, _ *dynamicconfig.Collection) (ComputeProvider, error) {
+	return &subprocessComputeProvider{}, nil
+}
+
+func (p *subprocessComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *subprocessComputeProvider) ValidateConfig(ctx context.Context, config iface.ComputeProviderConfig) error {
+	command, ok := config[configSubprocessCommand].(string)
+	if !ok || strings.TrimSpace(command) == "" {
+		return fmt.Errorf("command not found in config")
+	}
+
+	if _, err := exec.LookPath("timeout"); err != nil {
+		return fmt.Errorf("required GNU coreutils 'timeout' binary not found: %w", err)
+	}
+
+	command = strings.TrimSpace(command)
+	if _, err := exec.LookPath(command); err != nil {
+		return fmt.Errorf("command %q not found locally: %w", command, err)
+	}
+	return nil
+}
+
+func (p *subprocessComputeProvider) InvokeWorker(ctx context.Context, config iface.ComputeProviderConfig) error {
+	command, ok := config[configSubprocessCommand].(string)
+	if !ok || strings.TrimSpace(command) == "" {
+		return fmt.Errorf("command not found in config")
+	}
+
+	args := []string{}
+	if argsVal, ok := config[configSubprocessArgs].(string); ok {
+		args = splitOptionalArgs(argsVal)
+	}
+
+	// Use timeout(1) to limit the child to 1 minute; do not wait for completion.
+	// Use context.Background() so the subprocess is not killed when the activity returns.
+	timeoutArgs := append([]string{subprocessTimeoutArg, command}, args...)
+	cmd := exec.CommandContext(context.Background(), "timeout", timeoutArgs...)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start subprocess: %w", err)
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			// using plain printf as the activity logger might no longer be valid
+			// at this point, and this provider is meant for local-dev only anyhow
+			fmt.Printf("subprocess worker '%s' exited with error: %v\n", command, err)
+		}
+	}()
+	return nil
+}
+
+func (p *subprocessComputeProvider) UpdateWorkerSetSize(_ context.Context, _ iface.ComputeProviderConfig, _ int32) error {
+	return errors.ErrUnsupported
+}
+
+func splitOptionalArgs(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
+}

--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -41,22 +41,22 @@ type (
 )
 
 const (
-	ComputeProviderTypeAwsLambda   ComputeProviderType = "aws-lambda"
-	ComputeProviderTypeAwsEcs      ComputeProviderType = "aws-ecs"
+	ComputeProviderTypeAWSLambda   ComputeProviderType = "aws-lambda"
+	ComputeProviderTypeAWSECS      ComputeProviderType = "aws-ecs"
 	ComputeProviderTypeSubprocess  ComputeProviderType = "subprocess"
 	ComputeProviderTypeK8s         ComputeProviderType = "k8s"
-	ComputeProviderTypeGcpCloudRun ComputeProviderType = "gcp-cloud-run"
+	ComputeProviderTypeGCPCloudRun ComputeProviderType = "gcp-cloud-run"
 
 	ScalingAlgorithmNoSync    ScalingAlgorithmType = "no-sync"
 	ScalingAlgorithmRateBased ScalingAlgorithmType = "rate-based"
 )
 
 var validComputeProviderTypes = map[string]ComputeProviderType{
-	string(ComputeProviderTypeAwsLambda):   ComputeProviderTypeAwsLambda,
-	string(ComputeProviderTypeAwsEcs):      ComputeProviderTypeAwsEcs,
+	string(ComputeProviderTypeAWSLambda):   ComputeProviderTypeAWSLambda,
+	string(ComputeProviderTypeAWSECS):      ComputeProviderTypeAWSECS,
 	string(ComputeProviderTypeSubprocess):  ComputeProviderTypeSubprocess,
 	string(ComputeProviderTypeK8s):         ComputeProviderTypeK8s,
-	string(ComputeProviderTypeGcpCloudRun): ComputeProviderTypeGcpCloudRun,
+	string(ComputeProviderTypeGCPCloudRun): ComputeProviderTypeGCPCloudRun,
 }
 
 var validScalingAlgorithmTypes = map[string]ScalingAlgorithmType{

--- a/wci/workflow/scaling_algorithm/registry.go
+++ b/wci/workflow/scaling_algorithm/registry.go
@@ -21,7 +21,7 @@ type (
 	ScalingAction struct {
 		SpecKey string     `json:"spec_key"`
 		Action  ActionType `json:"action"`
-		Count   *int       `json:"count,omitempty"`
+		Count   *int32     `json:"count,omitempty"`
 	}
 
 	ScalingMetricsSnapshot struct {

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -309,7 +309,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 			continue
 		}
 
-		count := 1
+		count := int32(1)
 		if action.Count != nil {
 			if *action.Count < 0 {
 				d.logger.Warn("Scaling action has invalid count value", "count", *action.Count)
@@ -321,12 +321,15 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 
 		switch action.Action {
 		case scalingalgorithm.ActionTypeInvokeWorker:
+			if count != 1 {
+				d.logger.Warn("Invalid count for action type invoke worker received", "count", count)
+			}
+
 			if err := workflow.ExecuteActivity(
 				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 2 * time.Minute, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
 				d.a.InvokeWorker,
 				InvokeWorkerActivityRequest{
 					ComputeConfig: &spec.Compute,
-					Count:         count,
 				},
 			).Get(ctx, nil); err != nil {
 				d.logger.Warn("Failed to execute new worker instance activity", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "error", err)


### PR DESCRIPTION
## What was changed
This adds a first set of compute provider implementations for real compute providers AWS, GCP and K8s as well as a test provider for development (subprocess)

## Why?
Compute Providers integrate the auto-scaling decisions with the customers compute environment. A wide-variety allows for customer choice and breadth of coverage.
