### PR TITLE
feat: add generic webhook compute provider

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	_ "time/tzdata" // embed tzdata as a fallback
 
-	"go.temporal.io/auto-scaled-workers/wci"
 	"github.com/urfave/cli/v2"
+	"go.temporal.io/auto-scaled-workers/wci"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"

--- a/wci/client/hook.go
+++ b/wci/client/hook.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/api/enums/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"

--- a/wci/service.go
+++ b/wci/service.go
@@ -3,8 +3,8 @@ package wci
 import (
 	"context"
 
-	wciLog "go.temporal.io/auto-scaled-workers/wci/log"
 	"go.temporal.io/api/serviceerror"
+	wciLog "go.temporal.io/auto-scaled-workers/wci/log"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"

--- a/wci/workflow/compute_provider/webhook.go
+++ b/wci/workflow/compute_provider/webhook.go
@@ -1,0 +1,85 @@
+package computeprovider
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+const (
+	configWebhookURL        = "url"
+	configWebhookAuthHeader = "auth_header"
+	configWebhookAuthToken  = "auth_token"
+)
+
+type webhookComputeProvider struct{}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeWebhook, NewWebhookComputeProvider)
+}
+
+func NewWebhookComputeProvider(_ context.Context, _ *dynamicconfig.Collection) (ComputeProvider, error) {
+	return &webhookComputeProvider{}, nil
+}
+
+func (p *webhookComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *webhookComputeProvider) ValidateConfig(_ context.Context, config ComputeProviderConfig) error {
+	rawURL, ok := config[configWebhookURL].(string)
+	if !ok || rawURL == "" {
+		return fmt.Errorf("missing or invalid webhook %q in config", configWebhookURL)
+	}
+
+	if _, err := url.ParseRequestURI(rawURL); err != nil {
+		return fmt.Errorf("invalid webhook URL %q: %w", rawURL, err)
+	}
+
+	return nil
+}
+
+func (p *webhookComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+	rawURL, ok := config[configWebhookURL].(string)
+	if !ok || rawURL == "" {
+		return fmt.Errorf("missing or invalid webhook %q in config", configWebhookURL)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader([]byte{}))
+	if err != nil {
+		return fmt.Errorf("failed to create webhook request: %w", err)
+	}
+
+	if authHeader, ok := config[configWebhookAuthHeader].(string); ok && authHeader != "" {
+		if authToken, ok := config[configWebhookAuthToken].(string); ok {
+			req.Header.Set(authHeader, authToken)
+		}
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook invocation failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned non-success status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *webhookComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+	return errors.ErrUnsupported
+}

--- a/wci/workflow/compute_provider/webhook_test.go
+++ b/wci/workflow/compute_provider/webhook_test.go
@@ -1,0 +1,122 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+)
+
+func TestWebhookComputeProvider_ValidateConfig(t *testing.T) {
+	provider := &webhookComputeProvider{}
+
+	t.Run("valid config", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configWebhookURL: "https://example.com/webhook",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		config := ComputeProviderConfig{}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing or invalid webhook")
+	})
+
+	t.Run("invalid url format", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configWebhookURL: "://invalid-url",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid webhook URL")
+	})
+}
+
+func TestWebhookComputeProvider_InvokeWorker(t *testing.T) {
+	provider := &webhookComputeProvider{}
+
+	t.Run("successful invocation without auth", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		config := ComputeProviderConfig{
+			configWebhookURL: server.URL,
+		}
+		err := provider.InvokeWorker(context.Background(), config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("successful invocation with auth", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "Bearer my-secret-token", r.Header.Get("Authorization"))
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer server.Close()
+
+		config := ComputeProviderConfig{
+			configWebhookURL:        server.URL,
+			configWebhookAuthHeader: "Authorization",
+			configWebhookAuthToken:  "Bearer my-secret-token",
+		}
+		err := provider.InvokeWorker(context.Background(), config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invocation returns error status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		config := ComputeProviderConfig{
+			configWebhookURL: server.URL,
+		}
+		err := provider.InvokeWorker(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "non-success status code: 500")
+	})
+
+	t.Run("invocation with unreachable url", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configWebhookURL: "http://127.0.0.1:0/unreachable", // Port 0 will fail
+		}
+		err := provider.InvokeWorker(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "webhook invocation failed")
+	})
+}
+
+func TestWebhookComputeProvider_LaunchStrategy(t *testing.T) {
+	provider := &webhookComputeProvider{}
+	assert.Equal(t, LaunchStrategyInvoke, provider.LaunchStrategy())
+}
+
+func TestWebhookComputeProvider_UpdateWorkerSetSize(t *testing.T) {
+	provider := &webhookComputeProvider{}
+	err := provider.UpdateWorkerSetSize(context.Background(), ComputeProviderConfig{}, 5)
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+func TestWebhookComputeProvider_Registration(t *testing.T) {
+	providerConstructorsMu.RLock()
+	ctor, ok := providerConstructors[iface.ComputeProviderTypeWebhook]
+	providerConstructorsMu.RUnlock()
+	require.True(t, ok, "Webhook provider must be registered")
+
+	provider, err := ctor(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	assert.IsType(t, &webhookComputeProvider{}, provider)
+}

--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -51,6 +51,7 @@ const (
 	ComputeProviderTypeSubprocess    ComputeProviderType = "subprocess"
 	ComputeProviderTypeK8s           ComputeProviderType = "k8s"
 	ComputeProviderTypeGCPCloudRun   ComputeProviderType = "gcp-cloud-run"
+	ComputeProviderTypeWebhook       ComputeProviderType = "webhook"
 	ComputeProviderTypeTestInvoke    ComputeProviderType = "test-invoke"
 	ComputeProviderTypeTestWorkerSet ComputeProviderType = "test-worker-set"
 
@@ -64,6 +65,7 @@ var validComputeProviderTypes = map[string]ComputeProviderType{
 	string(ComputeProviderTypeSubprocess):    ComputeProviderTypeSubprocess,
 	string(ComputeProviderTypeK8s):           ComputeProviderTypeK8s,
 	string(ComputeProviderTypeGCPCloudRun):   ComputeProviderTypeGCPCloudRun,
+	string(ComputeProviderTypeWebhook):       ComputeProviderTypeWebhook,
 	string(ComputeProviderTypeTestInvoke):    ComputeProviderTypeTestInvoke,
 	string(ComputeProviderTypeTestWorkerSet): ComputeProviderTypeTestWorkerSet,
 }


### PR DESCRIPTION
This PR adds a generic HTTP webhook compute provider (LaunchStrategyInvoke) to support non-AWS serverless environments. It allows the WCI to send a POST request with an empty body and optional authorization headers to wake up containers on queues.