### PR TITLE
Check whether the external ID is actually used during config validation

### DIFF
--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -2,6 +2,7 @@ package computeprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -11,20 +12,31 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
 	"github.com/temporalio/temporal-managed-workers/wci/client"
 )
 
-// buildAWSConfig loads the default AWS config for the given region, applies any
-// intermediary role chain, then optionally assumes a final role.
-func buildAWSConfig(ctx context.Context, region, roleARN string, externalID *string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
+type stsAPI interface {
+	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+// buildBaseAWSConfig loads default AWS config and applies any intermediary roles.
+func buildBaseAWSConfig(ctx context.Context, region string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
 	}
+
+	// the AWS compute providers support role chaining to enable abstracting the role the temporal server has
+	// from the role that can assume the final execution/invocation role. This might be used in more complex
+	// setups to allow for rotating the AWS accounts used for both ends. Basically emulating service principals.
 	for _, step := range intermediaryRoles {
 		if len(step) == 0 {
 			continue
 		}
+
+		// At each stage of the role chaining, one of multiple roles might be chosen to proceed. This allows for load balancing
+		// requests across roles/accounts and reduces the impact of any of these accounts failing (until it is removed from the config).
 		req := step[rand.Intn(len(step))]
 		if err := validateRoleARN(req.RoleARN); err != nil {
 			return aws.Config{}, err
@@ -38,6 +50,16 @@ func buildAWSConfig(ctx context.Context, region, roleARN string, externalID *str
 			return aws.Config{}, err
 		}
 	}
+	return awsConfig, nil
+}
+
+// buildAWSConfig loads the default AWS config for the given region, applies any
+// intermediary role chain, then optionally assumes a final role.
+func buildAWSConfig(ctx context.Context, region, roleARN string, externalID *string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
+	awsConfig, err := buildBaseAWSConfig(ctx, region, intermediaryRoles)
+	if err != nil {
+		return aws.Config{}, err
+	}
 	if roleARN != "" {
 		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &client.AWSIAMRoleRequest{
 			RoleARN:         roleARN,
@@ -49,6 +71,38 @@ func buildAWSConfig(ctx context.Context, region, roleARN string, externalID *str
 		}
 	}
 	return awsConfig, nil
+}
+
+// checkExternalIDEnforced is the testable core: assumes roleARN with no external ID.
+// If the call succeeds the trust policy does not enforce the external ID → error.
+// An AccessDenied response confirms enforcement. Any other error (network, throttle, etc.)
+// is surfaced so the caller knows the check could not be completed.
+func checkExternalIDEnforced(ctx context.Context, stsClient stsAPI, roleARN string) error {
+	_, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleARN),
+		RoleSessionName: aws.String("managed-workers-aws"),
+	})
+	if err == nil {
+		return fmt.Errorf("role %s does not require the configured external ID; update the role's trust policy to enforce the aws:ExternalId condition", roleARN)
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDenied" {
+		return nil
+	}
+	return fmt.Errorf("unable to verify external ID enforcement for role %s: %w", roleARN, err)
+}
+
+// verifyExternalIDEnforcedFn is a package-level variable so tests can swap it out without
+// network calls.
+var verifyExternalIDEnforcedFn = verifyExternalIDEnforced
+
+// verifyExternalIDEnforced builds the base config then delegates to checkExternalIDEnforced.
+func verifyExternalIDEnforced(ctx context.Context, region, roleARN string, intermediaryRoles [][]client.AWSIAMRoleRequest) error {
+	baseConfig, err := buildBaseAWSConfig(ctx, region, intermediaryRoles)
+	if err != nil {
+		return err
+	}
+	return checkExternalIDEnforced(ctx, sts.NewFromConfig(baseConfig), roleARN)
 }
 
 func assumeRoleWithRequest(ctx context.Context, cfg aws.Config, req *client.AWSIAMRoleRequest) (aws.Config, error) {

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -67,6 +67,11 @@ func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, cfg iface.Co
 	if svc.Status == nil || *svc.Status != "ACTIVE" {
 		return fmt.Errorf("ECS service %q is not ACTIVE", service)
 	}
+
+	if err := p.checkExternalID(ctx, cfg, cluster); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -89,6 +94,28 @@ func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, cfg ifa
 		return fmt.Errorf("ECS UpdateService failed: %w", err)
 	}
 	return nil
