### PR TITLE
Move worker component into sub-package to break cycle

### DIFF
--- a/wci/fx.go
+++ b/wci/fx.go
@@ -3,6 +3,7 @@ package wci
 
 import (
 	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workercomponent"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
@@ -139,7 +140,7 @@ func PerNamespaceWorkerManagerProvider(
 	dynamicConfig *dynamicconfig.Collection,
 ) *worker.PerNamespaceWorkerManager {
 	components := []workercommon.PerNSWorkerComponent{
-		&workerComponent{dynamicConfig: dynamicConfig, sdkClientFactory: sdkClientFactory},
+		workercomponent.NewWCIPerNSWorkerComponent(dynamicConfig, sdkClientFactory),
 	}
 
 	return worker.NewPerNamespaceWorkerManager(

--- a/wci/workercomponent/component.go
+++ b/wci/workercomponent/component.go
@@ -1,4 +1,4 @@
-package wci
+package workercomponent
 
 import (
 	"go.temporal.io/auto-scaled-workers/wci/client"
@@ -19,6 +19,10 @@ type (
 		sdkClientFactory sdk.ClientFactory
 	}
 )
+
+func NewWCIPerNSWorkerComponent(dc *dynamicconfig.Collection, sdkClientFactory sdk.ClientFactory) workercommon.PerNSWorkerComponent {
+	return &workerComponent{dynamicConfig: dc, sdkClientFactory: sdkClientFactory}
+}
 
 func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
 	return &workercommon.PerNSDedicatedWorkerOptions{

--- a/wci/workercomponent/fx.go
+++ b/wci/workercomponent/fx.go
@@ -1,0 +1,33 @@
+package workercomponent
+
+import (
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/sdk"
+	workercommon "go.temporal.io/server/service/worker/common"
+	"go.uber.org/fx"
+)
+
+type (
+	componentDeps struct {
+		fx.In
+		ClientFactory sdk.ClientFactory
+	}
+
+	fxResult struct {
+		fx.Out
+		Component workercommon.PerNSWorkerComponent `group:"perNamespaceWorkerComponent"`
+	}
+)
+
+var Module = fx.Options(
+	fx.Provide(NewResult),
+)
+
+func NewResult(
+	dc *dynamicconfig.Collection,
+	params componentDeps,
+) fxResult {
+	return fxResult{
+		Component: NewWCIPerNSWorkerComponent(dc, params.ClientFactory),
+	}
+}

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -1,0 +1,69 @@
+package computeprovider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	configTestInvokeIllegalField = "illegal_field"
+)
+
+type testInvokeComputeProvider struct{}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeTestInvoke, NewTestInvokeComputeProvider)
+}
+
+func NewTestInvokeComputeProvider(_ context.Context, _ *dynamicconfig.Collection) (ComputeProvider, error) {
+	return &testInvokeComputeProvider{}, nil
+}
+
+func (p *testInvokeComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *testInvokeComputeProvider) ValidateConfig(ctx context.Context, config iface.ComputeProviderConfig) error {
+	if _, ok := config[configTestInvokeIllegalField].(string); ok {
+		return fmt.Errorf("illegal_field found in config")
+	}
+
+	return nil
+}
+
+func (p *testInvokeComputeProvider) InvokeWorker(ctx context.Context, config iface.ComputeProviderConfig) error {
+	return nil
+}
+
+func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ iface.ComputeProviderConfig, _ int32) error {
+	return errors.ErrUnsupported
+}
+
+// TestInvokeComputeProviderValidProviderDetails provides an example valid config for testing code to use
+func TestInvokeComputeProviderValidProviderDetails() []byte {
+	providerDetails := map[string]string{}
+	marshalled, err := json.Marshal(providerDetails)
+	if err != nil {
+		return nil
+	}
+
+	return marshalled
+}
+
+// TestInvokeComputeProviderInvalidProviderDetails provides an example invalid config for testing code to use
+func TestInvokeComputeProviderInvalidProviderDetails() []byte {
+	providerDetails := map[string]string{
+		configTestInvokeIllegalField: "something",
+	}
+	marshalled, err := json.Marshal(providerDetails)
+	if err != nil {
+		return nil
+	}
+
+	return marshalled
+}

