### PR TITLE
Buffer pending task-add signals across continue-as-new

### DIFF
--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -38,11 +38,11 @@ func buildBaseAWSConfig(ctx context.Context, region string, intermediaryRoles []
 		// At each stage of the role chaining, one of multiple roles might be chosen to proceed. This allows for load balancing
 		// requests across roles/accounts and reduces the impact of any of these accounts failing (until it is removed from the config).
 		req := step[rand.Intn(len(step))]
-		if err := validateRoleARN(req.RoleARN); err != nil {
+		if err = validateRoleARN(req.RoleARN); err != nil {
 			return aws.Config{}, err
 		}
 		if req.RoleSessionName == "" {
-			return aws.Config{}, fmt.Errorf("Empty role session name for intermediary role")
+			return aws.Config{}, fmt.Errorf("empty role session name for intermediary role")
 		}
 
 		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &req)

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -45,7 +45,7 @@ func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ Com
 	return errors.ErrUnsupported
 }
 
-// TestInvokeComputeProviderValidProviderDetails provides an example valid config for testing code to use
+// TestInvokeComputeProviderValidComputeProvider provides an example valid config for testing code to use
 func TestInvokeComputeProviderValidComputeProvider() *computepb.ComputeProvider {
 	providerDetails := map[string]string{}
 	payload, _ := sdk.PreferProtoDataConverter.ToPayload(providerDetails)

--- a/wci/workflow/iface/workflow.go
+++ b/wci/workflow/iface/workflow.go
@@ -83,6 +83,8 @@ type (
 		// ScalingStatus contains the state information keyd by the ScalingGroups key
 		ScalingStatus map[string]ScalingAlgorithmStatus `json:"scaling_state"`
 
+		PendingTaskAddSignals []*SignalTaskAddRequest `json:"pending_task_add_signals,omitempty"`
+
 		ConflictToken        []byte                 `json:"conflict_token,omitempty"`
 		CreateTime           *timestamppb.Timestamp `json:"create_time,omitempty"`
 		LastModifierIdentity string                 `json:"last_modifier_identity,omitempty"`

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -9,7 +9,6 @@ import (
 
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
-	"go.temporal.io/sdk/activity"
 )
 
 const (
@@ -126,7 +125,7 @@ func (a *scalingAlgorithmNoSync) ValidateConfig(ctx context.Context, config ifac
 }
 
 func (a *scalingAlgorithmNoSync) ProcessTaskAdd(ctx context.Context, config iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, event iface.SignalTaskAddRequest) (*TaskAddResponse, error) {
-	logger := activity.GetLogger(ctx)
+	logger := safeActivityLogger(ctx)
 
 	updatedState := maps.Clone(priorState)
 	actions := []ScalingAction{}

--- a/wci/workflow/scaling_algorithm/safe_activity_logger.go
+++ b/wci/workflow/scaling_algorithm/safe_activity_logger.go
@@ -1,0 +1,27 @@
+package scalingalgorithm
+
+import (
+	"context"
+
+	"go.temporal.io/sdk/activity"
+	sdklog "go.temporal.io/sdk/log"
+)
+
+type (
+	noopLogger struct{}
+)
+
+func safeActivityLogger(ctx context.Context) (logger sdklog.Logger) {
+	logger = noopLogger{}
+	defer func() {
+		if recover() != nil {
+			logger = noopLogger{}
+		}
+	}()
+	return activity.GetLogger(ctx)
+}
+
+func (noopLogger) Debug(string, ...interface{}) {}
+func (noopLogger) Info(string, ...interface{})  {}
+func (noopLogger) Warn(string, ...interface{})  {}
+func (noopLogger) Error(string, ...interface{}) {}

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -45,8 +45,8 @@ const (
 type (
 	// SignalHandler encapsulates the signal handling logic
 	SignalHandler struct {
-		signalSelector    workflow.Selector
-		processingSignals int
+		signalSelector       workflow.Selector
+		taskAddSignalChannel workflow.ReceiveChannel
 	}
 
 	// WorkflowRunner holds the local state while running a worker controller workflow
@@ -161,22 +161,68 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return err
 	}
 
-	// Listen to signals in a different goroutine to make business logic clearer
-	workflow.Go(ctx, d.listenToSignals)
+	// Process the signals from the prior run (pre-CaN)
+	d.processPendingTaskAddSignals(ctx)
 
-	// Wait until we can continue as new or are cancelled. The workflow will continue-as-new iff
-	// there are no pending updates/signals and the state has changed.
-	if err = workflow.Await(ctx, func() bool {
-		return d.deleteInstance || // instance is deleted -> it's ok to drop all signals and updates.
-			// There is no pending signal or update, but the state is dirty or forceCaN is requested:
-			(!d.signalHandler.signalSelector.HasPending() && d.signalHandler.processingSignals == 0 && workflow.AllHandlersFinished(ctx) &&
-				(d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()))
-	}); err != nil {
-		return err
+	// Setup the signal handler for the two signals we are dealing with
+	d.signalHandler.taskAddSignalChannel = workflow.GetSignalChannel(ctx, iface.SignalTaskAdd)
+	d.signalHandler.signalSelector.AddReceive(d.signalHandler.taskAddSignalChannel, func(c workflow.ReceiveChannel, more bool) {
+		var req *iface.SignalTaskAddRequest
+		c.Receive(ctx, &req)
+
+		d.recordTaskAddSignalMetric()
+		d.handleNoSyncMatchSignal(ctx, req)
+	})
+
+	var addStatsPullTimer func(nextPoll time.Duration)
+	addStatsPullTimer = func(nextPoll time.Duration) {
+		timerFuture := workflow.NewTimer(ctx, nextPoll)
+		d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
+			if err = f.Get(ctx, nil); err != nil {
+				d.logger.Debug("Periodic stats timer cancelled, not re-arming", "error", err)
+
+				// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
+				return
+			}
+			nextPollDuration := d.pullStatsAndUpdate(ctx)
+
+			// for now we don't want to mark things as dirty to avoid excessive CaN
+			// d.stateChanged = true
+			addStatsPullTimer(nextPollDuration)
+		})
 	}
 
+	if d.hasMinVersion(PeriodicValidationVersion) {
+		var addPeriodicValidationTimer func()
+		addPeriodicValidationTimer = func() {
+			timerFuture := workflow.NewTimer(ctx, periodicValidationInterval)
+			d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
+				if err = f.Get(ctx, nil); err != nil {
+					d.logger.Debug("Periodic validation timer cancelled, not re-arming", "error", err)
+
+					// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
+					return
+				}
+				d.periodicValidateSpec(ctx)
+				addPeriodicValidationTimer()
+			})
+		}
+		addPeriodicValidationTimer()
+	}
+
+	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
+	for !d.deleteInstance && !d.forceCAN && !d.stateChanged && !workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+		d.signalHandler.signalSelector.Select(ctx)
+	}
+
+	// instance is deleted -> it's ok to drop all signals and updates.
 	if d.deleteInstance {
 		return nil
+	}
+
+	// Wait for all handlers to finish before continueing.
+	if err = workflow.Await(ctx, func() bool { return workflow.AllHandlersFinished(ctx) }); err != nil {
+		return err
 	}
 
 	// We perform a continue-as-new after each update and signal is handled to ensure compatibility
@@ -184,6 +230,8 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// we pass the current state as input to the next workflow execution, resulting in a new
 	// workflow history with just two initial events. This minimizes the risk of NDE (Non-Deterministic Execution)
 	// errors during server rollbacks.
+	d.drainPendingTaskAddSignals()
+
 	return workflow.NewContinueAsNewError(ctx, iface.WorkerControllerInstanceWorkflowType, d.WorkerControllerInstanceWorkflowArgs)
 }
 
