### PR TITLE
Enforce role and external ID in AWS compute providers

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -50,4 +50,9 @@ var (
 		[]string(nil),
 		`WorkerControllerEnabledScalingAlgorithm defines the list of scaling algorithms enabled for use.`,
 	)
+	WorkerControllerAWSRequireRoleAndExternalID = dynamicconfig.NewGlobalBoolSetting(
+		"workercontroller.compute_providers.aws.require_role_and_external_id",
+		true,
+		`WorkerControllerAWSRequireRoleAndExternalID controls whether AWS compute providers require a role ARN and external ID. Defaults to true. Set to false to allow configurations without these fields and accepting the associated security risks.`,
+	)
 )

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -22,7 +22,8 @@ const (
 )
 
 type awsECSComputeProvider struct {
-	intermediaryRoles [][]client.AWSIAMRoleRequest
+	intermediaryRoles        [][]client.AWSIAMRoleRequest
+	requireRoleAndExternalID bool
 }
 
 func init() {
@@ -31,12 +32,15 @@ func init() {
 
 func NewAWSECSComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
 	var intermediaryRoles [][]client.AWSIAMRoleRequest
+	requireRoleAndExternalID := true
 	if dc != nil {
 		intermediaryRoles = client.WorkerControllerAWSIntermediaryRoles.Get(dc)()
+		requireRoleAndExternalID = client.WorkerControllerAWSRequireRoleAndExternalID.Get(dc)()
 	}
 
 	return &awsECSComputeProvider{
-		intermediaryRoles: intermediaryRoles,
+		intermediaryRoles:        intermediaryRoles,
+		requireRoleAndExternalID: requireRoleAndExternalID,
 	}, nil
 }
 
@@ -45,6 +49,15 @@ func (p *awsECSComputeProvider) LaunchStrategy() LaunchStrategy {
 }
 
 func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	if p.requireRoleAndExternalID {
+		if roleARN, _ := cfg[configAWSECSRole].(string); roleARN == "" {
+			return fmt.Errorf("ECS compute provider requires %q to be configured", configAWSECSRole)
+		}
+		if eid, _ := cfg[configAWSECSRoleExternalID].(string); eid == "" {
+			return fmt.Errorf("ECS compute provider requires %q to be configured", configAWSECSRoleExternalID)
+		}
+	}
+
 	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -138,6 +138,51 @@ func TestAWSECSCheckExternalID_NoRole_SkipsFn(t *testing.T) {
 	}
 }
 