+}
+
+func (p *awsECSComputeProvider) checkExternalID(ctx context.Context, cfg iface.ComputeProviderConfig, cluster string) error {
+	roleARN, _ := cfg[configAWSECSRole].(string)
+	eid, _ := cfg[configAWSECSRoleExternalID].(string)
+	if roleARN == "" || eid == "" {
+		return nil
+	}
+	var region string
+	if strings.HasPrefix(cluster, "arn:") {
+		var err error
+		region, err = extractRegionFromARN(cluster)
+		if err != nil {
+			return fmt.Errorf("cannot verify external ID enforcement: failed to extract region from cluster ARN %q: %w", cluster, err)
+		}
+	} else {
+		region, _ = cfg[configAWSECSRegion].(string)
+	}
+	if region == "" {
+		return fmt.Errorf("cannot verify external ID enforcement for role %q: region is required but could not be determined; provide a region in the config or use a cluster ARN that contains a region", roleARN)
+	}
+	return verifyExternalIDEnforcedFn(ctx, region, roleARN, p.intermediaryRoles)
 }
 
 // getECSClientAndParams builds AWS config (including intermediary and config role assumption),

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -1,0 +1,157 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+)
+
+const (
+	testClusterARN = "arn:aws:ecs:us-west-2:123456789012:cluster/my-cluster"
+)
+
+func newECSProvider() *awsECSComputeProvider {
+	return &awsECSComputeProvider{intermediaryRoles: [][]client.AWSIAMRoleRequest{}}
+}
+
+func TestAWSECSCheckExternalID_ClusterARN_CallsFn(t *testing.T) {
+	called := false
+	var gotRegion, gotRoleARN string
+
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, region, roleARN string, _ [][]client.AWSIAMRoleRequest) error {
+		called = true
+		gotRegion = region
+		gotRoleARN = roleARN
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRole:           testRoleARN,
+		configAWSECSRoleExternalID: "my-eid",
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected verifyExternalIDEnforcedFn to be called")
+	}
+	if gotRegion != "us-west-2" {
+		t.Errorf("expected region us-west-2, got %q", gotRegion)
+	}
+	if gotRoleARN != testRoleARN {
+		t.Errorf("expected role ARN %q, got %q", testRoleARN, gotRoleARN)
+	}
+}
+
+func TestAWSECSCheckExternalID_PlainClusterWithRegionConfig_CallsFn(t *testing.T) {
+	called := false
+	var gotRegion string
+
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, region, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		called = true
+		gotRegion = region
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRole:           testRoleARN,
+		configAWSECSRoleExternalID: "my-eid",
+		configAWSECSRegion:         "eu-central-1",
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, "my-cluster"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected verifyExternalIDEnforcedFn to be called")
+	}
+	if gotRegion != "eu-central-1" {
+		t.Errorf("expected region eu-central-1, got %q", gotRegion)
+	}
+}
+
+func TestAWSECSCheckExternalID_PlainClusterNoRegion_ReturnsError(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		t.Fatal("verifyExternalIDEnforcedFn should not be called when region is unknown")
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRole:           testRoleARN,
+		configAWSECSRoleExternalID: "my-eid",
+		// no region, plain cluster name
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, "my-cluster"); err == nil {
+		t.Fatal("expected error when region cannot be determined, got nil")
+	}
+}
+
+func TestAWSECSCheckExternalID_NoExternalID_SkipsFn(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		t.Fatal("verifyExternalIDEnforcedFn should not be called")
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRole: testRoleARN,
+		// no role_external_id
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAWSECSCheckExternalID_NoRole_SkipsFn(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		t.Fatal("verifyExternalIDEnforcedFn should not be called")
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRoleExternalID: "my-eid",
+		// no role
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAWSECSCheckExternalID_FnError_Propagated(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		return errors.New("external ID not enforced")
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newECSProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSRole:           testRoleARN,
+		configAWSECSRoleExternalID: "my-eid",
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err == nil {
+		t.Fatal("expected error to be propagated, got nil")
+	}
+}

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -53,6 +53,11 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, cfg iface
 	}); err != nil {
 		return fmt.Errorf("lambda GetFunction failed: %w", err)
 	}
+
+	if err := p.checkExternalID(ctx, cfg, arn); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -79,6 +84,19 @@ func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, cfg iface.C
 
 func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ iface.ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
