### PR TITLE
Add implementation for no-sync-match algo

### DIFF
--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -175,6 +175,9 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 func (a *Activities) HandleTaskAddSignal(ctx context.Context, req HandleTaskAddSignalActivityRequest) (*HandleTaskAddSignalActivityResponse, error) {
 	logger := activity.GetLogger(ctx)
 	updatedScalingStatus := req.ScalingStatus
+	if updatedScalingStatus == nil {
+		updatedScalingStatus = map[string]iface.ScalingAlgorithmStatus{}
+	}
 
 	if req.Spec == nil {
 		logger.Error("Did not receive a spec")
@@ -293,7 +296,7 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 			continue
 		}
 
-		logger.Info("Loaded scaling algo", "scaling_algo", scalingAlgo, "config", scalingConfig)
+		logger.Debug("Loaded scaling algo", "scaling_algo", scalingAlgo, "config", scalingConfig)
 
 		response, err := scalingAlgo.ProcessMetricsPoll(ctx, scalingConfig, scalingStatus, scalingMetricsSnapshot)
 		if err != nil {
@@ -333,7 +336,10 @@ func (a *Activities) getScalingAlgorithmAndConfig(ctx context.Context, entry ifa
 		return nil, nil, err
 	}
 	if scalingAlgo == nil {
-		return nil, nil, fmt.Errorf("Unknown scaling algorithm")
+		if entry.Scaling != nil {
+			return nil, nil, fmt.Errorf("unknown scaling algorithm %q", entry.Scaling.ScalingAlgorithm)
+		}
+		return nil, nil, fmt.Errorf("unknown default scaling algorithm for compute provider %q", entry.Compute.ProviderType)
 	}
 	var scalingConfig iface.ScalingAlgorithmConfig
 	if entry.Scaling != nil {

--- a/wci/workflow/iface/map_access.go
+++ b/wci/workflow/iface/map_access.go
@@ -118,7 +118,7 @@ func validateFloat64InMap(m map[string]any, key string, minValidValue float64) e
 	case string:
 		i, err := strconv.ParseFloat(val, 64)
 		if err != nil || i < minValidValue {
-			return serviceerror.NewInvalidArgumentf("%s must be a number and at least %d", key, minValidValue)
+			return serviceerror.NewInvalidArgumentf("%s must be a number and at least %v", key, minValidValue)
 		}
 	default:
 		return serviceerror.NewInvalidArgumentf("%s must be a number and at least %v", key, minValidValue)

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -1,0 +1,230 @@
+package scalingalgorithm
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"math"
+	"time"
+
+	computeprovider "github.com/temporalio/temporal-managed-workers/wci/workflow/compute_provider"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+)
+
+const (
+	// configNoSyncScaleUpCooloffMsKey is the minimum time in milliseconds between two scale-up (new-instance) actions.
+	// The cooloff is shared across all queue types via a single state key; a scale-up on any queue resets the timer for all.
+	// 0 means no cooloff (every eligible event may trigger a scale-up).
+	configNoSyncScaleUpCooloffMsKey     = "scale_up_cooloff_ms"
+	configNoSyncScaleUpCooloffMsDefault = 100
+
+	// configNoSyncScaleUpBacklogThresholdKey: in ProcessMetricsPoll, request a new instance when backlog > this
+	// (strict greater-than) and scale_up_cooloff_ms has elapsed since last scale-up.
+	// Default 0 means any non-zero backlog triggers a scale-up.
+	configNoSyncScaleUpBacklogThresholdKey     = "scale_up_backlog_threshold"
+	configNoSyncScaleUpBacklogThresholdDefault = 0
+
+	// configNoSyncMaxWorkerLifetimeMsKey: in ProcessMetricsPoll, request a new instance when backlog > 0 and at
+	// least this many ms have elapsed since the last scale-up (worker refresh). Uses the same
+	// last_scale_up_time_ms state key as ProcessTaskAdd and the backlog-threshold branch of ProcessMetricsPoll,
+	// so any scale-up from either path resets the lifetime timer. Only fires when the backlog-threshold branch
+	// did not already set perTypeScaleUp for this queue in the current poll. Uses maxWorkerLifetimeMs (not
+	// scale_up_cooloff_ms) as the elapsed threshold, so it can fire even while the cooloff is still active.
+	// 0 means disabled.
+	configNoSyncMaxWorkerLifetimeMsKey     = "max_worker_lifetime_ms"
+	configNoSyncMaxWorkerLifetimeMsDefault = 10 * 60 * 1000 // default is 10min
+
+	// configNoSyncScaleUpDispatchRateEpsilonKey: in ProcessMetricsPoll, skip scale-up when the current
+	// processing rate (QueueTypeScalingMetrics.LastProcessingRate) is within this epsilon of the previous
+	// poll's value, stored per queue under the state key "<queue>_last_dispatch_rate" (see stateLastDispatchRateKeyFmt).
+	// 0 means disabled. Suppression is skipped on the first poll for a queue when no prior rate is recorded in state.
+	configNoSyncScaleUpDispatchRateEpsilonKey     = "scale_up_dispatch_rate_epsilon"
+	configNoSyncScaleUpDispatchRateEpsilonDefault = 0
+
+	// configNoSyncMetricsPollIntervalMsKey is the interval in milliseconds between metrics poll calls.
+	configNoSyncMetricsPollIntervalMsKey     = "metrics_poll_interval_ms"
+	configNoSyncMetricsPollIntervalMsDefault = int64(60_000) // 60s
+
+	stateLastScaleUpTimestampKey = "last_scale_up_time_ms"
+	// stateLastDispatchRateKeyFmt is a format string for per-queue dispatch rate state keys.
+	// The %s placeholder is replaced by the queue type name ("workflow", "activity", "nexus"),
+	// producing keys such as "workflow_last_dispatch_rate".
+	stateLastDispatchRateKeyFmt = "%s_last_dispatch_rate"
+)
+
+var _ ScalingAlgorithm = (*scalingAlgorithmNoSync)(nil)
+
+var noSyncValidConfigKeys = map[string]struct{}{
+	configNoSyncScaleUpCooloffMsKey:           {},
+	configNoSyncScaleUpBacklogThresholdKey:    {},
+	configNoSyncMaxWorkerLifetimeMsKey:        {},
+	configNoSyncScaleUpDispatchRateEpsilonKey: {},
+	configNoSyncMetricsPollIntervalMsKey:      {},
+}
+
+var noSyncValidStateKeys = map[string]struct{}{
+	stateLastScaleUpTimestampKey:                         {},
+	fmt.Sprintf(stateLastDispatchRateKeyFmt, "workflow"): {},
+	fmt.Sprintf(stateLastDispatchRateKeyFmt, "activity"): {},
+	fmt.Sprintf(stateLastDispatchRateKeyFmt, "nexus"):    {},
+}
+
+type (
+	scalingAlgorithmNoSync struct{}
+)
+
+func init() {
+	RegisterScalingAlgorithm(iface.ScalingAlgorithmNoSync, NewScalingAlgorithmNoSync, iface.ComputeProviderTypeAWSLambda, iface.ComputeProviderTypeSubprocess)
+}
+
+func NewScalingAlgorithmNoSync(_ context.Context) (ScalingAlgorithm, error) {
+	return &scalingAlgorithmNoSync{}, nil
+}
+
+func (a *scalingAlgorithmNoSync) CompatibleLaunchStrategies() []computeprovider.LaunchStrategy {
+	return []computeprovider.LaunchStrategy{computeprovider.LaunchStrategyInvoke}
+}
+
+func (a *scalingAlgorithmNoSync) ValidateConfig(ctx context.Context, config iface.ScalingAlgorithmConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	for k := range config {
+		if _, ok := noSyncValidConfigKeys[k]; !ok {
+			return fmt.Errorf("unknown config key %q for no-sync scaling algorithm", k)
+		}
+	}
+
+	if err := config.ValidateInt64Field(configNoSyncScaleUpCooloffMsKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateInt64Field(configNoSyncScaleUpBacklogThresholdKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateInt64Field(configNoSyncMaxWorkerLifetimeMsKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateFloat64Field(configNoSyncScaleUpDispatchRateEpsilonKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateInt64Field(configNoSyncMetricsPollIntervalMsKey, 10000); err != nil {
+		return err
+	}
+
+	// Cross-field: if poll interval < cooloff, metric-driven scale-ups can never fire.
+	// The guard `cooloff > 0` reflects the "0 means disabled" semantics: when cooloff is
+	// disabled there is no minimum interval constraint, so the cross-field check is skipped.
+	pollInterval := config.GetInt64Field(configNoSyncMetricsPollIntervalMsKey, configNoSyncMetricsPollIntervalMsDefault)
+	cooloff := config.GetInt64Field(configNoSyncScaleUpCooloffMsKey, configNoSyncScaleUpCooloffMsDefault)
+	if cooloff > 0 && pollInterval < cooloff {
+		return fmt.Errorf("metrics_poll_interval_ms (%d) must be >= scale_up_cooloff_ms (%d), otherwise metric-driven scale-ups will never fire", pollInterval, cooloff)
+	}
+
+	return nil
+}
+
+func (a *scalingAlgorithmNoSync) ProcessTaskAdd(ctx context.Context, config iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, event iface.SignalTaskAddRequest) (*TaskAddResponse, error) {
+	updatedState := maps.Clone(priorState)
+	actions := []ScalingAction{}
+
+	if updatedState == nil {
+		updatedState = map[string]any{}
+	}
+	if priorState == nil {
+		priorState = iface.ScalingAlgorithmStatus{}
+	}
+	if config == nil {
+		config = iface.ScalingAlgorithmConfig{}
+	}
+
+	for k := range updatedState {
+		if _, ok := noSyncValidStateKeys[k]; !ok {
+			delete(updatedState, k)
+		}
+	}
+
+	if !event.IsSyncMatch || event.NoSyncMatchSignalsSinceLast > 0 {
+		cooloffMs := config.GetInt64Field(configNoSyncScaleUpCooloffMsKey, configNoSyncScaleUpCooloffMsDefault)
+		lastScaleUpMs := priorState.GetInt64Field(stateLastScaleUpTimestampKey, 0)
+		nowMs := time.Now().UnixMilli() // safe: called from activity context, not workflow
+		elapsedMs := nowMs - lastScaleUpMs
+
+		// TODO: add metric for throttling
+		if elapsedMs >= cooloffMs {
+			actions = append(actions, ScalingAction{Action: ActionTypeInvokeWorker})
+			updatedState[stateLastScaleUpTimestampKey] = nowMs
+		}
+	}
+
+	return &TaskAddResponse{Actions: actions, Status: updatedState}, nil
+}
+
+func (a *scalingAlgorithmNoSync) ProcessMetricsPoll(ctx context.Context, config iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, metricsSnapshot ScalingMetricsSnapshot) (*MetricsPollResponse, error) {
+	updatedState := maps.Clone(priorState)
+	actions := []ScalingAction{}
+
+	if updatedState == nil {
+		updatedState = map[string]any{}
+	}
+	if priorState == nil {
+		priorState = iface.ScalingAlgorithmStatus{}
+	}
+	if config == nil {
+		config = iface.ScalingAlgorithmConfig{}
+	}
+
+	for k := range updatedState {
+		if _, ok := noSyncValidStateKeys[k]; !ok {
+			delete(updatedState, k)
+		}
+	}
+
+	pollIntervalMs := config.GetInt64Field(configNoSyncMetricsPollIntervalMsKey, configNoSyncMetricsPollIntervalMsDefault)
+	nextPoll := time.Duration(pollIntervalMs) * time.Millisecond
+	cooloffMs := config.GetInt64Field(configNoSyncScaleUpCooloffMsKey, configNoSyncScaleUpCooloffMsDefault)
+	backlogThreshold := config.GetInt64Field(configNoSyncScaleUpBacklogThresholdKey, configNoSyncScaleUpBacklogThresholdDefault)
+	maxWorkerLifetimeMs := config.GetInt64Field(configNoSyncMaxWorkerLifetimeMsKey, configNoSyncMaxWorkerLifetimeMsDefault)
+	epsilon := config.GetFloat64Field(configNoSyncScaleUpDispatchRateEpsilonKey, configNoSyncScaleUpDispatchRateEpsilonDefault)
+	lastScaleUpMs := priorState.GetInt64Field(stateLastScaleUpTimestampKey, 0)
+	nowMs := time.Now().UnixMilli() // safe: called from activity context, not workflow
+	elapsedSinceScaleUp := nowMs - lastScaleUpMs
+
+	scaleUp := false
+	for _, q := range []struct {
+		qName   string
+		metrics *iface.QueueTypeScalingMetrics
+	}{
+		{"workflow", metricsSnapshot.Workflow},
+		{"activity", metricsSnapshot.Activity},
+		{"nexus", metricsSnapshot.Nexus},
+	} {
+		if q.metrics == nil {
+			continue
+		}
+		backlog := q.metrics.LastBacklogCount
+		currentRate := float64(q.metrics.LastProcessingRate)
+		lastDispatchRateKey := fmt.Sprintf(stateLastDispatchRateKeyFmt, q.qName)
+		lastRate := priorState.GetFloat64Field(lastDispatchRateKey, -1)
+
+		perTypeScaleUp := false
+		if backlog > backlogThreshold && elapsedSinceScaleUp >= cooloffMs {
+			perTypeScaleUp = true
+		}
+		if !perTypeScaleUp && maxWorkerLifetimeMs > 0 && backlog > 0 && elapsedSinceScaleUp >= maxWorkerLifetimeMs {
+			perTypeScaleUp = true
+		}
+		if perTypeScaleUp && epsilon > 0 && lastRate >= 0 && math.Abs(currentRate-lastRate) <= epsilon {
+			perTypeScaleUp = false
+		}
+
+		scaleUp = scaleUp || perTypeScaleUp
+		updatedState[lastDispatchRateKey] = currentRate
+	}
+	if scaleUp {
+		actions = append(actions, ScalingAction{Action: ActionTypeInvokeWorker})
+		updatedState[stateLastScaleUpTimestampKey] = nowMs
+	}
+
+	return &MetricsPollResponse{Actions: actions, Status: updatedState, NextPoll: &nextPoll}, nil
+}

--- a/wci/workflow/scaling_algorithm/no_sync_match_test.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match_test.go
@@ -1,0 +1,679 @@
+package scalingalgorithm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computeprovider "github.com/temporalio/temporal-managed-workers/wci/workflow/compute_provider"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	enumspb "go.temporal.io/api/enums/v1"
+)
+
+func newNoSync() *scalingAlgorithmNoSync {
+	algo, err := NewScalingAlgorithmNoSync(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	return algo.(*scalingAlgorithmNoSync)
+}
+
+func TestNoSyncValidateConfig(t *testing.T) {
+	a := newNoSync()
+	ctx := context.Background()
+
+	t.Run("nil config", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, nil))
+	})
+
+	t.Run("empty config defaults", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{}))
+	})
+
+	t.Run("scale_up_cooloff_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("scale_up_backlog_threshold negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpBacklogThresholdKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("max_worker_lifetime_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncMaxWorkerLifetimeMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("scale_up_dispatch_rate_epsilon negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpDispatchRateEpsilonKey: float64(-1.0)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("metrics_poll_interval_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncMetricsPollIntervalMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("metrics_poll_interval_ms zero", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncMetricsPollIntervalMsKey: int64(0)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("zero values valid for other fields", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+			configNoSyncScaleUpBacklogThresholdKey:    int64(0),
+			configNoSyncMaxWorkerLifetimeMsKey:        int64(0), // 0 = disabled
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("unknown key rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{"scale_up_coolof_ms": int64(1000)} // typo
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("metrics_poll_interval_ms below minimum rejected", func(t *testing.T) {
+		// The field minimum for metrics_poll_interval_ms is 10000ms; values below that are rejected
+		// by the individual field validation regardless of the cooloff setting.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncMetricsPollIntervalMsKey: int64(50)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("poll interval < cooloff rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMetricsPollIntervalMsKey: int64(10000),
+			configNoSyncScaleUpCooloffMsKey:      int64(60000),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("poll interval < cooloff allowed when cooloff=0 (disabled)", func(t *testing.T) {
+		// cooloff=0 means "no cooloff"; the cross-field check must be skipped entirely.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMetricsPollIntervalMsKey: int64(10000),
+			configNoSyncScaleUpCooloffMsKey:      int64(0),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("poll interval >= cooloff valid", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMetricsPollIntervalMsKey: int64(60000),
+			configNoSyncScaleUpCooloffMsKey:      int64(60000),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+}
+
+func TestNoSyncProcessTaskAdd(t *testing.T) {
+	a := newNoSync()
+	ctx := context.Background()
+
+	t.Run("sync match no batched no-sync", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 0}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("no-sync match nil state first call", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+		assert.NotNil(t, resp.Status[stateLastScaleUpTimestampKey])
+	})
+
+	t.Run("no-sync match within cooloff", func(t *testing.T) {
+		nowMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: nowMs}
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30000)}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("no-sync match outside cooloff", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: int64(0)}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, state, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("sync match with batched no-sync signals", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 3, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("activity queue type writes shared state key", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_ACTIVITY}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.NotNil(t, resp.Status[stateLastScaleUpTimestampKey])
+	})
+
+	t.Run("nexus queue type writes shared state key", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_NEXUS}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.NotNil(t, resp.Status[stateLastScaleUpTimestampKey])
+	})
+
+	t.Run("state threads correctly across two calls", func(t *testing.T) {
+		// First call: fires and stores timestamp in state.
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		resp1, err := a.ProcessTaskAdd(ctx, cfg, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp1.Actions, 1)
+
+		// Second call within cooloff: must not fire when prior state is threaded back.
+		resp2, err := a.ProcessTaskAdd(ctx, cfg, resp1.Status, event)
+		require.NoError(t, err)
+		assert.Len(t, resp2.Actions, 0)
+	})
+
+	t.Run("cooloff=0 state recent still fires", func(t *testing.T) {
+		nowMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: nowMs}
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(0)}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+}
+
+func TestNoSyncCompatibleLaunchStrategies(t *testing.T) {
+	a := newNoSync()
+	strategies := a.CompatibleLaunchStrategies()
+	require.Len(t, strategies, 1)
+	assert.Equal(t, computeprovider.LaunchStrategyInvoke, strategies[0])
+}
+
+func TestNoSyncProcessMetricsPoll(t *testing.T) {
+	a := newNoSync()
+	ctx := context.Background()
+
+	t.Run("all nil metrics", func(t *testing.T) {
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		require.NotNil(t, resp.NextPoll)
+		assert.Equal(t, 60*time.Second, *resp.NextPoll)
+	})
+
+	t.Run("custom poll interval", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncMetricsPollIntervalMsKey: int64(5000)}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		require.NotNil(t, resp.NextPoll)
+		assert.Equal(t, 5*time.Second, *resp.NextPoll)
+	})
+
+	t.Run("single queue backlog=0", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 0, LastProcessingRate: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("single queue backlog>0 no prior state", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+		assert.NotNil(t, resp.Status[stateLastScaleUpTimestampKey])
+	})
+
+	t.Run("single queue backlog>0 within cooloff", func(t *testing.T) {
+		nowMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: nowMs}
+		// Use an explicit large cooloff to avoid flakiness on slow CI machines.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("lifetime fires when within cooloff but past lifetime threshold", func(t *testing.T) {
+		// The backlog-threshold branch is guarded by cooloff, but the lifetime
+		// branch uses maxWorkerLifetimeMs as its own threshold. This test verifies that the lifetime
+		// path fires independently of the cooloff: lastScaleUpMs is recent enough to suppress the
+		// backlog-threshold branch, but the lifetime has expired so a scale-up must still fire.
+		recentMs := time.Now().UnixMilli() - 2_000 // 2s ago
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: recentMs}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpCooloffMsKey:        int64(30_000), // 30s — suppresses backlog threshold
+			configNoSyncScaleUpBacklogThresholdKey: int64(0),
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(1_000), // 1s — already elapsed (2s > 1s)
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1, "lifetime path must fire even when cooloff suppresses backlog-threshold path")
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("worker refresh backlog present elapsed>=lifetime", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: int64(0)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpBacklogThresholdKey: int64(10),
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(1000),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("worker refresh disabled lifetime=0", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: int64(0)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpBacklogThresholdKey: int64(10),
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("epsilon suppression on lifetime refresh path", func(t *testing.T) {
+		// Lifetime path triggers scale-up but epsilon suppresses it because rate is unchanged.
+		// Backlog threshold is set high so only the lifetime path would fire.
+		state := iface.ScalingAlgorithmStatus{
+			stateLastScaleUpTimestampKey:  int64(0),
+			"workflow_last_dispatch_rate": float64(10),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMaxWorkerLifetimeMsKey:        int64(1000),
+			configNoSyncScaleUpBacklogThresholdKey:    int64(100),
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("epsilon does not suppress lifetime refresh when rate changed", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateLastScaleUpTimestampKey:  int64(0),
+			"workflow_last_dispatch_rate": float64(10),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMaxWorkerLifetimeMsKey:        int64(1000),
+			configNoSyncScaleUpBacklogThresholdKey:    int64(100),
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 15},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("epsilon suppression rate unchanged", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("epsilon suppression rate changed", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 15},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("epsilon disabled rate unchanged fires", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("all three queues have backlog", func(t *testing.T) {
+		// ProcessMetricsPoll emits at most one action per poll regardless of how many queue types have backlog.
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Nexus:    &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("only workflow has backlog", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 0},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("dispatch rate saved in state without scale-up", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 0, LastProcessingRate: 7},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, float64(7), resp.Status["workflow_last_dispatch_rate"])
+	})
+
+	t.Run("epsilon suppression skipped on first poll no prior rate", func(t *testing.T) {
+		// With no prior rate in state, lastRate defaults to -1 which skips the epsilon guard.
+		// A scale-up must still fire even when epsilon is enabled.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("only activity has backlog", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+		assert.Equal(t, float64(0), resp.Status["activity_last_dispatch_rate"])
+	})
+
+	t.Run("only nexus has backlog", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Nexus: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+		assert.Equal(t, float64(0), resp.Status["nexus_last_dispatch_rate"])
+	})
+
+	t.Run("cooloff is shared across queue types", func(t *testing.T) {
+		nowMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: nowMs}
+		// Use an explicit large cooloff to avoid flakiness on slow CI machines.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("backlog exactly at threshold does not fire", func(t *testing.T) {
+		// backlog > threshold is strict; backlog == threshold must not trigger.
+		// lifetime refresh is disabled to isolate the threshold check.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpBacklogThresholdKey: int64(5),
+			configNoSyncScaleUpCooloffMsKey:        int64(0),
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("nil config uses defaults", func(t *testing.T) {
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, nil, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.NextPoll)
+		assert.Equal(t, 60*time.Second, *resp.NextPoll)
+	})
+
+	t.Run("dispatch rate saved in state after epsilon suppression", func(t *testing.T) {
+		// When scale-up is suppressed by epsilon, the rate should still be updated in state
+		// so that the next poll has the correct reference point.
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, float64(10), resp.Status["workflow_last_dispatch_rate"])
+	})
+
+	t.Run("state threads correctly across two calls", func(t *testing.T) {
+		// First call: backlog triggers a scale-up and stores the timestamp in state.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp1, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp1.Actions, 1)
+
+		// Second call within cooloff: must not fire when prior state is threaded back.
+		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp2.Actions, 0)
+	})
+
+	t.Run("lifetime state threads correctly across two calls", func(t *testing.T) {
+		// First call: lifetime path fires and records nowMs in state.
+		// Second call: lifetime has not elapsed again, so it must not fire.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpCooloffMsKey:        int64(0),
+			configNoSyncScaleUpBacklogThresholdKey: int64(100), // suppress backlog-threshold path
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(1_000),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3},
+		}
+		// Start with epoch-0 so lifetime has elapsed on the first call.
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: int64(0)}
+		resp1, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp1.Actions, 1, "first call: lifetime should fire")
+
+		// Second call with the updated state: the lifetime timer was reset to nowMs, so 1s has not yet elapsed.
+		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp2.Actions, 0, "second call: lifetime not yet elapsed, must not fire")
+	})
+
+	t.Run("epsilon at exact boundary suppresses", func(t *testing.T) {
+		// |currentRate - lastRate| == epsilon: the <= comparison must suppress the scale-up.
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		// Use rate that differs by exactly epsilon from lastRate via float arithmetic (10 + 0.5 = 10.5).
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10.5}, // diff = 0.0 <= 0.5
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0, "diff == 0 is within epsilon, must suppress")
+	})
+
+	t.Run("epsilon just above boundary fires", func(t *testing.T) {
+		// |currentRate - lastRate| > epsilon: the scale-up must proceed.
+		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			// LastProcessingRate is int32; use a value whose float64 diff is > 0.5.
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 11}, // diff = 1.0 > 0.5
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1, "diff > epsilon, must fire")
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("dispatch rate state threads correctly across two calls", func(t *testing.T) {
+		// First call: stores dispatch rate in state.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
+		}
+		resp1, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp1.Actions, 1) // first poll: no prior rate, epsilon skipped
+
+		// Second call: same rate — epsilon suppresses scale-up using rate stored by first call.
+		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp2.Actions, 0)
+	})
+
+	t.Run("worker refresh does not fire when backlog is zero", func(t *testing.T) {
+		// The lifetime path requires backlog > 0; zero backlog must not trigger even if lifetime elapsed.
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: int64(0)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncMaxWorkerLifetimeMsKey: int64(10000),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 0},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("backlog one above threshold fires", func(t *testing.T) {
+		// Confirms the positive side of the backlog > threshold boundary.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpBacklogThresholdKey: int64(5),
+			configNoSyncScaleUpCooloffMsKey:        int64(0),
+			configNoSyncMaxWorkerLifetimeMsKey:     int64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 6},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
+	})
+
+	t.Run("cooloff suppresses all queue types", func(t *testing.T) {
+		nowMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: nowMs}
+		// Use an explicit large cooloff to avoid flakiness on slow CI machines.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+			Nexus:    &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+	})
+
+	t.Run("ProcessTaskAdd state suppresses ProcessMetricsPoll within cooloff", func(t *testing.T) {
+		// Both methods share the same last_scale_up_time_ms key, so a scale-up via ProcessTaskAdd
+		// must suppress a subsequent ProcessMetricsPoll within the cooloff window.
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+		taskAddResp, err := a.ProcessTaskAdd(ctx, cfg, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, taskAddResp.Actions, 1)
+
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+		}
+		pollResp, err := a.ProcessMetricsPoll(ctx, cfg, taskAddResp.Status, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, pollResp.Actions, 0)
+	})
+}


### PR DESCRIPTION
## What was changed
Adding a scaling algo implementation for function providers, e.g. AWS Lambda. This is focused on the no-sync-match signals with some backstops for error cases.

## Why?
This is one of the last pieces missing to make function providers work, and is likely the simplest meaningful algorithm for these platforms.