+func TestAWSECSValidateConfig_MissingRole_ReturnsError(t *testing.T) {
+	p := &awsECSComputeProvider{requireRoleAndExternalID: true}
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSCluster: testClusterARN,
+		configAWSECSService: "my-service",
+		// no role
+	}
+
+	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+		t.Fatal("expected error when role is missing, got nil")
+	}
+}
+
+func TestAWSECSValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
+	p := &awsECSComputeProvider{requireRoleAndExternalID: true}
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSCluster: testClusterARN,
+		configAWSECSService: "my-service",
+		configAWSECSRole:    testRoleARN,
+		// no role_external_id
+	}
+
+	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+		t.Fatal("expected error when external ID is missing, got nil")
+	}
+}
+
+func TestAWSECSValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *testing.T) {
+	// With requireRoleAndExternalID=false the mandatory check is skipped.
+	// The call will still fail when it tries to reach AWS, which is expected.
+	p := &awsECSComputeProvider{requireRoleAndExternalID: false}
+	cfg := iface.ComputeProviderConfig{
+		configAWSECSCluster: testClusterARN,
+		configAWSECSService: "my-service",
+		// no role or external ID
+	}
+
+	err := p.ValidateConfig(context.Background(), cfg)
+	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
+	if err != nil && (err.Error() == `ECS compute provider requires "role" to be configured` ||
+		err.Error() == `ECS compute provider requires "role_external_id" to be configured`) {
+		t.Fatalf("mandatory check should be skipped when requireRoleAndExternalID=false, got: %v", err)
+	}
+}
+
 func TestAWSECSCheckExternalID_FnError_Propagated(t *testing.T) {
 	orig := verifyExternalIDEnforcedFn
 	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -20,7 +20,8 @@ const (
 )
 
 type awsLambdaComputeProvider struct {
-	intermediaryRoles [][]client.AWSIAMRoleRequest
+	intermediaryRoles          [][]client.AWSIAMRoleRequest
+	requireRoleAndExternalID   bool
 }
 
 func init() {
@@ -29,12 +30,15 @@ func init() {
 
 func NewAWSLambdaComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
 	var intermediaryRoles [][]client.AWSIAMRoleRequest
+	requireRoleAndExternalID := true
 	if dc != nil {
 		intermediaryRoles = client.WorkerControllerAWSIntermediaryRoles.Get(dc)()
+		requireRoleAndExternalID = client.WorkerControllerAWSRequireRoleAndExternalID.Get(dc)()
 	}
 
 	return &awsLambdaComputeProvider{
-		intermediaryRoles: intermediaryRoles,
+		intermediaryRoles:        intermediaryRoles,
+		requireRoleAndExternalID: requireRoleAndExternalID,
 	}, nil
 }
 
@@ -43,6 +47,15 @@ func (p *awsLambdaComputeProvider) LaunchStrategy() LaunchStrategy {
 }
 
 func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, cfg iface.ComputeProviderConfig) error {
+	if p.requireRoleAndExternalID {
+		if roleARN, _ := cfg[configAWSLambdaRole].(string); roleARN == "" {
+			return fmt.Errorf("AWS Lambda compute provider requires %q to be configured", configAWSLambdaRole)
+		}
+		if eid, _ := cfg[configAWSLambdaRoleExternalID].(string); eid == "" {
+			return fmt.Errorf("AWS Lambda compute provider requires %q to be configured", configAWSLambdaRoleExternalID)
+		}
+	}
+
 	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -89,6 +89,48 @@ func TestAWSLambdaCheckExternalID_NoRole_SkipsFn(t *testing.T) {
 	}
 }
 
+func TestAWSLambdaValidateConfig_MissingRole_ReturnsError(t *testing.T) {
+	p := &awsLambdaComputeProvider{requireRoleAndExternalID: true}
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaARN: testLambdaARN,
+		// no role
+	}
+
+	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+		t.Fatal("expected error when role is missing, got nil")
+	}
+}
+
+func TestAWSLambdaValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
+	p := &awsLambdaComputeProvider{requireRoleAndExternalID: true}
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaARN:  testLambdaARN,
+		configAWSLambdaRole: testRoleARN,
+		// no role_external_id
+	}
+
+	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+		t.Fatal("expected error when external ID is missing, got nil")
+	}
+}
+
+func TestAWSLambdaValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *testing.T) {
+	// With requireRoleAndExternalID=false the mandatory check is skipped.
+	// The call will still fail when it tries to reach AWS, which is expected.
+	p := &awsLambdaComputeProvider{requireRoleAndExternalID: false}
+	cfg := iface.ComputeProviderConfig{
+		configAWSLambdaARN: testLambdaARN,
+		// no role or external ID
+	}
+
+	err := p.ValidateConfig(context.Background(), cfg)
+	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
+	if err != nil && (err.Error() == `AWS Lambda compute provider requires "role" to be configured` ||
+		err.Error() == `AWS Lambda compute provider requires "role_external_id" to be configured`) {
+		t.Fatalf("mandatory check should be skipped when requireRoleAndExternalID=false, got: %v", err)
+	}
+}
+
 func TestAWSLambdaCheckExternalID_FnError_Propagated(t *testing.T) {
 	orig := verifyExternalIDEnforcedFn
 	verifyExternalIDEnforcedFn = func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {


### PR DESCRIPTION
## What was changed
Add enforcement of the external ID and associated confused deputy protection. Also offers opt-out for special cases.

## Why?
Confused Deputy protection is an important security safeguard, that also self-hosted customers should consider. Enforcing it
by default provides a good incentive to make it work - and opt-out is still available for other cases.
