### PR TITLE
Increase ValidateSpec activity timeout to 15s

### DIFF
--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	validateSpecTimeout           = 2 * time.Second
+	validateSpecTimeout           = 15 * time.Second
 	startNewWorkerInstanceTimeout = 60 * time.Second
 	updateWorkerSetSizeTimeout    = 60 * time.Second
 

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	ValidateSpecActivityTimeout                 = 2 * time.Second
+	ValidateSpecActivityTimeout                 = 15 * time.Second
 	PullStatsActivityTimeout                    = 15 * time.Second
 	HandleTaskAddSignalActivityTimeout          = 15 * time.Second
 	InvokeWorkerActivityTimeout                 = 2 * time.Minute


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Increase the timeout of `ValidateSpec` activity from `2 seconds` to `15 seconds`

## Why?
<!-- Tell your future self why have you made these changes -->
The 2s timeout was set before External ID enforcement and intermediary role chaining were added, which require multiple sequential AWS API calls that exceed the original limit.
