### PR TITLE
feat: add gcp-cloud-run-invoke compute provider with OIDC

### DIFF
--- a/wci/workflow/compute_provider/gcp_cloudrun_invoke.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_invoke.go
@@ -1,0 +1,158 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
+	"google.golang.org/api/idtoken"
+	"google.golang.org/api/impersonate"
+
+	"golang.org/x/oauth2"
+)
+
+const (
+	configGCPCloudRunInvokeURL            = "url"
+	configGCPCloudRunInvokeServiceAccount = "service_account"
+)
+
+type gcpCloudRunInvokeComputeProvider struct {
+	intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+}
+
+func init() {
+	RegisterComputeProvider(iface.ComputeProviderTypeGCPCloudRunInvoke, NewGCPCloudRunInvokeComputeProvider)
+}
+
+func NewGCPCloudRunInvokeComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	var intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+	if dc != nil {
+		intermediaryServiceAccounts = client.WorkerControllerGCPIntermediaryServiceAccounts.Get(dc)()
+	}
+
+	return &gcpCloudRunInvokeComputeProvider{
+		intermediaryServiceAccounts: intermediaryServiceAccounts,
+	}, nil
+}
+
+func (p *gcpCloudRunInvokeComputeProvider) LaunchStrategy() LaunchStrategy {
+	return LaunchStrategyInvoke
+}
+
+func (p *gcpCloudRunInvokeComputeProvider) ValidateConfig(_ context.Context, config ComputeProviderConfig) error {
+	rawURL, ok := config[configGCPCloudRunInvokeURL].(string)
+	if !ok || rawURL == "" {
+		return fmt.Errorf("missing or invalid %q in config", configGCPCloudRunInvokeURL)
+	}
+
+	if _, err := url.ParseRequestURI(rawURL); err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+
+	return nil
+}
+
+func (p *gcpCloudRunInvokeComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+	targetURL, ok := config[configGCPCloudRunInvokeURL].(string)
+	if !ok || targetURL == "" {
+		return fmt.Errorf("missing or invalid %q in config", configGCPCloudRunInvokeURL)
+	}
+
+	tokenSource, err := p.buildTokenSource(ctx, targetURL, config)
+	if err != nil {
+		return fmt.Errorf("failed to create token source: %w", err)
+	}
+
+	token, err := tokenSource.Token()
+	if err != nil {
+		return fmt.Errorf("failed to obtain OIDC token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Cloud Run invocation failed: %w", err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Cloud Run returned non-success status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (p *gcpCloudRunInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+	return errors.ErrUnsupported
+}
+
+// buildTokenSource returns an oauth2.TokenSource that produces OIDC identity tokens
+// for the target Cloud Run URL.
+//
+// If a service_account is configured, it uses SA impersonation with the intermediary
+// delegate chain (cross-project / Temporal Cloud scenario).
+//
+// If no service_account is configured, it falls back to the default credentials on the
+// host (Workload Identity on GKE, attached SA on Compute Engine / Cloud Run).
+func (p *gcpCloudRunInvokeComputeProvider) buildTokenSource(ctx context.Context, audience string, config ComputeProviderConfig) (oauth2.TokenSource, error) {
+	serviceAccount, _ := config[configGCPCloudRunInvokeServiceAccount].(string)
+
+	if serviceAccount != "" {
+		// Impersonation path: build a delegate chain and mint an ID token
+		// via the target service account.
+		delegates := p.buildDelegates()
+
+		ts, err := impersonate.IDTokenSource(ctx, impersonate.IDTokenConfig{
+			Audience:        audience,
+			TargetPrincipal: serviceAccount,
+			Delegates:       delegates,
+			IncludeEmail:    true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create impersonated ID token source for %q: %w", serviceAccount, err)
+		}
+		return ts, nil
+	}
+
+	// Workload Identity path: use the default credentials on the host to
+	// mint an ID token for the target audience.
+	ts, err := idtoken.NewTokenSource(ctx, audience)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default ID token source: %w", err)
+	}
+	return ts, nil
+}
+
+// buildDelegates constructs the intermediary service account delegate chain from the
+// dynamic configuration, matching the pattern used by the existing gcp-cloud-run provider.
+func (p *gcpCloudRunInvokeComputeProvider) buildDelegates() []string {
+	delegates := []string{}
+	for _, step := range p.intermediaryServiceAccounts {
+		if len(step) == 0 {
+			continue
+		}
+		req := step[rand.Intn(len(step))]
+		if req.ServiceAccountEmail == "" {
+			continue
+		}
+		delegates = append(delegates, req.ServiceAccountEmail)
+	}
+	return delegates
+}

--- a/wci/workflow/compute_provider/gcp_cloudrun_invoke_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_invoke_test.go
@@ -1,0 +1,88 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+)
+
+func TestGCPCloudRunInvokeComputeProvider_ValidateConfig(t *testing.T) {
+	provider := &gcpCloudRunInvokeComputeProvider{}
+
+	t.Run("valid config with url only", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configGCPCloudRunInvokeURL: "https://my-worker-abc123-uc.a.run.app",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid config with url and service_account", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configGCPCloudRunInvokeURL:            "https://my-worker-abc123-uc.a.run.app",
+			configGCPCloudRunInvokeServiceAccount: "invoker@my-project.iam.gserviceaccount.com",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.NoError(t, err)
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		config := ComputeProviderConfig{}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing or invalid")
+	})
+
+	t.Run("empty url", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configGCPCloudRunInvokeURL: "",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "missing or invalid")
+	})
+
+	t.Run("invalid url format", func(t *testing.T) {
+		config := ComputeProviderConfig{
+			configGCPCloudRunInvokeURL: "://invalid",
+		}
+		err := provider.ValidateConfig(context.Background(), config)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid URL")
+	})
+}
+
+func TestGCPCloudRunInvokeComputeProvider_LaunchStrategy(t *testing.T) {
+	provider := &gcpCloudRunInvokeComputeProvider{}
+	assert.Equal(t, LaunchStrategyInvoke, provider.LaunchStrategy())
+}
+
+func TestGCPCloudRunInvokeComputeProvider_UpdateWorkerSetSize(t *testing.T) {
+	provider := &gcpCloudRunInvokeComputeProvider{}
+	err := provider.UpdateWorkerSetSize(context.Background(), ComputeProviderConfig{}, 5)
+	assert.ErrorIs(t, err, errors.ErrUnsupported)
+}
+
+func TestGCPCloudRunInvokeComputeProvider_Registration(t *testing.T) {
+	providerConstructorsMu.RLock()
+	ctor, ok := providerConstructors[iface.ComputeProviderTypeGCPCloudRunInvoke]
+	providerConstructorsMu.RUnlock()
+	require.True(t, ok, "gcp-cloud-run-invoke provider must be registered")
+
+	provider, err := ctor(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	assert.IsType(t, &gcpCloudRunInvokeComputeProvider{}, provider)
+}
+
+func TestGCPCloudRunInvokeComputeProvider_BuildDelegates(t *testing.T) {
+	t.Run("no intermediary accounts", func(t *testing.T) {
+		provider := &gcpCloudRunInvokeComputeProvider{}
+		delegates := provider.buildDelegates()
+		assert.Empty(t, delegates)
+	})
+}

--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -50,9 +50,10 @@ const (
 	ComputeProviderTypeAWSECS        ComputeProviderType = "aws-ecs"
 	ComputeProviderTypeSubprocess    ComputeProviderType = "subprocess"
 	ComputeProviderTypeK8s           ComputeProviderType = "k8s"
-	ComputeProviderTypeGCPCloudRun   ComputeProviderType = "gcp-cloud-run"
-	ComputeProviderTypeTestInvoke    ComputeProviderType = "test-invoke"
-	ComputeProviderTypeTestWorkerSet ComputeProviderType = "test-worker-set"
+	ComputeProviderTypeGCPCloudRun       ComputeProviderType = "gcp-cloud-run"
+	ComputeProviderTypeGCPCloudRunInvoke ComputeProviderType = "gcp-cloud-run-invoke"
+	ComputeProviderTypeTestInvoke        ComputeProviderType = "test-invoke"
+	ComputeProviderTypeTestWorkerSet     ComputeProviderType = "test-worker-set"
 
 	ScalingAlgorithmNoSync    ScalingAlgorithmType = "no-sync"
 	ScalingAlgorithmRateBased ScalingAlgorithmType = "rate-based"
@@ -63,9 +64,10 @@ var validComputeProviderTypes = map[string]ComputeProviderType{
 	string(ComputeProviderTypeAWSECS):        ComputeProviderTypeAWSECS,
 	string(ComputeProviderTypeSubprocess):    ComputeProviderTypeSubprocess,
 	string(ComputeProviderTypeK8s):           ComputeProviderTypeK8s,
-	string(ComputeProviderTypeGCPCloudRun):   ComputeProviderTypeGCPCloudRun,
-	string(ComputeProviderTypeTestInvoke):    ComputeProviderTypeTestInvoke,
-	string(ComputeProviderTypeTestWorkerSet): ComputeProviderTypeTestWorkerSet,
+	string(ComputeProviderTypeGCPCloudRun):       ComputeProviderTypeGCPCloudRun,
+	string(ComputeProviderTypeGCPCloudRunInvoke): ComputeProviderTypeGCPCloudRunInvoke,
+	string(ComputeProviderTypeTestInvoke):        ComputeProviderTypeTestInvoke,
+	string(ComputeProviderTypeTestWorkerSet):     ComputeProviderTypeTestWorkerSet,
 }
 
 var validScalingAlgorithmTypes = map[string]ScalingAlgorithmType{


### PR DESCRIPTION
## Summary

Adds a new `gcp-cloud-run-invoke` compute provider that uses `LaunchStrategyInvoke` to trigger Cloud Run services via HTTP POST with OIDC identity tokens. This is the GCP analog to the existing `aws-lambda` provider.

## Authentication

Supports two authentication modes:

- **Workload Identity (default)**: When no `service_account` is configured, uses `idtoken.NewTokenSource` which transparently leverages the host's default credentials (GKE Workload Identity, attached SA on Compute Engine/Cloud Run).
- **SA Impersonation**: When a `service_account` is configured, uses `impersonate.IDTokenSource` with the intermediary delegate chain for cross-project or Temporal Cloud scenarios.

Both paths produce OIDC identity tokens with the Cloud Run service URL as the audience, which is what Cloud Run's IAM invoker check requires.

## Relationship to existing `gcp-cloud-run` provider

The existing `gcp-cloud-run` provider uses `LaunchStrategyWorkerSet` to manage Cloud Run WorkerPool instance counts. This new provider complements it by enabling per-task invocation semantics, similar to how `aws-lambda` works.

## Config

```yaml
provider_type: gcp-cloud-run-invoke
# Config details (passed as Payload):
# url: https://my-worker-abc123-uc.a.run.app   (required)
# service_account: invoker@proj.iam.gserviceaccount.com  (optional, omit for Workload Identity)
```