### PR TITLE
chore: rename worker-controller to worker-controller-workers

### DIFF
--- a/config/development-sqlite-file.yaml
+++ b/config/development-sqlite-file.yaml
@@ -94,7 +94,7 @@ services:
       membershipPort: 6939
       bindOnLocalHost: true
 
-  worker-controller:
+  worker-controller-workers:
     rpc:
       grpcPort: 7240
       membershipPort: 6940

--- a/config/development-sqlite.yaml
+++ b/config/development-sqlite.yaml
@@ -90,7 +90,7 @@ services:
       membershipPort: 6939
       bindOnLocalHost: true
 
-  worker-controller:
+  worker-controller-workers:
     rpc:
       grpcPort: 7240
       membershipPort: 6940

--- a/wci/log/tag.go
+++ b/wci/log/tag.go
@@ -2,7 +2,7 @@ package log
 
 import "go.temporal.io/server/common/log/tag"
 
-var ComponentWorkerController = componentTag("worker-controller")
+var ComponentWorkerControllerWorkers = componentTag("worker-controller-workers")
 
 // Component returns tag for Component
 func componentTag(component string) tag.ZapTag {

--- a/wci/service.go
+++ b/wci/service.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ServiceName primitives.ServiceName = "worker-controller"
+	ServiceName primitives.ServiceName = "worker-controller-workers"
 
 	// ServiceType is the number identification for the service in the DB
 	// this needs to be distinct from the values already defined in the
@@ -81,8 +81,8 @@ func NewService(
 
 func (s *Service) Start() {
 	s.logger.Info(
-		"worker-controller starting",
-		wciLog.ComponentWorkerController,
+		"worker-controller-workers starting",
+		wciLog.ComponentWorkerControllerWorkers,
 	)
 
 	metrics.RestartCount.With(s.metricsHandler).Record(1)
@@ -100,8 +100,8 @@ func (s *Service) Start() {
 	)
 
 	s.logger.Info(
-		"worker-controller service started",
-		wciLog.ComponentWorkerController,
+		"worker-controller-workers service started",
+		wciLog.ComponentWorkerControllerWorkers,
 		tag.Address(s.hostInfo.GetAddress()),
 	)
 }
@@ -113,8 +113,8 @@ func (s *Service) Stop() {
 	s.clusterMetadata.Stop()
 
 	s.logger.Info(
-		"worker-controller service stopped",
-		wciLog.ComponentWorkerController,
+		"worker-controller-workers service stopped",
+		wciLog.ComponentWorkerControllerWorkers,
 		tag.Address(s.hostInfo.GetAddress()),
 	)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Rename WCI deployment and service from `worker-controller` to `worker-controller-workers`

## Why?
<!-- Tell your future self why have you made these changes -->
Avoid naming confusion with the already existing K8s Operator, which is named as `Temporal Worker Controller (TWC)`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->: N/A

2. How was this tested: Deployed and verified in a test cell: `s-compute-dev-01`
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?: N/A
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
