### PR TITLE
Add automatic validation of Compute Config

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -27,7 +27,7 @@ var (
 	)
 	WorkerControllerInstanceWorkflowVersion = dynamicconfig.NewNamespaceIntSetting(
 		"workercontroller.instanceWorkflowVersion",
-		0,
+		1,
 		`WorkerControllerInstanceWorkflowVersion controls what version of the logic should the manager workflows use.`,
 	)
 	WorkerControllerAWSIntermediaryRoles = dynamicconfig.NewGlobalTypedSetting(

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -321,7 +321,7 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 		return nil, err
 	}
 	if deploymentVersionDetails == nil {
-		return nil, fmt.Errorf("Did not receive details in the describe response")
+		return nil, fmt.Errorf("did not receive details in the describe response")
 	}
 
 	metricsSnapshot := scalingalgorithm.ScalingMetricsSnapshot{

--- a/wci/workflow/iface/workflow.go
+++ b/wci/workflow/iface/workflow.go
@@ -41,6 +41,10 @@ const (
 	ErrInstanceDeleted    = "worker deployment deleted" // returned in the race condition that the deployment is deleted but the workflow is not yet closed.
 	ErrLongHistory        = "errLongHistory"            // update is not accepted until CaN happens. client should retry
 	ErrFailedPrecondition = "FailedPrecondition"
+
+	// ValidationStatus values
+	ValidationStatusSuccess ValidationStatus = "success"
+	ValidationStatusFailed  ValidationStatus = "failed"
 )
 
 var WorkerControllerInstanceVisibilityBaseListQuery = fmt.Sprintf(
@@ -81,6 +85,10 @@ type (
 		ConflictToken        []byte                 `json:"conflict_token,omitempty"`
 		CreateTime           *timestamppb.Timestamp `json:"create_time,omitempty"`
 		LastModifierIdentity string                 `json:"last_modifier_identity,omitempty"`
+
+		// ValidationState holds the result of the last validation attempt performed
+		// during an UpdateWorkerControllerInstance update.
+		ValidationState *ValidationState `json:"validation_state,omitempty"`
 	}
 
 	QueryDescribeWorkerControllerInstanceResponse struct {
@@ -92,6 +100,8 @@ type (
 
 		ConflictToken        []byte `json:"conflict_token,omitempty"`
 		LastModifierIdentity string `json:"last_modifier_identity,omitempty"`
+
+		ValidationState *ValidationState `json:"validation_state,omitempty"`
 	}
 
 	UpdateWorkerControllerInstanceRequest struct {
@@ -119,6 +129,17 @@ type (
 	}
 
 	ValidateSpecResponse struct{}
+
+	ValidationStatus string
+
+	ValidationState struct {
+		// LastValidatedTime is the time of the last validation attempt.
+		LastValidatedTime *timestamppb.Timestamp `json:"last_validated_time,omitempty"`
+		// Status is the outcome of the last validation attempt.
+		Status ValidationStatus `json:"status,omitempty"`
+		// ErrMessage is a description of any encountered validation errors.
+		ErrMessage string `json:"err_message,omitempty"`
+	}
 
 	SignalTaskAddRequest struct {
 		TaskQueueName string                `json:"task_queue_name"`

--- a/wci/workflow/iface/workflow.go
+++ b/wci/workflow/iface/workflow.go
@@ -5,6 +5,7 @@ package iface
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -42,9 +43,9 @@ const (
 	ErrLongHistory        = "errLongHistory"            // update is not accepted until CaN happens. client should retry
 	ErrFailedPrecondition = "FailedPrecondition"
 
-	// ValidationStatus values
-	ValidationStatusSuccess ValidationStatus = "success"
-	ValidationStatusFailed  ValidationStatus = "failed"
+	// ValidationResult values
+	ValidationResultSuccess ValidationResult = "success"
+	ValidationResultFailed  ValidationResult = "failed"
 )
 
 var WorkerControllerInstanceVisibilityBaseListQuery = fmt.Sprintf(
@@ -86,9 +87,8 @@ type (
 		CreateTime           *timestamppb.Timestamp `json:"create_time,omitempty"`
 		LastModifierIdentity string                 `json:"last_modifier_identity,omitempty"`
 
-		// ValidationState holds the result of the last validation attempt performed
-		// during an UpdateWorkerControllerInstance update.
-		ValidationState *ValidationState `json:"validation_state,omitempty"`
+		// ValidationStatus holds the result of the last validation.
+		ValidationStatus *ValidationStatus `json:"validation_state,omitempty"`
 	}
 
 	QueryDescribeWorkerControllerInstanceResponse struct {
@@ -101,7 +101,7 @@ type (
 		ConflictToken        []byte `json:"conflict_token,omitempty"`
 		LastModifierIdentity string `json:"last_modifier_identity,omitempty"`
 
-		ValidationState *ValidationState `json:"validation_state,omitempty"`
+		ValidationStatus *ValidationStatus `json:"validation_state,omitempty"`
 	}
 
 	UpdateWorkerControllerInstanceRequest struct {
@@ -130,14 +130,14 @@ type (
 
 	ValidateSpecResponse struct{}
 
-	ValidationStatus string
+	ValidationResult string
 
-	ValidationState struct {
-		// LastValidatedTime is the time of the last validation attempt.
-		LastValidatedTime *timestamppb.Timestamp `json:"last_validated_time,omitempty"`
+	ValidationStatus struct {
+		// LastValidationTime is the time of the last validation attempt.
+		LastValidationTime time.Time `json:"last_validation_time"`
 		// Status is the outcome of the last validation attempt.
-		Status ValidationStatus `json:"status,omitempty"`
-		// ErrMessage is a description of any encountered validation errors.
+		Status ValidationResult `json:"status"`
+		// ErrMessage is a description of any encountered validation errors. It should be empty if validation succeeded.
 		ErrMessage string `json:"err_message,omitempty"`
 	}
 
@@ -156,6 +156,21 @@ type (
 		CreateTime     *timestamppb.Timestamp `json:"create_time,omitempty"`
 	}
 )
+
+func NewValidationStatusSuccess(t time.Time) *ValidationStatus {
+	return &ValidationStatus{
+		LastValidationTime: t,
+		Status:             ValidationResultSuccess,
+	}
+}
+
+func NewValidationStatusFailed(t time.Time, msg string) *ValidationStatus {
+	return &ValidationStatus{
+		LastValidationTime: t,
+		Status:             ValidationResultFailed,
+		ErrMessage:         msg,
+	}
+}
 
 func DecodeWorkerControllerInstanceMemo(memo *commonpb.Memo) (*WorkerControllerInstanceMemo, error) {
 	if memo == nil || memo.Fields == nil {

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -134,6 +134,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 			ConflictToken:        d.State.ConflictToken,
 			CreateTime:           d.State.CreateTime,
 			LastModifierIdentity: d.State.LastModifierIdentity,
+			ValidationState:      d.State.ValidationState,
 		}, nil
 	}); err != nil {
 		return err
@@ -270,7 +271,14 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			return &iface.UpdateWorkerControllerInstanceResponse{Spec: d.State.Spec}, nil
 		}
 
+		validationTime := workflow.Now(ctx)
+
 		if err := updatedSpec.Validate(); err != nil {
+			d.State.ValidationState = &iface.ValidationState{
+				LastValidatedTime: timestamppb.New(validationTime),
+				Status:            iface.ValidationStatusFailed,
+				ErrMessage:        err.Error(),
+			}
 			return nil, serviceerror.NewInvalidArgumentf("%w", err)
 		}
 
@@ -280,11 +288,19 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			&ValidateSpecRequest{Spec: updatedSpec},
 		).Get(ctx, nil); err != nil {
 			var appErr *temporal.ApplicationError
+			errMsg := err.Error()
+			if errors.As(err, &appErr) {
+				errMsg = appErr.Message()
+			}
+			d.State.ValidationState = &iface.ValidationState{
+				LastValidatedTime: timestamppb.New(validationTime),
+				Status:            iface.ValidationStatusFailed,
+				ErrMessage:        errMsg,
+			}
 			if errors.As(err, &appErr) {
 				return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
-			} else {
-				return nil, err
 			}
+			return nil, err
 		}
 
 		// we need to scale up each of the groups for a moment to get them to register the task queues
@@ -294,15 +310,28 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			updatedSpec,
 		).Get(ctx, nil); err != nil {
 			var appErr *temporal.ApplicationError
+			errMsg := err.Error()
+			if errors.As(err, &appErr) {
+				errMsg = appErr.Message()
+			}
+			d.State.ValidationState = &iface.ValidationState{
+				LastValidatedTime: timestamppb.New(validationTime),
+				Status:            iface.ValidationStatusFailed,
+				ErrMessage:        errMsg,
+			}
 			if errors.As(err, &appErr) {
 				if appErr.Type() == "InvalidArgument" {
 					return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
 				} else {
 					return nil, serviceerror.NewFailedPreconditionf("%s", appErr.Message())
 				}
-			} else {
-				return nil, err
 			}
+			return nil, err
+		}
+
+		d.State.ValidationState = &iface.ValidationState{
+			LastValidatedTime: timestamppb.New(validationTime),
+			Status:            iface.ValidationStatusSuccess,
 		}
 
 		d.State.ConflictToken = args.ConflictToken
@@ -457,6 +486,11 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				},
 			).Get(ctx, nil); err != nil {
 				d.logger.Warn("Failed to execute new worker instance activity", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "error", err)
+				d.State.ValidationState = &iface.ValidationState{
+					LastValidatedTime: timestamppb.New(workflow.Now(ctx)),
+					Status:            iface.ValidationStatusFailed,
+					ErrMessage:        err.Error(),
+				}
 				d.metrics.WithTags(map[string]string{
 					wcimetrics.OperationTagName: wcimetrics.OperationTypeInvokeWorker,
 					// TODO: add standardized error type codes
@@ -477,6 +511,11 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				},
 			).Get(ctx, nil); err != nil {
 				d.logger.Warn("Failed to execute update worker-set size activity", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "error", err)
+				d.State.ValidationState = &iface.ValidationState{
+					LastValidatedTime: timestamppb.New(workflow.Now(ctx)),
+					Status:            iface.ValidationStatusFailed,
+					ErrMessage:        err.Error(),
+				}
 			}
 		default:
 			d.logger.Warn("Unknown scaling action", "action", action.Action)

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -24,6 +24,8 @@ const (
 	InvokeWorkerActivityTimeout                 = 2 * time.Minute
 	UpdateWorkerSetSizeActivityTimeout          = 2 * time.Minute
 	RegisterTaskQueuesViaWorkersActivityTimeout = 30 * time.Second
+
+	periodicValidationInterval = 6 * time.Hour
 )
 
 type WorkerControllerInstanceWorkflowVersion int64
@@ -34,6 +36,10 @@ const (
 
 	// Represents the very first version of the workflow
 	InitialVersion WorkerControllerInstanceWorkflowVersion = iota
+
+	// Adds periodic background re-validation of the spec. The timer fires every
+	// periodicValidationInterval (6h).
+	PeriodicValidationVersion
 )
 
 type (
@@ -134,7 +140,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 			ConflictToken:        d.State.ConflictToken,
 			CreateTime:           d.State.CreateTime,
 			LastModifierIdentity: d.State.LastModifierIdentity,
-			ValidationState:      d.State.ValidationState,
+			ValidationStatus:     d.State.ValidationStatus,
 		}, nil
 	}); err != nil {
 		return err
@@ -202,12 +208,12 @@ func (d *WorkflowRunner) handleValidateSpec(ctx workflow.Context, args *iface.Va
 		RemoveScalingGroups: args.RemoveScalingGroups,
 	})
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgumentf("%w", err)
+		return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 	}
 
 	if updatedSpec != nil {
 		if err := updatedSpec.Validate(); err != nil {
-			return nil, serviceerror.NewInvalidArgumentf("%w", err)
+			return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 		}
 
 		if err := workflow.ExecuteActivity(
@@ -215,8 +221,7 @@ func (d *WorkflowRunner) handleValidateSpec(ctx workflow.Context, args *iface.Va
 			d.a.ValidateSpec,
 			&ValidateSpecRequest{Spec: updatedSpec},
 		).Get(ctx, nil); err != nil {
-			var appErr *temporal.ApplicationError
-			if errors.As(err, &appErr) {
+			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
 			} else {
 				return nil, err
@@ -258,7 +263,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 
 	updatedSpec, err := iface.BuildUpdatedSpec(d.State.Spec, args)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgumentf("%w", err)
+		return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 	}
 
 	if updatedSpec != nil {
@@ -274,12 +279,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		validationTime := workflow.Now(ctx)
 
 		if err := updatedSpec.Validate(); err != nil {
-			d.State.ValidationState = &iface.ValidationState{
-				LastValidatedTime: timestamppb.New(validationTime),
-				Status:            iface.ValidationStatusFailed,
-				ErrMessage:        err.Error(),
-			}
-			return nil, serviceerror.NewInvalidArgumentf("%w", err)
+			return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 		}
 
 		if err := workflow.ExecuteActivity(
@@ -287,17 +287,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			d.a.ValidateSpec,
 			&ValidateSpecRequest{Spec: updatedSpec},
 		).Get(ctx, nil); err != nil {
-			var appErr *temporal.ApplicationError
-			errMsg := err.Error()
-			if errors.As(err, &appErr) {
-				errMsg = appErr.Message()
-			}
-			d.State.ValidationState = &iface.ValidationState{
-				LastValidatedTime: timestamppb.New(validationTime),
-				Status:            iface.ValidationStatusFailed,
-				ErrMessage:        errMsg,
-			}
-			if errors.As(err, &appErr) {
+			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
 			}
 			return nil, err
@@ -309,31 +299,16 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			d.a.InvokeWorkersToRegisterTaskQueues,
 			updatedSpec,
 		).Get(ctx, nil); err != nil {
-			var appErr *temporal.ApplicationError
-			errMsg := err.Error()
-			if errors.As(err, &appErr) {
-				errMsg = appErr.Message()
-			}
-			d.State.ValidationState = &iface.ValidationState{
-				LastValidatedTime: timestamppb.New(validationTime),
-				Status:            iface.ValidationStatusFailed,
-				ErrMessage:        errMsg,
-			}
-			if errors.As(err, &appErr) {
+			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				if appErr.Type() == "InvalidArgument" {
 					return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
-				} else {
-					return nil, serviceerror.NewFailedPreconditionf("%s", appErr.Message())
 				}
+				return nil, serviceerror.NewFailedPreconditionf("%s", appErr.Message())
 			}
 			return nil, err
 		}
 
-		d.State.ValidationState = &iface.ValidationState{
-			LastValidatedTime: timestamppb.New(validationTime),
-			Status:            iface.ValidationStatusSuccess,
-		}
-
+		d.State.ValidationStatus = iface.NewValidationStatusSuccess(validationTime)
 		d.State.ConflictToken = args.ConflictToken
 		d.State.Spec = updatedSpec
 	}
@@ -411,6 +386,35 @@ func (d *WorkflowRunner) pullStatsAndUpdate(ctx workflow.Context) time.Duration 
 	}
 }
 
+func (d *WorkflowRunner) periodicValidateSpec(ctx workflow.Context) {
+	if d.State == nil || d.State.Spec == nil || len(d.State.Spec.ScalingGroupSpecs) == 0 {
+		return
+	}
+	now := workflow.Now(ctx)
+
+	if err := workflow.ExecuteActivity(
+		workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			StartToCloseTimeout: ValidateSpecActivityTimeout,
+			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 3},
+		}),
+		d.a.ValidateSpec,
+		&ValidateSpecRequest{Spec: d.State.Spec},
+	).Get(ctx, nil); err != nil {
+		if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
+			d.State.ValidationStatus = iface.NewValidationStatusFailed(now, appErr.Message())
+			d.logger.Warn("Periodic spec validation failed with spec error", "error", err)
+		} else {
+			// Transient infrastructure errors (timeouts, server errors, cancellation) are not
+			// spec failures — leave ValidationStatus at its last known value.
+			d.logger.Warn("Periodic spec validation failed with transient error, leaving validation state unchanged", "error", err)
+		}
+	} else {
+		d.State.ValidationStatus = iface.NewValidationStatusSuccess(now)
+	}
+
+	// We are not setting stateChanged to true to avoid unneccessary CaNs here.
+}
+
 func (d *WorkflowRunner) handleNoSyncMatchSignal(ctx workflow.Context, req *iface.SignalTaskAddRequest) {
 	if req == nil {
 		return
@@ -478,6 +482,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 
 			d.metrics.Counter(wcimetrics.ScaleUpCount.Name()).Inc(1)
 
+			now := workflow.Now(ctx)
 			if err := workflow.ExecuteActivity(
 				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: InvokeWorkerActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
 				d.a.InvokeWorker,
@@ -486,10 +491,11 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				},
 			).Get(ctx, nil); err != nil {
 				d.logger.Warn("Failed to execute new worker instance activity", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "error", err)
-				d.State.ValidationState = &iface.ValidationState{
-					LastValidatedTime: timestamppb.New(workflow.Now(ctx)),
-					Status:            iface.ValidationStatusFailed,
-					ErrMessage:        err.Error(),
+
+				// only application errors can indicate validation errors, so filtering for them first
+				if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
+					// TODO: filter out further transient errors to avoid the validation state oscillating
+					d.State.ValidationStatus = iface.NewValidationStatusFailed(now, appErr.Message())
 				}
 				d.metrics.WithTags(map[string]string{
 					wcimetrics.OperationTagName: wcimetrics.OperationTypeInvokeWorker,
@@ -500,8 +506,11 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				d.metrics.WithTags(map[string]string{
 					wcimetrics.OperationTagName: wcimetrics.OperationTypeInvokeWorker,
 				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+
+				// We are not setting stateChanged to true to avoid unneccessary CaNs here.
 			}
 		case scalingalgorithm.ActionTypeUpdateWorkerSetSize:
+			now := workflow.Now(ctx)
 			if err := workflow.ExecuteActivity(
 				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: UpdateWorkerSetSizeActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
 				d.a.UpdateWorkerSetSize,
@@ -511,11 +520,14 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				},
 			).Get(ctx, nil); err != nil {
 				d.logger.Warn("Failed to execute update worker-set size activity", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "error", err)
-				d.State.ValidationState = &iface.ValidationState{
-					LastValidatedTime: timestamppb.New(workflow.Now(ctx)),
-					Status:            iface.ValidationStatusFailed,
-					ErrMessage:        err.Error(),
+
+				// only application errors can indicate validation errors, so filtering for them first
+				if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
+					// TODO: filter out transient errors to avoid the validation state oscillating
+					d.State.ValidationStatus = iface.NewValidationStatusFailed(now, appErr.Message())
 				}
+
+				// We are not setting stateChanged to true to avoid unneccessary CaNs here.
 			}
 		default:
 			d.logger.Warn("Unknown scaling action", "action", action.Action)
@@ -542,7 +554,12 @@ func (d *WorkflowRunner) listenToSignals(ctx workflow.Context) {
 	addStatsPullTimer = func(nextPoll time.Duration) {
 		timerFuture := workflow.NewTimer(ctx, nextPoll)
 		d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
-			_ = f.Get(ctx, nil)
+			if err := f.Get(ctx, nil); err != nil {
+				d.logger.Debug("Periodic stats timer cancelled, not re-arming", "error", err)
+
+				// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
+				return
+			}
 			nextPollDuration := d.pullStatsAndUpdate(ctx)
 
 			// for now we don't want to mark things as dirty to avoid excessive CaN
@@ -551,6 +568,24 @@ func (d *WorkflowRunner) listenToSignals(ctx workflow.Context) {
 		})
 	}
 	addStatsPullTimer(maxPollInterval)
+
+	if d.hasMinVersion(PeriodicValidationVersion) {
+		var addPeriodicValidationTimer func()
+		addPeriodicValidationTimer = func() {
+			timerFuture := workflow.NewTimer(ctx, periodicValidationInterval)
+			d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
+				if err := f.Get(ctx, nil); err != nil {
+					d.logger.Debug("Periodic validation timer cancelled, not re-arming", "error", err)
+
+					// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
+					return
+				}
+				d.periodicValidateSpec(ctx)
+				addPeriodicValidationTimer()
+			})
+		}
+		addPeriodicValidationTimer()
+	}
 
 	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
 	for {


### PR DESCRIPTION
## What was changed
Adds a tracking of the validation state of the compute config. When an update is successful, that means the spec is good. The spec is re-checked on a cadence to make sure it still works. The validation state is exposed via the query for upstream to expose it to external callers.
<!-- Describe what has changed in this PR -->

## Why?
A compute config that was valid when it got stored, might become invalid by virtue of changes outside of the temporal server (e.g. the AWS IAM config changing). This adds regular validation so we can highlight that to customers.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
