### PR TITLE
Add support for external ID in the final role assumption for AWS Lambda and AWS ECS

### DIFF
--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -16,7 +16,7 @@ import (
 
 // buildAWSConfig loads the default AWS config for the given region, applies any
 // intermediary role chain, then optionally assumes a final role.
-func buildAWSConfig(ctx context.Context, region, roleARN string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
+func buildAWSConfig(ctx context.Context, region, roleARN string, externalID *string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
@@ -42,6 +42,7 @@ func buildAWSConfig(ctx context.Context, region, roleARN string, intermediaryRol
 		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &client.AWSIAMRoleRequest{
 			RoleARN:         roleARN,
 			RoleSessionName: "managed-workers-aws",
+			ExternalID:      externalID,
 		})
 		if err != nil {
 			return aws.Config{}, err

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	configAWSECSCluster = "cluster"
-	configAWSECSService = "service"
-	configAWSECSRegion  = "region"
-	configAWSECSRole    = "role"
+	configAWSECSCluster        = "cluster"
+	configAWSECSService        = "service"
+	configAWSECSRegion         = "region"
+	configAWSECSRole           = "role"
+	configAWSECSRoleExternalID = "role_external_id"
 )
 
 type awsECSComputeProvider struct {
@@ -126,7 +127,12 @@ func (p *awsECSComputeProvider) getECSClientAndParams(ctx context.Context, cfg i
 		}
 	}
 
-	awsConfig, err := buildAWSConfig(ctx, region, roleARN, p.intermediaryRoles)
+	var roleExternalID *string
+	if eid, ok := cfg[configAWSECSRoleExternalID].(string); ok && eid != "" {
+		roleExternalID = &eid
+	}
+
+	awsConfig, err := buildAWSConfig(ctx, region, roleARN, roleExternalID, p.intermediaryRoles)
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	configAWSLambdaARN  = "arn"
-	configAWSLambdaRole = "role"
+	configAWSLambdaARN            = "arn"
+	configAWSLambdaRole           = "role"
+	configAWSLambdaRoleExternalID = "role_external_id"
 )
 
 type awsLambdaComputeProvider struct {
@@ -99,7 +100,12 @@ func (p *awsLambdaComputeProvider) getLambdaClientAndARN(ctx context.Context, cf
 		}
 	}
 
-	awsConfig, err := buildAWSConfig(ctx, region, roleARN, p.intermediaryRoles)
+	var roleExternalID *string
+	if eid, ok := cfg[configAWSLambdaRoleExternalID].(string); ok && eid != "" {
+		roleExternalID = &eid
+	}
+
+	awsConfig, err := buildAWSConfig(ctx, region, roleARN, roleExternalID, p.intermediaryRoles)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## What was changed
Adding an option to provide an external ID for the role assumption in the lambda and ecs compute providers.

## Why?
While intermediate roles always supported external ID, this was missing from the final/client-side role. This adds it as using external IDs is the way to avoid confused deputies.