@@ -535,62 +583,41 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 	}
 }
 
-func (d *WorkflowRunner) listenToSignals(ctx workflow.Context) {
-	noSyncMatchSignalChannel := workflow.GetSignalChannel(ctx, iface.SignalTaskAdd)
-	d.signalHandler.signalSelector.AddReceive(noSyncMatchSignalChannel, func(c workflow.ReceiveChannel, more bool) {
-		d.signalHandler.processingSignals++
-		defer func() { d.signalHandler.processingSignals-- }()
-		var req *iface.SignalTaskAddRequest
-		c.Receive(ctx, &req)
+func (d *WorkflowRunner) processPendingTaskAddSignals(ctx workflow.Context) {
+	if d.State == nil || len(d.State.PendingTaskAddSignals) == 0 {
+		return
+	}
 
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.SignalTypeTagName: wcimetrics.SignalTypeTaskAdd,
-		}).Counter(wcimetrics.Signals.Name()).Inc(1)
-
+	pendingSignals := d.State.PendingTaskAddSignals
+	d.State.PendingTaskAddSignals = nil
+	for _, req := range pendingSignals {
+		d.recordTaskAddSignalMetric()
 		d.handleNoSyncMatchSignal(ctx, req)
-	})
-
-	var addStatsPullTimer func(nextPoll time.Duration)
-	addStatsPullTimer = func(nextPoll time.Duration) {
-		timerFuture := workflow.NewTimer(ctx, nextPoll)
-		d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
-			if err := f.Get(ctx, nil); err != nil {
-				d.logger.Debug("Periodic stats timer cancelled, not re-arming", "error", err)
-
-				// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
-				return
-			}
-			nextPollDuration := d.pullStatsAndUpdate(ctx)
-
-			// for now we don't want to mark things as dirty to avoid excessive CaN
-			// d.stateChanged = true
-			addStatsPullTimer(nextPollDuration)
-		})
 	}
