### PR TITLE
Rename to use go.temporal.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A group with no `task_types` acts as a catch-all for any task type not claimed b
 ## Client API
 
 ```go
-import "github.com/temporalio/temporal-auto-scaled-workers/wci/client"
+import "go.temporal.io/auto-scaled-workers/wci/client"
 
 // Register the Fx module in your server
 fx.Provide(client.ClientProvider)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	_ "time/tzdata" // embed tzdata as a fallback
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci"
+	"go.temporal.io/auto-scaled-workers/wci"
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/temporalio/temporal-auto-scaled-workers
+module go.temporal.io/auto-scaled-workers
 
 go 1.26.0
 

--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"

--- a/wci/client/errors.go
+++ b/wci/client/errors.go
@@ -3,7 +3,7 @@ package client
 import (
 	"errors"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"

--- a/wci/client/hook.go
+++ b/wci/client/hook.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/api/enums/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/dynamicconfig"

--- a/wci/client/workflow_interaction.go
+++ b/wci/client/workflow_interaction.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"

--- a/wci/component.go
+++ b/wci/component.go
@@ -1,9 +1,9 @@
 package wci
 
 import (
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	instancewf "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	instancewf "go.temporal.io/auto-scaled-workers/wci/workflow"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"

--- a/wci/config.go
+++ b/wci/config.go
@@ -1,7 +1,7 @@
 package wci
 
 import (
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/service/worker"

--- a/wci/fx.go
+++ b/wci/fx.go
@@ -2,7 +2,7 @@
 package wci
 
 import (
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"

--- a/wci/service.go
+++ b/wci/service.go
@@ -3,7 +3,7 @@ package wci
 import (
 	"context"
 
-	wciLog "github.com/temporalio/temporal-auto-scaled-workers/wci/log"
+	wciLog "go.temporal.io/auto-scaled-workers/wci/log"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	computeprovider "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/compute_provider"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
-	scalingalgorithm "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/scaling_algorithm"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	scalingalgorithm "go.temporal.io/auto-scaled-workers/wci/workflow/scaling_algorithm"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithy "github.com/aws/smithy-go"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/client"
 )
 
 type stsAPI interface {

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
 
 const (

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
 
 const (

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -8,8 +8,8 @@ import (
 
 	run "cloud.google.com/go/run/apiv2"
 	runpb "cloud.google.com/go/run/apiv2/runpb"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"

--- a/wci/workflow/compute_provider/k8s.go
+++ b/wci/workflow/compute_provider/k8s.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -6,8 +6,8 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 

--- a/wci/workflow/compute_provider/subprocess.go
+++ b/wci/workflow/compute_provider/subprocess.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"time"
 
-	computeprovider "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/compute_provider"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/sdk/activity"
 )
 

--- a/wci/workflow/scaling_algorithm/no_sync_match_test.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	computeprovider "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/compute_provider"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
 	enumspb "go.temporal.io/api/enums/v1"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
 
 func newNoSync() *scalingAlgorithmNoSync {

--- a/wci/workflow/scaling_algorithm/registry.go
+++ b/wci/workflow/scaling_algorithm/registry.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/client"
-	computeprovider "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/compute_provider"
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 )
 

--- a/wci/workflow/validate_workflow.go
+++ b/wci/workflow/validate_workflow.go
@@ -3,7 +3,7 @@ package workflow
 import (
 	"errors"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 )

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/iface"
-	scalingalgorithm "github.com/temporalio/temporal-auto-scaled-workers/wci/workflow/scaling_algorithm"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	scalingalgorithm "go.temporal.io/auto-scaled-workers/wci/workflow/scaling_algorithm"
 	"go.temporal.io/api/serviceerror"
 	sdkclient "go.temporal.io/sdk/client"
 	sdklog "go.temporal.io/sdk/log"


### PR DESCRIPTION
## What was changed
Renaming to use the nicer go.temporal.io as module basis

