### PR TITLE
Return the updated spec on update

### DIFF
--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -68,7 +68,7 @@ type (
 			identity string,
 			upsertScalingGroups map[string]iface.ScalingGroupSpecUpdate,
 			removeScalingGroups []string,
-		) error
+		) (*iface.UpdateWorkerControllerInstanceResponse, error)
 
 		ValidateWorkerControllerInstanceSpec(
 			ctx context.Context,
@@ -244,19 +244,19 @@ func (d *clientImpl) UpdateWorkerControllerInstance(
 	identity string,
 	upsertScalingGroups map[string]iface.ScalingGroupSpecUpdate,
 	removeScalingGroups []string,
-) (retErr error) {
+) (_ *iface.UpdateWorkerControllerInstanceResponse, retErr error) {
 	//revive:disable-next-line:defer
 	defer d.convertAndRecordError("UpdateWorkerControllerInstance", version, &retErr, namespaceEntry.Name(), identity)()
 
 	// validating params
 	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentNameFieldName, version.DeploymentName, d.maxIDLengthLimit()); err != nil {
-		return err
+		return nil, err
 	}
 	if err := validateWorkerControllerInstanceWFParams(worker_versioning.WorkerDeploymentBuildIDFieldName, version.BuildId, d.maxIDLengthLimit()); err != nil {
-		return err
+		return nil, err
 	}
 	if err := d.checkInstanceCount(ctx, namespaceEntry, version); err != nil {
-		return err
+		return nil, err
 	}
 
 	requestID := uuid.NewString()
@@ -289,18 +289,23 @@ func (d *clientImpl) UpdateWorkerControllerInstance(
 		requestID,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if failure := outcome.GetFailure(); failure != nil {
 		if appFailureInfo := failure.GetApplicationFailureInfo(); appFailureInfo != nil {
 			if appFailureInfo.Type == "InvalidArgument" {
-				return serviceerror.NewInvalidArgument(failure.Message)
+				return nil, serviceerror.NewInvalidArgument(failure.Message)
 			}
 		}
-		return serviceerror.NewInternal(failure.Message)
+		return nil, serviceerror.NewInternal(failure.Message)
 	}
-	return nil
+
+	var resp iface.UpdateWorkerControllerInstanceResponse
+	if err := sdk.PreferProtoDataConverter.FromPayloads(outcome.GetSuccess(), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
 }
 
 func (d *clientImpl) ValidateWorkerControllerInstanceSpec(

--- a/wci/workflow/iface/workflow.go
+++ b/wci/workflow/iface/workflow.go
@@ -102,7 +102,9 @@ type (
 		RemoveScalingGroups []string                          `json:"remove_scaling_groups"`
 	}
 
-	UpdateWorkerControllerInstanceResponse struct{}
+	UpdateWorkerControllerInstanceResponse struct {
+		Spec *WorkerControllerInstanceSpec `json:"spec,omitempty"`
+	}
 
 	DeleteWorkerControllerInstanceRequest struct {
 		Identity string `json:"identity,omitempty"`

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -255,7 +255,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			d.deleteInstance = true
 			d.State.ConflictToken = args.ConflictToken
 			d.State.Spec = updatedSpec
-			return &iface.UpdateWorkerControllerInstanceResponse{}, nil
+			return &iface.UpdateWorkerControllerInstanceResponse{Spec: d.State.Spec}, nil
 		}
 
 		if err := updatedSpec.Validate(); err != nil {
@@ -297,7 +297,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		d.State.Spec = updatedSpec
 	}
 
-	return &iface.UpdateWorkerControllerInstanceResponse{}, nil
+	return &iface.UpdateWorkerControllerInstanceResponse{Spec: d.State.Spec}, nil
 }
 
 func (d *WorkflowRunner) validateDeleteInstance(args *iface.DeleteWorkerControllerInstanceRequest) error {


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Returning the updated spec on update to avoid having to make another call to get it.

## Why?
The Worker Deployment Version keeps track of summary-level details on the spec. Having the updated spec returned simplifies that bookkeeping.