-	addStatsPullTimer(maxPollInterval)
+}
 
-	if d.hasMinVersion(PeriodicValidationVersion) {
-		var addPeriodicValidationTimer func()
-		addPeriodicValidationTimer = func() {
-			timerFuture := workflow.NewTimer(ctx, periodicValidationInterval)
-			d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
-				if err := f.Get(ctx, nil); err != nil {
-					d.logger.Debug("Periodic validation timer cancelled, not re-arming", "error", err)
-
-					// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
-					return
-				}
-				d.periodicValidateSpec(ctx)
-				addPeriodicValidationTimer()
-			})
-		}
-		addPeriodicValidationTimer()
+func (d *WorkflowRunner) drainPendingTaskAddSignals() {
+	if d.State == nil || d.signalHandler == nil || d.signalHandler.taskAddSignalChannel == nil {
+		return
 	}
 
-	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
 	for {
-		d.signalHandler.signalSelector.Select(ctx)
+		var req *iface.SignalTaskAddRequest
+		if !d.signalHandler.taskAddSignalChannel.ReceiveAsync(&req) {
+			return
+		}
+		if req == nil {
+			continue
+		}
+		d.State.PendingTaskAddSignals = append(d.State.PendingTaskAddSignals, req)
+		d.stateChanged = true
 	}
+}
+
+func (d *WorkflowRunner) recordTaskAddSignalMetric() {
+	d.metrics.WithTags(map[string]string{
+		wcimetrics.SignalTypeTagName: wcimetrics.SignalTypeTaskAdd,
+	}).Counter(wcimetrics.Signals.Name()).Inc(1)
 }
 
 func (d *WorkflowRunner) hasMinVersion(version WorkerControllerInstanceWorkflowVersion) bool {


### PR DESCRIPTION
## What was changed
Drain unprocessed task-add signals into local state before continue-as-new and replay them on the next run so signals are not lost. Inline the signal listener into the main goroutine, add a safe activity logger fallback, and cover the new behavior with workflow tests.

## Why?
The workflow crashed with history-too-large in case of constant signal load (as it would not not CaN).