--- a/wci/workflow/compute_provider/test_worker_set.go
+++ b/wci/workflow/compute_provider/test_worker_set.go
@@ -1,0 +1,44 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	configTestWorkerSetIllegalField = "illegal_field"
+)
+
+type testWorkerSetComputeProvider struct{}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeTestWorkerSet, NewTestWorkerSetComputeProvider)
+}
+
+func NewTestWorkerSetComputeProvider(_ context.Context, _ *dynamicconfig.Collection) (ComputeProvider, error) {
+	return &testWorkerSetComputeProvider{}, nil
+}
+
+func (p *testWorkerSetComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *testWorkerSetComputeProvider) ValidateConfig(ctx context.Context, config iface.ComputeProviderConfig) error {
+	if _, ok := config[configTestInvokeIllegalField].(string); ok {
+		return fmt.Errorf("illegal_field found in config")
+	}
+
+	return nil
+}
+
+func (p *testWorkerSetComputeProvider) InvokeWorker(ctx context.Context, config iface.ComputeProviderConfig) error {
+	return errors.ErrUnsupported
+}
+
+func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ iface.ComputeProviderConfig, _ int32) error {
+	return nil
+}

--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -40,22 +40,26 @@ type (
 )
 
 const (
-	ComputeProviderTypeAWSLambda   ComputeProviderType = "aws-lambda"
-	ComputeProviderTypeAWSECS      ComputeProviderType = "aws-ecs"
-	ComputeProviderTypeSubprocess  ComputeProviderType = "subprocess"
-	ComputeProviderTypeK8s         ComputeProviderType = "k8s"
-	ComputeProviderTypeGCPCloudRun ComputeProviderType = "gcp-cloud-run"
+	ComputeProviderTypeAWSLambda     ComputeProviderType = "aws-lambda"
+	ComputeProviderTypeAWSECS        ComputeProviderType = "aws-ecs"
+	ComputeProviderTypeSubprocess    ComputeProviderType = "subprocess"
+	ComputeProviderTypeK8s           ComputeProviderType = "k8s"
+	ComputeProviderTypeGCPCloudRun   ComputeProviderType = "gcp-cloud-run"
+	ComputeProviderTypeTestInvoke    ComputeProviderType = "test-invoke"
+	ComputeProviderTypeTestWorkerSet ComputeProviderType = "test-worker-set"
 
 	ScalingAlgorithmNoSync    ScalingAlgorithmType = "no-sync"
 	ScalingAlgorithmRateBased ScalingAlgorithmType = "rate-based"
 )
 
 var validComputeProviderTypes = map[string]ComputeProviderType{
-	string(ComputeProviderTypeAWSLambda):   ComputeProviderTypeAWSLambda,
-	string(ComputeProviderTypeAWSECS):      ComputeProviderTypeAWSECS,
-	string(ComputeProviderTypeSubprocess):  ComputeProviderTypeSubprocess,
-	string(ComputeProviderTypeK8s):         ComputeProviderTypeK8s,
-	string(ComputeProviderTypeGCPCloudRun): ComputeProviderTypeGCPCloudRun,
+	string(ComputeProviderTypeAWSLambda):     ComputeProviderTypeAWSLambda,
+	string(ComputeProviderTypeAWSECS):        ComputeProviderTypeAWSECS,
+	string(ComputeProviderTypeSubprocess):    ComputeProviderTypeSubprocess,
+	string(ComputeProviderTypeK8s):           ComputeProviderTypeK8s,
+	string(ComputeProviderTypeGCPCloudRun):   ComputeProviderTypeGCPCloudRun,
+	string(ComputeProviderTypeTestInvoke):    ComputeProviderTypeTestInvoke,
+	string(ComputeProviderTypeTestWorkerSet): ComputeProviderTypeTestWorkerSet,
 }
 
 var validScalingAlgorithmTypes = map[string]ScalingAlgorithmType{


### PR DESCRIPTION
## What was changed
Moved the worker component into a dedicated package.

## Why?
Having the worker component and the WCI-specific worker in the same go package leads to a dependency cycle when using the worker in OSS. This break apart should fix that cycle.