+}
+
+func (p *awsLambdaComputeProvider) checkExternalID(ctx context.Context, cfg iface.ComputeProviderConfig, arn string) error {
+	roleARN, _ := cfg[configAWSLambdaRole].(string)
+	eid, _ := cfg[configAWSLambdaRoleExternalID].(string)
+	if roleARN == "" || eid == "" {
+		return nil
+	}
+	region, err := extractRegionFromARN(arn)
+	if err != nil {
+		return fmt.Errorf("cannot verify external ID enforcement: failed to extract region from Lambda ARN %q: %w", arn, err)
+	}
+	return verifyExternalIDEnforcedFn(ctx, region, roleARN, p.intermediaryRoles)
 }
 
 // getLambdaClientAndARN builds AWS config (including intermediary and config role assumption), returns a Lambda client and the function ARN.

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -1,0 +1,108 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/temporalio/temporal-managed-workers/wci/client"
+	"github.com/temporalio/temporal-managed-workers/wci/workflow/iface"
+)
+
+const (
+	testLambdaARN = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	testRoleARN   = "arn:aws:iam::123456789012:role/MyRole"
+)
+
+func newLambdaProvider() *awsLambdaComputeProvider {
+	return &awsLambdaComputeProvider{intermediaryRoles: [][]client.AWSIAMRoleRequest{}}
+}
+
+func TestAWSLambdaCheckExternalID_BothSet_CallsFn(t *testing.T) {
+	called := false
+	var gotRegion, gotRoleARN string
+
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, region, roleARN string, _ [][]client.AWSIAMRoleRequest) error {
+		called = true
+		gotRegion = region
+		gotRoleARN = roleARN
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newLambdaProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaRole:           testRoleARN,
+		configAWSLambdaRoleExternalID: "my-eid",
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testLambdaARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected verifyExternalIDEnforcedFn to be called")
+	}
+	if gotRegion != "us-east-1" {
+		t.Errorf("expected region us-east-1, got %q", gotRegion)
+	}
+	if gotRoleARN != testRoleARN {
+		t.Errorf("expected role ARN %q, got %q", testRoleARN, gotRoleARN)
+	}
+}
+
+func TestAWSLambdaCheckExternalID_NoExternalID_SkipsFn(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		t.Fatal("verifyExternalIDEnforcedFn should not be called")
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newLambdaProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaRole: testRoleARN,
+		// no role_external_id
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testLambdaARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAWSLambdaCheckExternalID_NoRole_SkipsFn(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		t.Fatal("verifyExternalIDEnforcedFn should not be called")
+		return nil
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newLambdaProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaRoleExternalID: "my-eid",
+		// no role
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testLambdaARN); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAWSLambdaCheckExternalID_FnError_Propagated(t *testing.T) {
+	orig := verifyExternalIDEnforcedFn
+	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		return errors.New("external ID not enforced")
+	}
+	t.Cleanup(func() { verifyExternalIDEnforcedFn = orig })
+
+	p := newLambdaProvider()
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaRole:           testRoleARN,
+		configAWSLambdaRoleExternalID: "my-eid",
+	}
+
+	if err := p.checkExternalID(context.Background(), cfg, testLambdaARN); err == nil {
+		t.Fatal("expected error to be propagated, got nil")
+	}
+}

--- a/wci/workflow/compute_provider/aws_test.go
+++ b/wci/workflow/compute_provider/aws_test.go
@@ -1,0 +1,84 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithy "github.com/aws/smithy-go"
+)
+
+type mockSTS struct {
+	assumeRoleFunc func(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+func (m *mockSTS) AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	return m.assumeRoleFunc(ctx, params, optFns...)
+}
+
+// mockAPIError is a minimal smithy.APIError for testing.
+type mockAPIError struct{ code string }
+
+func (e *mockAPIError) ErrorCode() string    { return e.code }
+func (e *mockAPIError) ErrorMessage() string { return e.code }
+func (e *mockAPIError) ErrorFault() smithy.ErrorFault {
+	return smithy.FaultClient
+}
+func (e *mockAPIError) Error() string { return e.code }
+
+func TestCheckExternalIDEnforced_Enforced(t *testing.T) {
+	mock := &mockSTS{
+		assumeRoleFunc: func(_ context.Context, _ *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			return nil, &mockAPIError{code: "AccessDenied"}
+		},
+	}
+	err := checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+	if err != nil {
+		t.Fatalf("expected nil (external ID enforced), got: %v", err)
+	}
+}
+
+func TestCheckExternalIDEnforced_NotEnforced(t *testing.T) {
+	mock := &mockSTS{
+		assumeRoleFunc: func(_ context.Context, _ *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			return &sts.AssumeRoleOutput{}, nil
+		},
+	}
+	roleARN := "arn:aws:iam::123456789012:role/MyRole"
+	err := checkExternalIDEnforced(context.Background(), mock, roleARN)
+	if err == nil {
+		t.Fatal("expected error (external ID not enforced), got nil")
+	}
+	if !strings.Contains(err.Error(), roleARN) {
+		t.Errorf("error should mention the role ARN; got: %v", err)
+	}
+}
+
+func TestCheckExternalIDEnforced_InfraError_Surfaced(t *testing.T) {
+	mock := &mockSTS{
+		assumeRoleFunc: func(_ context.Context, _ *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			return nil, errors.New("connection timeout")
+		},
+	}
+	err := checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+	if err == nil {
+		t.Fatal("expected error for infrastructure failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "unable to verify") {
+		t.Errorf("error should indicate verification failed; got: %v", err)
+	}
+}
+
+func TestCheckExternalIDEnforced_ProbeHasNoExternalID(t *testing.T) {
+	mock := &mockSTS{
+		assumeRoleFunc: func(_ context.Context, params *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+			if params.ExternalId != nil {
+				t.Errorf("probe must not include ExternalId, got %q", *params.ExternalId)
+			}
+			return nil, &mockAPIError{code: "AccessDenied"}
+		},
+	}
+	_ = checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+}


### PR DESCRIPTION
## What was changed
There is a risk of a customer specifying an external ID with us, but not actually using it correctly in their policy. This adds a check as part of the config validation.

## Why?
Adds validation that the external ID is correctly setup if provided to avoid a false sense of security
