### PR TITLE
Add ValidateWorkerControllerInstanceSpec API

### DIFF
--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -70,6 +70,13 @@ type (
 			spec *iface.WorkerControllerInstanceSpec,
 		) error
 
+		ValidateWorkerControllerInstanceSpec(
+			ctx context.Context,
+			namespaceEntry *namespace.Namespace,
+			spec *iface.WorkerControllerInstanceSpec,
+			identity string,
+		) error
+
 		DeleteWorkerControllerInstance(
 			ctx context.Context,
 			namespaceEntry *namespace.Namespace,
@@ -284,6 +291,41 @@ func (d *clientImpl) UpdateWorkerControllerInstance(
 		return serviceerror.NewInternal(failure.Message)
 	}
 	return nil
+}
+
+func (d *clientImpl) ValidateWorkerControllerInstanceSpec(
+	ctx context.Context,
+	namespaceEntry *namespace.Namespace,
+	spec *iface.WorkerControllerInstanceSpec,
+	identity string,
+) (retErr error) {
+	//revive:disable-next-line:defer
+	defer d.convertAndRecordError("ValidateWorkerControllerInstanceSpec", nil, &retErr, namespaceEntry.Name(), identity)()
+
+	if spec == nil {
+		return serviceerror.NewInvalidArgument("spec must be provided")
+	}
+	if err := spec.Validate(); err != nil {
+		return err
+	}
+
+	workflowID := uuid.NewString()
+	d.logger.Debug("starting validate worker controller instance spec workflow", tag.WorkflowID(workflowID))
+
+	return startWorkflowAndWait(
+		ctx,
+		d.historyClient,
+		namespaceEntry,
+		d.controllerTaskQueueName,
+		iface.WorkerControllerInstanceValidateWorkflowType,
+		workflowID,
+		&iface.ValidateWorkerControllerInstanceSpecWorkflowArgs{
+			Spec: spec,
+		},
+		identity,
+		uuid.NewString(),
+		validateWorkflowExecutionTimeout,
+	)
 }
 
 func (d *clientImpl) DeleteWorkerControllerInstance(

--- a/wci/client/workflow_interaction.go
+++ b/wci/client/workflow_interaction.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
 	commonpb "go.temporal.io/api/common/v1"
@@ -20,7 +21,107 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute/sadefs"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+const (
+	// validateWorkflowExecutionTimeout is the server-side execution timeout for the validate workflow.
+	// The validate activity has a 2s StartToCloseTimeout; this provides an upper bound for the full execution.
+	validateWorkflowExecutionTimeout = 30 * time.Second
+)
+
+func startWorkflowAndWait(
+	ctx context.Context,
+	historyClient historyservice.HistoryServiceClient,
+	namespaceEntry *namespace.Namespace,
+	taskQueueName string,
+	workflowType string,
+	workflowID string,
+	input interface{},
+	identity string,
+	requestID string,
+	timeout time.Duration,
+) error {
+	inputPayload, err := sdk.PreferProtoDataConverter.ToPayloads(input)
+	if err != nil {
+		return err
+	}
+
+	_, err = historyClient.StartWorkflowExecution(ctx, &historyservice.StartWorkflowExecutionRequest{
+		NamespaceId: namespaceEntry.ID().String(),
+		StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+			RequestId:                requestID,
+			Namespace:                namespaceEntry.Name().String(),
+			WorkflowId:               workflowID,
+			WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+			TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+			Input:                    inputPayload,
+			WorkflowExecutionTimeout: durationpb.New(timeout),
+			WorkflowIdReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+			WorkflowIdConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
+			SearchAttributes: &commonpb.SearchAttributes{
+				IndexedFields: map[string]*commonpb.Payload{
+					sadefs.TemporalNamespaceDivision: payload.EncodeString(iface.WorkerControllerInstanceNamespaceDivision),
+				},
+			},
+			Identity: identity,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	pollCtx, cancel := context.WithTimeout(ctx, timeout+5*time.Second)
+	defer cancel()
+
+	var nextPageToken []byte
+	for {
+		resp, err := historyClient.GetWorkflowExecutionHistory(pollCtx, &historyservice.GetWorkflowExecutionHistoryRequest{
+			NamespaceId: namespaceEntry.ID().String(),
+			Request: &workflowservice.GetWorkflowExecutionHistoryRequest{
+				Namespace:              namespaceEntry.Name().String(),
+				Execution:              &commonpb.WorkflowExecution{WorkflowId: workflowID},
+				MaximumPageSize:        1,
+				WaitNewEvent:           true,
+				HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
+				NextPageToken:          nextPageToken,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		events := resp.GetResponse().GetHistory().GetEvents()
+		if len(events) > 0 {
+			event := events[0]
+			if event.GetWorkflowExecutionCompletedEventAttributes() != nil {
+				return nil
+			}
+			if attrs := event.GetWorkflowExecutionFailedEventAttributes(); attrs != nil {
+				failure := attrs.GetFailure()
+				if failure == nil {
+					return serviceerror.NewInternal("workflow execution failed")
+				}
+				if appInfo := failure.GetApplicationFailureInfo(); appInfo != nil && appInfo.GetType() == "InvalidArgument" {
+					return serviceerror.NewInvalidArgument(failure.GetMessage())
+				}
+				return serviceerror.NewInternal(failure.GetMessage())
+			}
+			if event.GetWorkflowExecutionTimedOutEventAttributes() != nil {
+				return serviceerror.NewInternalf("workflow execution for request %s timed out", requestID)
+			}
+			if event.GetWorkflowExecutionCanceledEventAttributes() != nil {
+				return serviceerror.NewInternalf("workflow execution for request %s was cancelled", requestID)
+			}
+			if event.GetWorkflowExecutionTerminatedEventAttributes() != nil {
+				return serviceerror.NewInternalf("workflow execution for request %s was terminated", requestID)
+			}
+			return serviceerror.NewInternalf("workflow for request %s closed unexpectedly (event type: %s)", requestID, event.GetEventType())
+		}
+
+		nextPageToken = resp.GetResponse().GetNextPageToken()
+	}
+}
 
 func queryWorkflowWithRetry(
 	ctx context.Context,

--- a/wci/component.go
+++ b/wci/component.go
@@ -44,6 +44,10 @@ func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Na
 		return instancewf.Workflow(ctx, workflowVersionGetter, maxVersionsGetter, args, activities)
 	}
 	registry.RegisterWorkflowWithOptions(versionWorkflow, workflow.RegisterOptions{Name: iface.WorkerControllerInstanceWorkflowType})
+	validateWorkflow := func(ctx workflow.Context, args *iface.ValidateWorkerControllerInstanceSpecWorkflowArgs) error {
+		return instancewf.ValidateSpecWorkflow(ctx, args, activities)
+	}
+	registry.RegisterWorkflowWithOptions(validateWorkflow, workflow.RegisterOptions{Name: iface.WorkerControllerInstanceValidateWorkflowType})
 	registry.RegisterActivity(activities)
 
 	return nil

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -14,6 +14,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 )
@@ -87,7 +88,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 	logger := activity.GetLogger(ctx)
 
 	if req == nil || req.Spec == nil {
-		return errors.Errorf("Invalid activity request")
+		return temporal.NewApplicationError("Invalid activity request", "InvalidArgument")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, validateSpecTimeout)
@@ -96,32 +97,32 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 	for _, entry := range req.Spec.TaskTypeSpecs {
 		provider, err := computeprovider.GetComputeProvider(timeoutCtx, entry.Compute.ProviderType, a.dc)
 		if err != nil {
-			return err
+			return temporal.NewApplicationError(err.Error(), "InvalidArgument")
 		}
 		if provider == nil {
-			return errors.Errorf("Could not instantiate compute provider with type '%s'", entry.Compute.ProviderType)
+			return temporal.NewApplicationError(fmt.Sprintf("Could not instantiate compute provider with type '%s'", entry.Compute.ProviderType), "InvalidArgument")
 		}
 		logger.Debug("Validating compute provider", "compute_provider_type", entry.Compute.ProviderType)
 		if err := provider.ValidateConfig(timeoutCtx, entry.Compute.Config); err != nil {
-			return err
+			return temporal.NewApplicationError(err.Error(), "InvalidArgument")
 		}
 
 		if entry.Scaling != nil {
 			scalingAlgo, err := scalingalgorithm.GetScalingAlgorithm(timeoutCtx, entry.Scaling.ScalingAlgorithm, a.dc)
 			if err != nil {
-				return err
+				return temporal.NewApplicationError(err.Error(), "InvalidArgument")
 			}
 			if scalingAlgo == nil {
-				return errors.Errorf("Could not instantiate scaling algorithm with type '%s'", entry.Scaling.ScalingAlgorithm)
+				return temporal.NewApplicationError(fmt.Sprintf("Could not instantiate scaling algorithm with type '%s'", entry.Scaling.ScalingAlgorithm), "InvalidArgument")
 			}
 			logger.Debug("Validating scaling algorithm", "scaling_algorithm_type", entry.Scaling.ScalingAlgorithm)
 			if err := scalingAlgo.ValidateConfig(timeoutCtx, entry.Scaling.Config); err != nil {
-				return err
+				return temporal.NewApplicationError(err.Error(), "InvalidArgument")
 			}
 
 			compatibleLaunchStrategies := scalingAlgo.CompatibleLaunchStrategies()
 			if !slices.Contains(compatibleLaunchStrategies, provider.LaunchStrategy()) {
-				return errors.Errorf("Scaling Algorithm '%s' is not compatible with compute provider '%s'", entry.Scaling.ScalingAlgorithm, entry.Compute.ProviderType)
+				return temporal.NewApplicationError(fmt.Sprintf("Scaling Algorithm '%s' is not compatible with compute provider '%s'", entry.Scaling.ScalingAlgorithm, entry.Compute.ProviderType), "InvalidArgument")
 			}
 		}
 	}

--- a/wci/workflow/iface/workflow.go
+++ b/wci/workflow/iface/workflow.go
@@ -16,7 +16,8 @@ import (
 
 const (
 	// Workflow types
-	WorkerControllerInstanceWorkflowType = "temporal-sys-worker-controller-instance-workflow"
+	WorkerControllerInstanceWorkflowType         = "temporal-sys-worker-controller-instance-workflow"
+	WorkerControllerInstanceValidateWorkflowType = "temporal-sys-worker-controller-instance-validate-workflow"
 
 	// Namespace division
 	WorkerControllerInstanceNamespaceDivision = "TemporalWorkerControllerInstance"
@@ -56,6 +57,10 @@ type (
 		LastBacklogCount   int64   `json:"last_backlog_count"`
 		LastArrivalRate    float32 `json:"last_arrival_rate"`
 		LastProcessingRate float32 `json:"last_processing_rate"`
+	}
+
+	ValidateWorkerControllerInstanceSpecWorkflowArgs struct {
+		Spec *WorkerControllerInstanceSpec `json:"spec"`
 	}
 
 	WorkerControllerInstanceWorkflowArgs struct {

--- a/wci/workflow/validate_workflow.go
+++ b/wci/workflow/validate_workflow.go
@@ -1,0 +1,36 @@
+package workflow
+
+import (
+	"errors"
+
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+func ValidateSpecWorkflow(ctx workflow.Context, args *iface.ValidateWorkerControllerInstanceSpecWorkflowArgs, activities *Activities) error {
+	if args == nil || args.Spec == nil {
+		return temporal.NewApplicationError("spec must be provided", "InvalidArgument")
+	}
+
+	if err := args.Spec.Validate(); err != nil {
+		return temporal.NewApplicationError(err.Error(), "InvalidArgument")
+	}
+
+	err := workflow.ExecuteActivity(
+		workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: ValidateSpecActivityTimeout,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
+		}),
+		activities.ValidateSpec,
+		&ValidateSpecRequest{Spec: args.Spec},
+	).Get(ctx, nil)
+	if err != nil {
+		var appErr *temporal.ApplicationError
+		if errors.As(err, &appErr) && appErr.Type() == "InvalidArgument" {
+			return appErr
+		}
+		return err
+	}
+	return nil
+}

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -16,6 +16,14 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+const (
+	ValidateSpecActivityTimeout        = 2 * time.Second
+	PullStatsActivityTimeout           = 15 * time.Second
+	HandleTaskAddSignalActivityTimeout = 15 * time.Second
+	InvokeWorkerActivityTimeout        = 2 * time.Minute
+	UpdateWorkerSetSizeActivityTimeout = 2 * time.Minute
+)
+
 type WorkerControllerInstanceWorkflowVersion int64
 
 const (
@@ -190,7 +198,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 
 	if args.Spec != nil {
 		if err := workflow.ExecuteActivity(
-			workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 2 * time.Second, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
+			workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: ValidateSpecActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
 			d.a.ValidateSpec,
 			&ValidateSpecRequest{Spec: args.Spec},
 		).Get(ctx, nil); err != nil {
@@ -240,7 +248,7 @@ func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.
 func (d *WorkflowRunner) pullStatsAndUpdate(ctx workflow.Context) time.Duration {
 	var resp PullStatsActivityResponse
 	if err := workflow.ExecuteActivity(
-		workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 15 * time.Second, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
+		workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: PullStatsActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
 		d.a.PullStats,
 		&PullStatsActivityRequest{
 			NamespaceName:     d.NamespaceName,
@@ -271,7 +279,7 @@ func (d *WorkflowRunner) handleNoSyncMatchSignal(ctx workflow.Context, req *ifac
 
 	var resp HandleTaskAddSignalActivityResponse
 	if err := workflow.ExecuteLocalActivity(
-		workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{StartToCloseTimeout: 15 * time.Second, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
+		workflow.WithLocalActivityOptions(ctx, workflow.LocalActivityOptions{StartToCloseTimeout: HandleTaskAddSignalActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
 		d.a.HandleTaskAddSignal,
 		HandleTaskAddSignalActivityRequest{
 			Request: *req,
@@ -326,7 +334,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 			}
 
 			if err := workflow.ExecuteActivity(
-				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 2 * time.Minute, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
+				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: InvokeWorkerActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
 				d.a.InvokeWorker,
 				InvokeWorkerActivityRequest{
 					ComputeConfig: &spec.Compute,
@@ -336,7 +344,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 			}
 		case scalingalgorithm.ActionTypeUpdateWorkerSetSize:
 			if err := workflow.ExecuteActivity(
-				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: 2 * time.Minute, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
+				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: UpdateWorkerSetSizeActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
 				d.a.UpdateWorkerSetSize,
 				UpdateWorkerSetSizeActivityRequest{
 					ComputeConfig: &spec.Compute,


### PR DESCRIPTION
## What was changed
Adding a new API to validate an instance spec without applying it anywhere. This allows customers to get dry-run feedback on their configuration.

## Why?
Users might want to check their config before committing it - this gives them feedback.
