### PR TITLE
Arm periodic stats pull timer on workflow start

### DIFF
--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -191,6 +191,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 			addStatsPullTimer(nextPollDuration)
 		})
 	}
+	addStatsPullTimer(maxPollInterval)
 
 	if d.hasMinVersion(PeriodicValidationVersion) {
 		var addPeriodicValidationTimer func()


### PR DESCRIPTION
The stats pull timer was defined but never initially scheduled, so the periodic stats poll would not fire after a fresh workflow run or continue-as-new. Add the initial addStatsPullTimer(maxPollInterval) call to kick off the polling loop.

This was broken in the rebase for the prior PR — oopsie.
