### PR TITLE
Replace fixed hook batching with dynamicconfig

### DIFF
--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -33,11 +33,6 @@ import (
 
 const (
 	WorkerControllerPerNSWorkerTaskQueue = "temporal-sys-worker-controller-per-ns-tq"
-
-	// minSignalIntervalNoSyncMatch is the minimum time between SignalWorkflowExecution calls per (namespace, workflow ID) for no-sync matches.
-	minSignalIntervalNoSyncMatch = 500 * time.Millisecond
-	// minSignalIntervalSyncMatch is the minimum time between SignalWorkflowExecution calls per (namespace, workflow ID) for sync matches.
-	minSignalIntervalSyncMatch = 1 * time.Minute
 )
 
 type (

--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -55,4 +55,14 @@ var (
 		true,
 		`WorkerControllerAWSRequireRoleAndExternalID controls whether AWS compute providers require a role ARN and external ID. Defaults to true. Set to false to allow configurations without these fields and accepting the associated security risks.`,
 	)
+	WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.hook.min_signal_interval_no_sync_match",
+		500,
+		`WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds controls the batching interval of no-sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal. `,
+	)
+	WorkerControllerMinSignalIntervalSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.hook.min_signal_interval_sync_match",
+		60_000, // 1 minute
+		`WorkerControllerMinSignalIntervalSyncMatchMilliseconds controls the batching interval of sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal.`,
+	)
 )

--- a/wci/client/hook.go
+++ b/wci/client/hook.go
@@ -139,9 +139,17 @@ func (th *taskHookImpl) batchMatchSignals(_ context.Context, workflowID string, 
 		last.noSyncMatchCount++
 	}
 
-	sendBy := last.timestamp.Add(minSignalIntervalSyncMatch)
+	minSignalIntervalSyncMatch := WorkerControllerMinSignalIntervalSyncMatchMilliseconds.Get(th.dc)(th.namespace.Name().String())
+	if minSignalIntervalSyncMatch <= 0 {
+		minSignalIntervalSyncMatch = 60_000
+	}
+	sendBy := last.timestamp.Add(time.Duration(minSignalIntervalSyncMatch) * time.Millisecond)
 	if last.noSyncMatchCount > 0 {
-		sendBy = last.timestamp.Add(minSignalIntervalNoSyncMatch)
+		minSignalIntervalNoSyncMatch := WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds.Get(th.dc)(th.namespace.Name().String())
+		if minSignalIntervalNoSyncMatch <= 0 {
+			minSignalIntervalNoSyncMatch = 500
+		}
+		sendBy = last.timestamp.Add(time.Duration(minSignalIntervalNoSyncMatch) * time.Millisecond)
 	}
 
 	if sendBy.Before(now) {


### PR DESCRIPTION
## What was changed
Updating for the hook batching to be driven by dynamicconfig instead of const values.

## Why?
This allows us to adjust the timings post rollout.
