### PR TITLE
Consider ContinueAsNewSuggested for CaN

### DIFF
--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -147,7 +147,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return d.deleteInstance || // instance is deleted -> it's ok to drop all signals and updates.
 			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
 			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
-				(d.forceCAN || d.stateChanged))
+				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What was changed
So far the workflow only Continued-as-New when explicitly told to, e.g. after an update. This adds considering the servers suggestion on the matter as well.

## Why?
This suggestion is already used in other parts of the system and is indicated per our documentation. The consideration in other parts actually meant that the WF was broken
when reaching the suggestion state, but not CaN-ing so this is a bug fix.

## Checklist

1. Closes https://temporalio.atlassian.net/browse/COM-49
