### PR TITLE
Fix issue with waiting for workflow completion

### DIFF
--- a/wci/client/workflow_interaction.go
+++ b/wci/client/workflow_interaction.go
@@ -91,9 +91,11 @@ func startWorkflowAndWait(
 			return err
 		}
 
-		events := resp.GetResponse().GetHistory().GetEvents()
+		events := resp.GetHistory().GetEvents()
 		if len(events) > 0 {
-			event := events[0]
+			// the very last event is the one we are looking for
+			event := events[len(events)-1]
+
 			if event.GetWorkflowExecutionCompletedEventAttributes() != nil {
 				return nil
 			}


### PR DESCRIPTION
## What was changed
In the temporal server tests the response from HistoryService is slightly different than when it runs normally. To be compatible with both cases, this adds a little bit more flexibility.
