### PR TITLE
Add EWMA queue consumer autoscaling simulator

### DIFF
--- a/docs/simulators/workerset-ewma/SPEC.md
+++ b/docs/simulators/workerset-ewma/SPEC.md
@@ -1,0 +1,219 @@
+# Worker Set Scaling Algorithm Spec
+
+This document specifies a worker set scaling algorithm using exponential weighted-moving-average (EWMA) on the arrival/dispatch rates reported by matching service. It determines the size of the worker set (a.k.a. the replica count) with a combination of a steady state, queueing theory-based formula and a fast-path handler for no-sync matches (that quickly triggers upscaling).
+
+The fast path is driven by the clarity of the signal: when a no-sync match happens, it directly means that there is not sufficient compute for processing all work and so a scale-up should be strongly considered. For simplicity this is only smoothed via a cooldown.
+
+The steady state path leverages the rate information as well as the backlog size (to allow for burndown if needed). This is based on queueing theory: it combines an estimated per-worker dispatch capacity with two staffing rules — a utilization-target rule that dominates at low load and a Halfin-Whitt square-root staffing rule that dominates under heavy load — and takes the larger of the two as desired capacity. As the raw rates might be very noisy (e.g. arrival rate can be very spiky) they are smoothed using EWMA (see https://en.wikipedia.org/wiki/EWMA_chart).
+
+## Inputs
+
+The scaler receives these values from its caller:
+
+- `Backlog length`: number of tasks in the backlog of the task queue (waiting to be processed).
+- `Arrival rate (/s)`: rolling task-arrival rate measured by the caller.
+- `Dispatch rate (/s)`: rolling task-dispatch rate measured by the caller.
+- `No-sync match`: event signal that an arrival could not start immediately.
+
+The caller owns measurement configuration:
+
+- `Rate window (s)`: rolling window used to measure arrival and dispatch rates before passing them to the scaler.
+
+The scaler is configured with:
+
+- `Initial worker count`: default starting value for planned worker count when no prior planned value is available.
+- `Min workers`: lower bound for scale-down.
+- `Max workers`: upper bound for planned workers.
+- `Cadence (s)`: interval for regular scaler decisions.
+- `EWMA alpha (%)`: smoothing factor for EWMA arrival rate, EWMA dispatch rate, and per-worker capacity estimate.
+- `Initial per-worker capacity (/s)`: per-worker capacity used until the first saturation sample arrives (see Capacity Estimate).
+- `Target backlog drain rate (/s)`: additional required dispatch rate included while backlog length is greater than zero.
+- `Material backlog threshold`: backlog length at or above which cadence may sample per-worker capacity.
+- `Utilization target (%)`: target mean utilization used by the utilization-target staffing candidate. Lower values reserve more headroom and dominate at low load.
+- `Halfin-Whitt beta`: coefficient β in the square-root staffing formula `N = ρ + β·√ρ`. Larger values reserve more spare capacity and lower the probability that an arrival has to wait under heavy load.
+- `Max scale-up step`: maximum planned-worker-count increase a cadence decision can make at once.
+- `Scale-up cooldown (s)`: minimum time between planned-count increases.
+- `Scale-down cooldown (s)`: minimum time between planned-count decreases.
+- `No-sync quiet (s)`: minimum time since the last no-sync match before scale-down is allowed.
+
+## Planned vs Running Workers
+
+The scaler's only worker-count concept is the *planned worker count*: a target maintained by the scaler and updated by its decisions. The actual *running worker count* — how many worker processes are currently up and accepting work — is not available and so cannot be used by the algorithm.
+
+From the caller's perspective a worker is in one of three lifecycle states:
+
+- **Starting** — a planned-count increase has reserved this slot, but the underlying worker is still spinning up and not yet accepting tasks.
+- **Active** — the worker has finished spin-up and is dispatching tasks.
+- **Stopping** — a planned-count decrease has marked this worker for removal; the caller drains and shuts it down, or cancels its startup if it was still starting.
+
+Each scaler decision updates the planned count immediately; the caller reconciles the running set to match. Because spin-up takes time, `planned ≥ running + starting` does not hold instantaneously: planned can lead running during scale-up (workers reserved but not yet active) and lag running briefly during scale-down (workers marked for removal but still draining in-flight work).
+
+This split has three implications worth calling out, because the rest of the spec quietly relies on them:
+
+- **Cooldowns gate planned-count changes, not running-count changes.** `Scale-up cooldown (s)` starts when the scaler increments planned, not when the new worker becomes active. Two scale-ups separated by less than the cooldown are blocked even if neither new worker is running yet. This is what prevents bursts of no-sync matches from issuing redundant scale-ups while the first one is still spinning up.
+- **The per-worker capacity estimate divides by *planned* workers, not running.** During spin-up the dispatch rate is being served by fewer workers than planned, so the observed `dispatch rate / planned workers` is temporarily biased downward. The bias resolves as workers finish starting and as later saturation samples are taken; using planned (rather than running) keeps the scaler self-consistent — it estimates the capacity of the fleet *it has asked for*, which is what its next decision will compare against.
+- **Scale-down prefers cancelling starts over stopping active workers.** When planned drops, the caller drops a still-starting worker first (no in-flight work to drain); only when no starts are pending does it stop an active worker. The scaler emits only the new planned count; the choice of which worker to drop is the caller's.
+
+The scaler uses planned (not running) as its decision basis so that each decision is reflected in subsequent decisions immediately, without the scaler having to model spin-up latency or risk issuing duplicate scale-ups while a previous one is still in flight.
+
+## State
+
+The scaler tracks:
+
+- Planned worker count: target worker count maintained by the scaler and counted against scale limits.
+- EWMA arrival rate.
+- EWMA dispatch rate.
+- EWMA per-worker processing capacity.
+- Last planned-count increase time.
+- Last planned-count decrease time.
+- Last no-sync match time.
+
+The caller owns the measured backlog length and measured rates. The caller may restore a prior planned worker count; otherwise the scaler initializes planned worker count from `Initial worker count`.
+
+## Capacity Estimate
+
+The scaler updates its per-worker capacity estimate when a saturation signal provides a usable sample:
+
+```text
+observed per-worker capacity = dispatch rate / planned workers
+estimated per-worker capacity =
+  EWMA alpha * observed per-worker capacity +
+  (1 - EWMA alpha) * previous estimated per-worker capacity
+```
+
+Saturation signals are:
+
+- A no-sync match.
+- A cadence tick where backlog length is greater than or equal to `Material backlog threshold`.
+
+The estimate is updated only when planned worker count is greater than zero and dispatch rate is positive. Otherwise, the existing estimate is retained. Before the first usable sample, `Initial per-worker capacity (/s)` is used.
+
+## No-Sync Decision
+
+A no-sync match is an immediate scale-up signal.
+
+On each no-sync match, the scaler increments planned worker count by one if all of the following are true:
+
+- Planned worker count is below `Max workers`.
+- `Scale-up cooldown (s)` has elapsed since the last planned-count increase.
+
+The no-sync scale-up decision does not use backlog length, EWMA rates, cadence spare-capacity terms, or execution-capacity details.
+
+## Cadence Decision
+
+On every cadence tick:
+
+1. The scaler updates EWMA arrival and dispatch rates using `EWMA alpha (%)`.
+2. If the system is fully idle, the scaler snaps EWMA arrival and dispatch rates to zero.
+3. If backlog length is at least `Material backlog threshold`, the scaler updates its per-worker capacity estimate from the raw dispatch rate.
+4. The scaler computes one desired planned-worker count.
+5. The scaler compares desired planned workers to current planned workers.
+
+If desired is greater than current, the cadence path evaluates scale-up. If desired is less than current, it evaluates scale-down. Otherwise, it takes no action.
+
+## Idle Snap-To-Zero
+
+The cadence path removes residual EWMA rate memory once the caller reports a fully idle system:
+
+- Backlog length is zero.
+- Raw arrival rate is zero.
+- Raw dispatch rate is zero.
+
+When all conditions are true, EWMA arrival and dispatch rates are set to zero before computing desired workers. This allows desired workers to reach zero instead of staying at one because of a tiny smoothed arrival rate.
+
+## Cadence Desired Capacity
+
+Cadence computes desired workers from the smoothed arrival load, an optional backlog catch-up term, and the estimated per-worker capacity. The result is the larger of two staffing candidates, each capturing a different "how much spare capacity do we need" rule.
+
+First, the load:
+
+```text
+backlog catch-up rate = Target backlog drain rate if backlog length > 0, otherwise 0
+required rate         = EWMA arrival rate + backlog catch-up rate
+offered load (ρ)      = required rate / estimated per-worker capacity
+```
+
+`offered load` (denoted ρ, in Erlangs) is the dimensionless ratio of demand to single-worker throughput — equivalently, the minimum number of workers needed to keep up *on average*. At exactly ρ workers, mean utilization is 100% and queue length grows without bound under any variability; any sustainable system needs strictly more than ρ. The two candidates below each pick how much more.
+
+If `required rate` is zero, the formulas are skipped and `desired workers` is zero (then clamped to `Min workers`).
+
+```text
+utilization desired  = ceil(ρ / Utilization target)
+Halfin-Whitt desired = ceil(ρ + Halfin-Whitt beta · √ρ)
+desired workers      = max(utilization desired, Halfin-Whitt desired)
+```
+
+- **Utilization-target candidate** sizes the worker count so that mean utilization sits at `Utilization target`. The spare capacity is *proportional* to load (`ρ · (1/target − 1)`), so this candidate dominates at low load — e.g. at ρ = 1 with an 80% target it asks for 2 workers, leaving a full extra worker of headroom for a single unit of demand.
+- **Halfin-Whitt candidate** applies the square-root staffing rule from heavy-traffic queueing theory: with `N = ρ + β·√ρ` servers, the probability that an arrival has to wait converges to a constant determined by `β` as ρ grows. Spare capacity grows with `√ρ` rather than with `ρ`, so the *absolute* spare grows with load but the *relative* spare shrinks. This candidate dominates at high load, where the proportional headroom of the utilization rule would be wastefully large.
+
+Taking the max of the two gives the more conservative rule for the current load: utilization at low ρ, Halfin-Whitt at high ρ, with a smooth crossover. `desired workers` is then clamped to `[Min workers, Max workers]`.
+
+## Cadence Scale-Up
+
+When desired workers is greater than planned worker count, the scaler increases planned worker count by:
+
+```text
+min(Max scale-up step, desired - planned, Max workers - planned)
+```
+
+subject to `Scale-up cooldown (s)`. workers created by a planned-count increase may start accepting work later.
+
+## Scale-Down
+
+Scale-down runs only from cadence decisions.
+
+Scale-down is allowed when all of the following are true:
+
+- Desired worker count is less than planned worker count.
+- Time since the last no-sync match is at least `No-sync quiet (s)`.
+- Time since the last scale-down is at least `Scale-down cooldown (s)`.
+
+When scale-down occurs, the scaler decrements planned worker count by one. Unlike scale-up, scale-down has no `Max scale-down step` parameter — it is intentionally single-step per cadence tick. Combined with `Scale-down cooldown (s)`, this rate-limits the descent and biases the algorithm toward retaining warm capacity through transient dips: under-provisioning is a reliability problem worth correcting fast, while over-provisioning is only a cost problem and recovers naturally over multiple cadence ticks. If the excess capacity is still starting, that startup can be canceled instead of stopping an active worker.
+
+## Outputs
+
+Each scaling decision emits one of:
+
+- No action.
+- Updated planned worker count.
+
+The caller is responsible for reconciling running worker processes to the updated planned worker count and restoring that count on later decisions. If no prior planned worker count is available, the caller uses `Initial worker count` as the default.
+
+## Failure Modes
+
+The algorithm has a small number of slow-feedback paths where its internal state can drift from reality. None require external intervention to recover — the recovery dynamic noted with each item always applies — but each is worth understanding when tuning configured parameters or interpreting decisions.
+
+- **Stale per-worker capacity estimate.** The estimate updates only when a saturation signal fires (no-sync match, or cadence tick with backlog ≥ `Material backlog threshold`). Under sustained light load with no backlog, the estimate is frozen. If actual per-worker capacity has *decreased* in that interval (heavier tasks, slower downstream, etc.), the next demand spike will be under-provisioned by cadence; the resulting no-sync matches both scale up directly and refresh the estimate. If actual capacity has *increased*, cadence over-provisions until the next saturation sample arrives, which can take indefinitely long under light load — accepted as a cost-side rather than reliability-side error.
+
+- **Capacity estimate bias during spin-up.** `dispatch rate / planned workers` underestimates per-worker capacity while planned > running, because the running fleet is producing all of the dispatch rate. Cadence may briefly over-provision after a scale-up driven by saturation. The bias resolves naturally as workers finish starting and later saturation samples are taken.
+
+- **Capacity estimate noise at small planned counts.** When planned workers is small (especially 1–2), the divisor is small and the estimate is dominated by short-term dispatch-rate noise. EWMA smoothing absorbs most of this, but the estimate can swing meaningfully between samples until the worker count grows. Operators of systems that run persistently at small worker counts should expect larger swings here than in the rate EWMAs.
+
+- **EWMA hysteresis after a burst.** Smoothed rates decay exponentially at rate `1 − alpha` per cadence tick. After a burst clears, EWMA arrival rate remains elevated for several ticks, which delays scale-down. Lower `EWMA alpha (%)` exchanges responsiveness for stability. The idle snap-to-zero rescues the fully-idle case but not the "trickling at low rate" case.
+
+- **Step-change in arrival rate.** A sudden rate *increase* is absorbed first by no-sync scale-ups (one worker per no-sync, bounded by `Scale-up cooldown (s)`), then by cadence catching up over several ticks as EWMA arrivals climb (bounded per tick by `Max scale-up step`). A sudden rate *decrease* is conservatively absorbed via the EWMA decay and the `No-sync quiet (s)` / `Scale-down cooldown (s)` gates — capacity is retained longer than strictly needed to avoid thrashing.
+
+- **Worker failures invisible to the scaler.** If running workers die outside the scaler's decisions, planned stays ahead of running until the caller reconciles. Subsequent no-sync matches will scale up planned further; the planned count itself does not detect or correct for the loss. This is by design: worker liveness is the caller's domain, not the scaler's (see [Planned vs Running Workers](#planned-vs-running-workers)).
+
+## Non-Goals
+
+The algorithm intentionally does not use, and does not attempt to model, the following.
+
+**Signals not available today.** The matching-service surface the scaler runs against does not expose these, so the algorithm cannot consume them. If/when they become available, several of these would be worth reconsidering as inputs.
+
+- Execution-capacity internals beyond the no-sync-sampled per-worker capacity estimate: only the information matching service publishes on the server is available; richer slot- or queue-internal metrics are not.
+- Work-duration estimates as scaling inputs: end-of-processing for a specific task is not surfaced, and neither are reliable average processing times.
+- Worker idle state as a scaling input: idle/free-slot signals are not published to the server.
+- Lifecycle state of starting workers as separate scaling inputs: worker insights exposes some of this to the server, but it is not integrated into the scaling algorithm today.
+
+**Decisions delegated to the caller.** These are *available* in principle but are out of scope for this scaler by design — the scaler emits only a planned worker count.
+
+- Cross-task-queue coordination: the scaler operates per task queue with no awareness of other queues that may share underlying capacity. Global budgets, fair-share allocation, or priority arbitration belong above this layer.
+- Reconciliation of running worker processes to the planned count, including draining, deadline enforcement, and which specific worker to stop on scale-down (beyond the "prefer cancelling starts" guideline).
+
+**Out of scope by design.** These are deliberate omissions from the algorithm itself, not just missing data.
+
+- Backlog length or rates in the no-sync scale-up decision: a no-sync match alone already signals insufficient workers, so taking action should not be delayed for additional inputs. Any over-correction is bounded by `Scale-up cooldown (s)` and recovered (if needed) by the next cadence tick, which is not far off.
+- Direct SLO targets (P99 wait, max queue depth, max age in backlog): the algorithm exposes `Utilization target (%)` and `Halfin-Whitt beta` as indirect proxies and does not adapt them to observed SLO breaches. Closing the loop on SLOs is left to a higher-level controller.
+- Predictive or forecasting models: the algorithm is purely reactive on smoothed current rates. It does not project future arrivals from historical patterns, calendars, or learned seasonality.
+- Adaptive tuning of its own parameters: `EWMA alpha`, `Utilization target`, `Halfin-Whitt beta`, and the cooldowns are static configuration inputs, not self-tuned at runtime.

--- a/docs/simulators/workerset-ewma/app.js
+++ b/docs/simulators/workerset-ewma/app.js
@@ -1,0 +1,1130 @@
+(function () {
+  'use strict';
+
+  const MAX_HISTORY = 300;
+  const MAX_CHART_POINTS = 240;
+  const CHART_SAMPLE_MS = 1000;
+  const EPSILON_MS = 0.0001;
+  const IDLE_RATE_EPSILON = 1e-9;
+
+  const state = {
+    simTimeMs: 0,
+    targetTimeMs: 0,
+    lastFrameAt: null,
+    paused: true,
+    eventQueue: [],
+    nextEventId: 1,
+    nextTaskId: 1,
+    nextConsumerId: 1,
+    consumers: [],
+    pendingConsumers: [],
+    backlog: [],
+    arrivalTimes: [],
+    dispatchTimes: [],
+    waitSamplesMs: [],
+    history: [],
+    chartPoints: [],
+    lastChartSampleMs: -Infinity,
+    chartVersion: 0,
+    renderedChartVersion: -1,
+    stats: {
+      syncMatches: 0,
+      noSyncMatches: 0,
+      completed: 0,
+      totalWaitMs: 0,
+      waits: 0
+    },
+    scaler: {
+      lastScaleUpMs: -Infinity,
+      lastScaleDownMs: -Infinity,
+      lastNoSyncMs: -Infinity,
+      ewmaInitialized: false,
+      ewmaArrivalRate: 0,
+      ewmaDispatchRate: 0,
+      ewmaPerConsumerCapacity: 0,
+      plannedConsumers: null,
+      lastDecisionText: 'No decisions yet'
+    }
+  };
+
+  const els = {};
+  let capacityChart = null;
+  let rateChart = null;
+  let utilizationChart = null;
+
+  function cacheElements() {
+    for (const id of [
+      'runPauseBtn', 'stepBtn', 'resetBtn', 'addOneBtn', 'burstBtn', 'showMatchEvents',
+      'metricTime', 'metricPlannedConsumers', 'metricConsumers', 'metricStartingConsumers',
+      'metricBacklog', 'metricBusySlots', 'metricUtilization',
+      'metricOldestBacklog', 'metricArrivalRate', 'metricDispatchRate',
+      'metricEwmaArrivalRate', 'metricEwmaDispatchRate',
+      'metricSyncMatches', 'metricNoSyncMatches', 'metricCompleted', 'metricMeanWait',
+      'consumersList', 'history', 'slotSummary', 'capacityChart', 'rateChart', 'utilizationChart',
+      'capacityChartLegend', 'rateChartLegend', 'utilizationChartLegend'
+    ]) {
+      els[id] = document.getElementById(id);
+    }
+  }
+
+  function param(id) {
+    const el = document.getElementById(id);
+    const value = Number.parseFloat(el.value);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function intParam(id) {
+    return Math.max(0, Math.round(param(id)));
+  }
+
+  function msParam(id) {
+    return Math.max(0, param(id) * 1000);
+  }
+
+  function clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  function formatTime(ms) {
+    if (ms < 1000) return ms.toFixed(0) + 'ms';
+    if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return minutes + 'm ' + String(seconds).padStart(2, '0') + 's';
+  }
+
+  function logEvent(kind, message, className) {
+    state.history.unshift({
+      at: state.simTimeMs,
+      kind,
+      message,
+      className
+    });
+    if (state.history.length > MAX_HISTORY) state.history.pop();
+  }
+
+  function schedule(type, at, data) {
+    const event = {
+      id: state.nextEventId++,
+      type,
+      at,
+      data: data || {}
+    };
+    state.eventQueue.push(event);
+    state.eventQueue.sort((a, b) => a.at - b.at || a.id - b.id);
+    return event;
+  }
+
+  function popNextEvent() {
+    return state.eventQueue.shift();
+  }
+
+  function peekNextEvent() {
+    return state.eventQueue[0] || null;
+  }
+
+  function removeFutureEvents(type) {
+    state.eventQueue = state.eventQueue.filter(event => event.type !== type);
+  }
+
+  function randomNormal() {
+    let u = 0;
+    let v = 0;
+    while (u === 0) u = Math.random();
+    while (v === 0) v = Math.random();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+  }
+
+  function sampleTaskDurationMs() {
+    const mean = Math.max(0.1, param('durationMeanSec'));
+    const stdDev = Math.max(0, param('durationStdDevSec'));
+    const min = Math.max(0.1, param('durationMinSec'));
+    const max = Math.max(min, param('durationMaxSec'));
+    const sample = stdDev === 0 ? mean : mean + randomNormal() * stdDev;
+    return clamp(sample, min, max) * 1000;
+  }
+
+  function sampleInterarrivalMs() {
+    const rate = Math.max(0, param('arrivalRate'));
+    if (rate <= 0) return Infinity;
+    let u = 0;
+    while (u === 0) u = Math.random();
+    return (-Math.log(u) / rate) * 1000;
+  }
+
+  function scheduleNextArrival(fromMs) {
+    removeFutureEvents('arrival');
+    const delay = sampleInterarrivalMs();
+    if (Number.isFinite(delay)) schedule('arrival', fromMs + delay);
+  }
+
+  function scheduleNextCadence(fromMs) {
+    removeFutureEvents('cadence');
+    schedule('cadence', fromMs + Math.max(1000, msParam('cadenceSec')));
+  }
+
+  function getTotalSlots() {
+    return state.consumers.reduce((sum, consumer) => sum + consumer.slots.length, 0);
+  }
+
+  function getBusySlots() {
+    return state.consumers.reduce((sum, consumer) => {
+      return sum + consumer.slots.filter(slot => slot !== null).length;
+    }, 0);
+  }
+
+  function normalizeConsumerCount(value) {
+    const numeric = Number.isFinite(value) ? value : 0;
+    return Math.max(0, Math.round(numeric));
+  }
+
+  function minConsumerCount() {
+    return intParam('minConsumers');
+  }
+
+  function maxConsumerCount() {
+    return Math.max(1, intParam('maxConsumers'));
+  }
+
+  function clampPlannedConsumerCount(value) {
+    return clamp(normalizeConsumerCount(value), minConsumerCount(), maxConsumerCount());
+  }
+
+  function boundPlannedConsumerUpdate(value, current) {
+    const normalized = normalizeConsumerCount(value);
+    if (normalized > current) return Math.min(normalized, maxConsumerCount());
+    if (normalized < current) return Math.max(normalized, minConsumerCount());
+    return current;
+  }
+
+  function initialConsumerCount() {
+    return clampPlannedConsumerCount(intParam('initialConsumers'));
+  }
+
+  function getPlannedConsumerCount() {
+    const plannedConsumers = state.scaler.plannedConsumers;
+    return Number.isFinite(plannedConsumers) ? plannedConsumers : initialConsumerCount();
+  }
+
+  function setPlannedConsumerCount(value) {
+    state.scaler.plannedConsumers = normalizeConsumerCount(value);
+    return state.scaler.plannedConsumers;
+  }
+
+  function getLifecycleConsumerCount() {
+    return state.consumers.length + state.pendingConsumers.length;
+  }
+
+  function findFreeSlot() {
+    for (const consumer of state.consumers) {
+      const slotIndex = consumer.slots.findIndex(slot => slot === null);
+      if (slotIndex !== -1) return { consumer, slotIndex };
+    }
+    return null;
+  }
+
+  function createActiveConsumer(reason) {
+    const consumer = {
+      id: state.nextConsumerId++,
+      createdAt: state.simTimeMs,
+      slots: Array(Math.max(1, intParam('slotsPerConsumer'))).fill(null)
+    };
+    state.consumers.push(consumer);
+    if (reason) logEvent('scale up', 'Consumer #' + consumer.id + ' is active: ' + reason, 'scale-up');
+    return consumer;
+  }
+
+  function activatePendingConsumer(pending) {
+    const consumer = {
+      id: pending.id,
+      createdAt: state.simTimeMs,
+      slots: Array(pending.slotsPerConsumer).fill(null)
+    };
+    state.pendingConsumers = state.pendingConsumers.filter(item => item.id !== pending.id);
+    state.consumers.push(consumer);
+    logEvent('scale up', 'Consumer #' + consumer.id + ' is accepting tasks after ' +
+      formatTime(state.simTimeMs - pending.plannedAt) + ' spin-up', 'scale-up');
+    const dispatched = drainBacklog();
+    if (dispatched > 0) {
+      logEvent('decision', 'Dispatched ' + dispatched + ' backlog item(s) to newly ready capacity', 'decision');
+    }
+    return consumer;
+  }
+
+  function startConsumerAfterPlannedIncrease(reason) {
+    const spinUpMs = msParam('consumerSpinUpSec');
+    const pending = {
+      id: state.nextConsumerId++,
+      plannedAt: state.simTimeMs,
+      readyAt: state.simTimeMs + spinUpMs,
+      slotsPerConsumer: Math.max(1, intParam('slotsPerConsumer'))
+    };
+    logEvent('scale up', 'Consumer #' + pending.id + ' will start after planned count update: ' + reason +
+      (spinUpMs > 0 ? '; ready in ' + formatTime(spinUpMs) : '; ready now'), 'scale-up');
+    if (spinUpMs <= EPSILON_MS) {
+      activatePendingConsumer(pending);
+    } else {
+      state.pendingConsumers.push(pending);
+      schedule('consumer-ready', pending.readyAt, { consumerId: pending.id });
+    }
+    return pending;
+  }
+
+  function applyPlannedDecrease(reason) {
+    if (getLifecycleConsumerCount() <= getPlannedConsumerCount()) return false;
+    const pendingTarget = state.pendingConsumers
+      .slice()
+      .sort((a, b) => b.plannedAt - a.plannedAt || b.id - a.id)[0];
+
+    if (pendingTarget) {
+      state.pendingConsumers = state.pendingConsumers.filter(consumer => consumer.id !== pendingTarget.id);
+      state.eventQueue = state.eventQueue.filter(event => {
+        return event.type !== 'consumer-ready' || event.data.consumerId !== pendingTarget.id;
+      });
+      logEvent('scale down', 'Cancelled starting consumer #' + pendingTarget.id + ': ' + reason, 'scale-down');
+      return true;
+    }
+
+    if (state.consumers.length === 0) {
+      return true;
+    }
+
+    const target = state.consumers
+      .slice()
+      .sort((a, b) => b.createdAt - a.createdAt || b.id - a.id)[0];
+    const interrupted = target.slots
+      .filter(slot => slot !== null)
+      .map(slot => ({ id: slot.taskId, arrivedAt: slot.arrivedAt }));
+    state.consumers = state.consumers.filter(consumer => consumer.id !== target.id);
+    if (interrupted.length > 0) {
+      state.backlog = interrupted.concat(state.backlog);
+    }
+    logEvent('scale down', 'Stopped consumer #' + target.id + ': ' + reason +
+      (interrupted.length > 0 ? '; requeued ' + interrupted.length + ' in-flight task(s)' : ''), 'scale-down');
+    drainBacklog();
+    return true;
+  }
+
+  function updatePlannedConsumerCount(nextCount, reason) {
+    const previousPlanned = getPlannedConsumerCount();
+    const nextPlanned = boundPlannedConsumerUpdate(nextCount, previousPlanned);
+    const delta = nextPlanned - previousPlanned;
+    if (delta === 0) {
+      return {
+        changed: false,
+        previousPlanned,
+        nextPlanned,
+        delta
+      };
+    }
+
+    setPlannedConsumerCount(nextPlanned);
+    logEvent(delta > 0 ? 'scale up' : 'scale down',
+      'Updated planned consumers from ' + previousPlanned + ' to ' + nextPlanned + ': ' + reason,
+      delta > 0 ? 'scale-up' : 'scale-down');
+
+    if (delta > 0) {
+      for (let i = 0; i < delta; i += 1) startConsumerAfterPlannedIncrease(reason);
+    } else {
+      for (let i = 0; i < Math.abs(delta); i += 1) applyPlannedDecrease(reason);
+    }
+
+    return {
+      changed: true,
+      previousPlanned,
+      nextPlanned,
+      delta
+    };
+  }
+
+  function assignTaskToSlot(task, consumer, slotIndex, source) {
+    const waitMs = state.simTimeMs - task.arrivedAt;
+    const durationMs = sampleTaskDurationMs();
+    consumer.slots[slotIndex] = {
+      taskId: task.id,
+      startedAt: state.simTimeMs,
+      arrivedAt: task.arrivedAt,
+      durationMs,
+      source
+    };
+    state.dispatchTimes.push(state.simTimeMs);
+    if (source === 'backlog') {
+      state.stats.totalWaitMs += waitMs;
+      state.stats.waits += 1;
+      state.waitSamplesMs.push(waitMs);
+      if (state.waitSamplesMs.length > 500) state.waitSamplesMs.shift();
+    }
+    schedule('completion', state.simTimeMs + durationMs, {
+      consumerId: consumer.id,
+      slotIndex,
+      taskId: task.id
+    });
+  }
+
+  function drainBacklog() {
+    let dispatched = 0;
+    while (state.backlog.length > 0) {
+      const free = findFreeSlot();
+      if (!free) break;
+      const task = state.backlog.shift();
+      assignTaskToSlot(task, free.consumer, free.slotIndex, 'backlog');
+      dispatched += 1;
+    }
+    return dispatched;
+  }
+
+  function trimMetricWindows() {
+    const cutoff = state.simTimeMs - Math.max(1000, msParam('rateWindowSec'));
+    state.arrivalTimes = state.arrivalTimes.filter(t => t >= cutoff);
+    state.dispatchTimes = state.dispatchTimes.filter(t => t >= cutoff);
+  }
+
+  function getRates() {
+    trimMetricWindows();
+    const windowSec = Math.max(1, param('rateWindowSec'));
+    return {
+      arrivalRate: state.arrivalTimes.length / windowSec,
+      dispatchRate: state.dispatchTimes.length / windowSec
+    };
+  }
+
+  function getScaleMetrics(rateOverride) {
+    const rates = rateOverride || getRates();
+    return {
+      backlog: state.backlog.length,
+      arrivalRate: rates.arrivalRate,
+      dispatchRate: rates.dispatchRate
+    };
+  }
+
+  function ewmaAlpha() {
+    return clamp(param('ewmaAlphaPct') / 100, 0.01, 1);
+  }
+
+  function updateEwma(rates) {
+    const alpha = ewmaAlpha();
+    if (!state.scaler.ewmaInitialized) {
+      state.scaler.ewmaArrivalRate = rates.arrivalRate;
+      state.scaler.ewmaDispatchRate = rates.dispatchRate;
+      state.scaler.ewmaInitialized = true;
+      return;
+    }
+    state.scaler.ewmaArrivalRate =
+      alpha * rates.arrivalRate + (1 - alpha) * state.scaler.ewmaArrivalRate;
+    state.scaler.ewmaDispatchRate =
+      alpha * rates.dispatchRate + (1 - alpha) * state.scaler.ewmaDispatchRate;
+  }
+
+  function maybeSnapEwmaToZero(rawMetrics) {
+    if (rawMetrics.backlog > 0) return false;
+    if (rawMetrics.arrivalRate > IDLE_RATE_EPSILON) return false;
+    if (rawMetrics.dispatchRate > IDLE_RATE_EPSILON) return false;
+    if (state.scaler.ewmaArrivalRate === 0 && state.scaler.ewmaDispatchRate === 0) return false;
+
+    state.scaler.ewmaArrivalRate = 0;
+    state.scaler.ewmaDispatchRate = 0;
+    logEvent('decision',
+      'cadence idle snap-to-zero: no backlog, arrivals, or dispatches; reset EWMA rates to 0.00/s',
+      'decision');
+    return true;
+  }
+
+  function initialPerConsumerCapacity() {
+    return Math.max(0.01, param('initialPerConsumerCapacity'));
+  }
+
+  function estimatedPerConsumerCapacity() {
+    const estimate = state.scaler.ewmaPerConsumerCapacity;
+    return Number.isFinite(estimate) && estimate > 0 ? estimate : initialPerConsumerCapacity();
+  }
+
+  function materialBacklogThreshold() {
+    return Math.max(1, intParam('materialBacklogThreshold'));
+  }
+
+  function updatePerConsumerCapacityFromSaturation(reason, rates, context) {
+    const plannedConsumers = getPlannedConsumerCount();
+    if (plannedConsumers <= 0 || rates.dispatchRate <= 0) return false;
+
+    const observedCapacity = rates.dispatchRate / plannedConsumers;
+    if (!Number.isFinite(observedCapacity) || observedCapacity <= 0) return false;
+
+    const previousEstimate = estimatedPerConsumerCapacity();
+    const alpha = ewmaAlpha();
+    state.scaler.ewmaPerConsumerCapacity =
+      alpha * observedCapacity + (1 - alpha) * previousEstimate;
+
+    logEvent('decision', reason + ' capacity sample: observed=' +
+      observedCapacity.toFixed(2) + '/s per consumer, estimate=' +
+      state.scaler.ewmaPerConsumerCapacity.toFixed(2) + '/s per consumer' +
+      (context ? ', ' + context : ''), 'decision');
+    return true;
+  }
+
+  function targetBacklogDrainRate() {
+    return Math.max(0, param('targetBacklogDrainRate'));
+  }
+
+  function utilizationTarget() {
+    return clamp(param('utilizationTargetPct') / 100, 0.01, 1);
+  }
+
+  function halfinWhittBeta() {
+    return Math.max(0, param('halfinWhittBeta'));
+  }
+
+  function computeScalePlan(metrics) {
+    const minConsumers = intParam('minConsumers');
+    const maxConsumers = Math.max(1, intParam('maxConsumers'));
+    const plannedConsumers = getPlannedConsumerCount();
+    const catchUpRate = metrics.backlog > 0 ? targetBacklogDrainRate() : 0;
+    const requiredRate = metrics.arrivalRate + catchUpRate;
+    const perConsumerCapacity = estimatedPerConsumerCapacity();
+    const offeredLoad = requiredRate > 0 ? requiredRate / perConsumerCapacity : 0;
+    const baseConsumers = offeredLoad > 0 ? Math.ceil(offeredLoad) : 0;
+    const targetUtilization = utilizationTarget();
+    const utilizationDesired = offeredLoad > 0 ? Math.ceil(offeredLoad / targetUtilization) : 0;
+    const beta = halfinWhittBeta();
+    const halfinWhittDesired = offeredLoad > 0 ? Math.ceil(offeredLoad + beta * Math.sqrt(offeredLoad)) : 0;
+    const spareConsumers = Math.max(
+      0,
+      utilizationDesired - baseConsumers,
+      halfinWhittDesired - baseConsumers
+    );
+    const rawDesiredConsumers = baseConsumers + spareConsumers;
+    return {
+      desiredConsumers: clamp(rawDesiredConsumers, minConsumers, maxConsumers),
+      rawDesiredConsumers,
+      plannedConsumers,
+      catchUpRate,
+      requiredRate,
+      perConsumerCapacity,
+      offeredLoad,
+      baseConsumers,
+      targetUtilization,
+      utilizationDesired,
+      halfinWhittBeta: beta,
+      halfinWhittDesired,
+      spareConsumers
+    };
+  }
+
+  function formatScaleInputs(metrics, scalePlan) {
+    return ', backlog=' + metrics.backlog +
+      ', arrivals=' + metrics.arrivalRate.toFixed(2) + '/s' +
+      ', dispatches=' + metrics.dispatchRate.toFixed(2) + '/s' +
+      ', backlog catch-up=' + scalePlan.catchUpRate.toFixed(2) + '/s' +
+      ', required=' + scalePlan.requiredRate.toFixed(2) + '/s' +
+      ', capacity=' + scalePlan.perConsumerCapacity.toFixed(2) + '/s per consumer' +
+      ', load=' + scalePlan.offeredLoad.toFixed(2) +
+      ', base=' + scalePlan.baseConsumers +
+      ', util desired=' + scalePlan.utilizationDesired +
+      ' @ ' + (scalePlan.targetUtilization * 100).toFixed(0) + '%' +
+      ', HW desired=' + scalePlan.halfinWhittDesired +
+      ' beta=' + scalePlan.halfinWhittBeta.toFixed(2) +
+      ', spare=' + scalePlan.spareConsumers +
+      ', raw desired=' + scalePlan.rawDesiredConsumers;
+  }
+
+  function maybeScaleUp(trigger, metrics, scalePlan) {
+    const maxConsumers = Math.max(1, intParam('maxConsumers'));
+    const cooldownMs = msParam('scaleUpCooldownSec');
+    const maxStep = Math.max(1, intParam('maxScaleUpStep'));
+    const current = scalePlan.plannedConsumers;
+    const desired = scalePlan.desiredConsumers;
+
+    if (state.simTimeMs - state.scaler.lastScaleUpMs < cooldownMs) {
+      const wait = cooldownMs - (state.simTimeMs - state.scaler.lastScaleUpMs);
+      const text = trigger + ': scale-up blocked by cooldown for ' + formatTime(wait) +
+        '; desired=' + desired + ', current=' + current +
+        formatScaleInputs(metrics, scalePlan);
+      state.scaler.lastDecisionText = text;
+      logEvent('blocked', text, 'blocked');
+      return false;
+    }
+
+    const addCount = Math.min(maxStep, desired - current, maxConsumers - current);
+    const update = updatePlannedConsumerCount(current + addCount,
+      trigger + ' desired=' + desired + formatScaleInputs(metrics, scalePlan));
+    if (!update.changed) {
+      const text = trigger + ': scale-up blocked; no planned-consumer headroom' +
+        '; desired=' + desired + ', current=' + current +
+        formatScaleInputs(metrics, scalePlan);
+      state.scaler.lastDecisionText = text;
+      logEvent('blocked', text, 'blocked');
+      return false;
+    }
+    state.scaler.lastScaleUpMs = state.simTimeMs;
+    state.scaler.lastDecisionText = trigger + ': updated planned consumers from ' +
+      update.previousPlanned + ' to ' + update.nextPlanned;
+    return true;
+  }
+
+  function maybeScaleUpFromNoSync() {
+    const maxConsumers = Math.max(1, intParam('maxConsumers'));
+    const cooldownMs = msParam('scaleUpCooldownSec');
+    const current = getPlannedConsumerCount();
+
+    if (current >= maxConsumers) {
+      const text = 'no-sync: scale-up blocked; max consumers reached (' + current + ')';
+      state.scaler.lastDecisionText = text;
+      logEvent('blocked', text, 'blocked');
+      return false;
+    }
+
+    if (state.simTimeMs - state.scaler.lastScaleUpMs < cooldownMs) {
+      const wait = cooldownMs - (state.simTimeMs - state.scaler.lastScaleUpMs);
+      const text = 'no-sync: scale-up blocked by cooldown for ' + formatTime(wait);
+      state.scaler.lastDecisionText = text;
+      logEvent('blocked', text, 'blocked');
+      return false;
+    }
+
+    const update = updatePlannedConsumerCount(current + 1, 'no-sync match observed; all existing slots were busy');
+    if (!update.changed) {
+      const text = 'no-sync: scale-up blocked; no planned-consumer headroom';
+      state.scaler.lastDecisionText = text;
+      logEvent('blocked', text, 'blocked');
+      return false;
+    }
+    state.scaler.lastScaleUpMs = state.simTimeMs;
+    state.scaler.lastDecisionText = 'no-sync: updated planned consumers from ' +
+      update.previousPlanned + ' to ' + update.nextPlanned;
+    return true;
+  }
+
+  function maybeScaleDown(trigger, metrics, scalePlan) {
+    const cooldownMs = msParam('scaleDownCooldownSec');
+    const quietMs = msParam('scaleDownQuietSec');
+    const minConsumers = intParam('minConsumers');
+    const current = scalePlan.plannedConsumers;
+    const desired = scalePlan.desiredConsumers;
+    const scaleInputs = formatScaleInputs(metrics, scalePlan);
+
+    if (current <= minConsumers) {
+      const text = trigger + ': hold scale-down from ' + current + ' to desired=' + desired +
+        '; already at min planned consumers (' + minConsumers + ')' + scaleInputs;
+      state.scaler.lastDecisionText = text;
+      logEvent('decision', text, 'decision');
+      return false;
+    }
+    if (state.simTimeMs - state.scaler.lastNoSyncMs < quietMs) {
+      const wait = quietMs - (state.simTimeMs - state.scaler.lastNoSyncMs);
+      const text = trigger + ': hold scale-down from ' + current + ' to desired=' + desired +
+        '; no-sync quiet period has ' + formatTime(wait) + ' left' +
+        scaleInputs;
+      state.scaler.lastDecisionText = text;
+      logEvent('decision', text, 'decision');
+      return false;
+    }
+    if (state.simTimeMs - state.scaler.lastScaleDownMs < cooldownMs) {
+      const wait = cooldownMs - (state.simTimeMs - state.scaler.lastScaleDownMs);
+      const text = trigger + ': hold scale-down from ' + current + ' to desired=' + desired +
+        '; cooldown has ' + formatTime(wait) + ' left' +
+        scaleInputs;
+      state.scaler.lastDecisionText = text;
+      logEvent('decision', text, 'decision');
+      return false;
+    }
+
+    const update = updatePlannedConsumerCount(current - 1,
+      'desired scale ' + desired + ' is below current ' + current + scaleInputs);
+    if (update.changed) {
+      state.scaler.lastScaleDownMs = state.simTimeMs;
+      state.scaler.lastDecisionText = trigger + ': updated planned consumers from ' +
+        update.previousPlanned + ' to ' + update.nextPlanned + '; desired=' + desired + scaleInputs;
+      return true;
+    }
+    state.scaler.lastDecisionText = trigger + ': hold scale-down from ' + current +
+      ' to desired=' + desired + '; planned count cannot be reduced' + scaleInputs;
+    logEvent('decision', state.scaler.lastDecisionText, 'decision');
+    return false;
+  }
+
+  function runScalingDecision(trigger, metrics) {
+    const scalePlan = computeScalePlan(metrics);
+    const current = scalePlan.plannedConsumers;
+    const desired = scalePlan.desiredConsumers;
+
+    if (desired > current) {
+      maybeScaleUp(trigger, metrics, scalePlan);
+      return;
+    }
+    if (desired < current) {
+      maybeScaleDown(trigger, metrics, scalePlan);
+      return;
+    }
+    const text = trigger + ': hold at ' + current + ' consumers; desired=' + desired +
+      formatScaleInputs(metrics, scalePlan);
+    state.scaler.lastDecisionText = text;
+    logEvent('decision', text, 'decision');
+  }
+
+  function processArrival(data) {
+    const count = data.count || 1;
+    for (let i = 0; i < count; i += 1) {
+      const task = {
+        id: state.nextTaskId++,
+        arrivedAt: state.simTimeMs
+      };
+      state.arrivalTimes.push(state.simTimeMs);
+      const free = findFreeSlot();
+      if (free) {
+        state.stats.syncMatches += 1;
+        assignTaskToSlot(task, free.consumer, free.slotIndex, 'sync');
+        if (els.showMatchEvents.checked) {
+          logEvent('match', 'Task #' + task.id + ' sync matched to consumer #' + free.consumer.id, 'match');
+        }
+      } else {
+        state.stats.noSyncMatches += 1;
+        state.scaler.lastNoSyncMs = state.simTimeMs;
+        state.backlog.push(task);
+        logEvent('match', 'Task #' + task.id + ' no-sync matched; backlog=' + state.backlog.length, 'match');
+        updatePerConsumerCapacityFromSaturation('no-sync', getRates(), 'backlog=' + state.backlog.length);
+        maybeScaleUpFromNoSync();
+      }
+    }
+    if (!data.manual) scheduleNextArrival(state.simTimeMs);
+  }
+
+  function processCompletion(data) {
+    const consumer = state.consumers.find(item => item.id === data.consumerId);
+    if (!consumer) return;
+    const slot = consumer.slots[data.slotIndex];
+    if (!slot || slot.taskId !== data.taskId) return;
+    consumer.slots[data.slotIndex] = null;
+    state.stats.completed += 1;
+    if (state.backlog.length > 0) {
+      const task = state.backlog.shift();
+      assignTaskToSlot(task, consumer, data.slotIndex, 'backlog');
+    }
+  }
+
+  function processConsumerReady(data) {
+    const pending = state.pendingConsumers.find(item => item.id === data.consumerId);
+    if (!pending) return;
+    activatePendingConsumer(pending);
+  }
+
+  function processCadence() {
+    const rawMetrics = getScaleMetrics();
+    updateEwma(rawMetrics);
+    maybeSnapEwmaToZero(rawMetrics);
+    const smoothedMetrics = getScaleMetrics({
+      arrivalRate: state.scaler.ewmaArrivalRate,
+      dispatchRate: state.scaler.ewmaDispatchRate
+    });
+    const backlogThreshold = materialBacklogThreshold();
+    logEvent('decision', 'cadence input: backlog=' + rawMetrics.backlog +
+      ', raw arrivals=' + rawMetrics.arrivalRate.toFixed(2) + '/s' +
+      ', raw dispatches=' + rawMetrics.dispatchRate.toFixed(2) + '/s' +
+      ', ewma arrivals=' + smoothedMetrics.arrivalRate.toFixed(2) + '/s' +
+      ', ewma dispatches=' + smoothedMetrics.dispatchRate.toFixed(2) + '/s', 'decision');
+    if (rawMetrics.backlog >= backlogThreshold) {
+      updatePerConsumerCapacityFromSaturation('cadence backlog', rawMetrics,
+        'backlog=' + rawMetrics.backlog + ', threshold=' + backlogThreshold);
+    }
+    runScalingDecision('cadence', smoothedMetrics);
+    scheduleNextCadence(state.simTimeMs);
+  }
+
+  function processEvent(event) {
+    state.simTimeMs = event.at;
+    if (event.type === 'arrival') processArrival(event.data);
+    if (event.type === 'completion') processCompletion(event.data);
+    if (event.type === 'consumer-ready') processConsumerReady(event.data);
+    if (event.type === 'cadence') processCadence();
+    sampleCharts();
+  }
+
+  function processUntil(targetTimeMs, maxEvents) {
+    let processed = 0;
+    while (processed < maxEvents) {
+      const next = peekNextEvent();
+      if (!next || next.at > targetTimeMs + EPSILON_MS) break;
+      processEvent(popNextEvent());
+      processed += 1;
+    }
+    state.simTimeMs = Math.max(state.simTimeMs, targetTimeMs);
+    sampleCharts();
+    return processed;
+  }
+
+  function stepOneEvent() {
+    const next = popNextEvent();
+    if (!next) return;
+    processEvent(next);
+    state.targetTimeMs = state.simTimeMs;
+    render();
+  }
+
+  function initializeConsumers() {
+    const initial = getPlannedConsumerCount();
+    for (let i = 0; i < initial; i += 1) createActiveConsumer('');
+    state.history = [];
+  }
+
+  function reset() {
+    state.simTimeMs = 0;
+    state.targetTimeMs = 0;
+    state.lastFrameAt = null;
+    state.paused = true;
+    state.eventQueue = [];
+    state.nextEventId = 1;
+    state.nextTaskId = 1;
+    state.nextConsumerId = 1;
+    state.consumers = [];
+    state.pendingConsumers = [];
+    state.backlog = [];
+    state.arrivalTimes = [];
+    state.dispatchTimes = [];
+    state.waitSamplesMs = [];
+    state.history = [];
+    state.chartPoints = [];
+    state.lastChartSampleMs = -Infinity;
+    state.chartVersion = 0;
+    state.renderedChartVersion = -1;
+    state.stats = {
+      syncMatches: 0,
+      noSyncMatches: 0,
+      completed: 0,
+      totalWaitMs: 0,
+      waits: 0
+    };
+    state.scaler = {
+      lastScaleUpMs: -Infinity,
+      lastScaleDownMs: -Infinity,
+      lastNoSyncMs: -Infinity,
+      ewmaInitialized: false,
+      ewmaArrivalRate: 0,
+      ewmaDispatchRate: 0,
+      ewmaPerConsumerCapacity: initialPerConsumerCapacity(),
+      plannedConsumers: initialConsumerCount(),
+      lastDecisionText: 'No decisions yet'
+    };
+    initializeConsumers();
+    scheduleNextArrival(0);
+    scheduleNextCadence(0);
+    sampleCharts(true);
+    updateRunButton();
+    render();
+  }
+
+  function sampleCharts(force) {
+    if (!force && state.simTimeMs - state.lastChartSampleMs < CHART_SAMPLE_MS) return;
+    state.lastChartSampleMs = state.simTimeMs;
+    const rates = getRates();
+    const plannedConsumers = getPlannedConsumerCount();
+    const totalSlots = getTotalSlots();
+    const busySlots = getBusySlots();
+    state.chartPoints.push({
+      timeSec: state.simTimeMs / 1000,
+      consumers: state.consumers.length,
+      startingConsumers: state.pendingConsumers.length,
+      backlog: state.backlog.length,
+      busySlots,
+      slotUtilizationPct: totalSlots > 0 ? (busySlots / totalSlots) * 100 : 0,
+      arrivalRate: rates.arrivalRate,
+      dispatchRate: rates.dispatchRate,
+      perConsumerDispatchRate: plannedConsumers > 0 ? rates.dispatchRate / plannedConsumers : 0,
+      ewmaArrivalRate: state.scaler.ewmaArrivalRate,
+      ewmaDispatchRate: state.scaler.ewmaDispatchRate,
+      ewmaPerConsumerCapacity: estimatedPerConsumerCapacity()
+    });
+    if (state.chartPoints.length > MAX_CHART_POINTS) state.chartPoints.shift();
+    state.chartVersion += 1;
+  }
+
+  function makeDataset(label, color, formatValue) {
+    return {
+      label,
+      data: [],
+      borderColor: color,
+      backgroundColor: color,
+      borderWidth: 2,
+      pointRadius: 0,
+      pointHoverRadius: 4,
+      tension: 0.25,
+      fill: false,
+      formatValue
+    };
+  }
+
+  function makeChartOptions(formatTick, yBounds) {
+    const tickFormatter = formatTick || (value => value.toFixed(0));
+    const bounds = yBounds || {};
+    return {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: {
+          labels: {
+            color: '#687076',
+            boxWidth: 12,
+            padding: 12
+          }
+        },
+        tooltip: {
+          mode: 'index',
+          intersect: false,
+          callbacks: {
+            title(items) {
+              return items.length > 0 ? 'time: ' + items[0].label : '';
+            },
+            label(context) {
+              const formatter = context.dataset.formatValue || tickFormatter;
+              return context.dataset.label + ': ' + formatter(context.parsed.y);
+            }
+          }
+        }
+      },
+      scales: {
+        x: {
+          ticks: {
+            color: '#687076',
+            maxTicksLimit: 8
+          },
+          grid: { color: '#e9e1d2' }
+        },
+        y: {
+          beginAtZero: true,
+          min: bounds.min,
+          max: bounds.max,
+          ticks: {
+            color: '#687076',
+            callback: value => tickFormatter(Number(value))
+          },
+          grid: { color: '#e9e1d2' }
+        }
+      }
+    };
+  }
+
+  function initCharts() {
+    const ChartCtor = window.Chart;
+    if (!ChartCtor) return;
+
+    capacityChart = new ChartCtor(els.capacityChart, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [
+          makeDataset('consumers', '#0f766e', value => value.toFixed(0)),
+          makeDataset('starting', '#2563eb', value => value.toFixed(0)),
+          makeDataset('backlog', '#c2410c', value => value.toFixed(0)),
+          makeDataset('busy slots', '#b45309', value => value.toFixed(0))
+        ]
+      },
+      options: makeChartOptions(value => value.toFixed(0))
+    });
+
+    rateChart = new ChartCtor(els.rateChart, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [
+          makeDataset('raw arrivals', '#2563eb', value => value.toFixed(2) + '/s'),
+          makeDataset('raw dispatches', '#15803d', value => value.toFixed(2) + '/s'),
+          makeDataset('raw / consumer', '#0891b2', value => value.toFixed(2) + '/s'),
+          makeDataset('ewma arrivals', '#7c3aed', value => value.toFixed(2) + '/s'),
+          makeDataset('ewma dispatches', '#b45309', value => value.toFixed(2) + '/s'),
+          makeDataset('ewma / consumer', '#be185d', value => value.toFixed(2) + '/s')
+        ]
+      },
+      options: makeChartOptions(value => value.toFixed(1))
+    });
+
+    utilizationChart = new ChartCtor(els.utilizationChart, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [
+          makeDataset('slot utilization', '#7c3aed', value => value.toFixed(1) + '%')
+        ]
+      },
+      options: makeChartOptions(value => value.toFixed(0) + '%', { min: 0, max: 100 })
+    });
+  }
+
+  function updateChart(chart, extractors) {
+    if (!chart) return;
+    chart.data.labels = state.chartPoints.map(point => point.timeSec.toFixed(1) + 's');
+    chart.data.datasets.forEach((dataset, index) => {
+      dataset.data = state.chartPoints.map(extractors[index]);
+    });
+    chart.update('none');
+  }
+
+  function renderCharts() {
+    if (state.renderedChartVersion === state.chartVersion) return;
+    updateChart(capacityChart, [
+      point => point.consumers,
+      point => point.startingConsumers,
+      point => point.backlog,
+      point => point.busySlots
+    ]);
+    updateChart(rateChart, [
+      point => point.arrivalRate,
+      point => point.dispatchRate,
+      point => point.perConsumerDispatchRate,
+      point => point.ewmaArrivalRate,
+      point => point.ewmaDispatchRate,
+      point => point.ewmaPerConsumerCapacity
+    ]);
+    updateChart(utilizationChart, [
+      point => point.slotUtilizationPct
+    ]);
+    state.renderedChartVersion = state.chartVersion;
+    els.capacityChartLegend.textContent = 'hover for exact values';
+    els.rateChartLegend.textContent = 'hover for exact values';
+    els.utilizationChartLegend.textContent = 'hover for exact values';
+  }
+
+  function renderMetrics() {
+    const rates = getRates();
+    const totalSlots = getTotalSlots();
+    const busySlots = getBusySlots();
+    const utilization = totalSlots > 0 ? Math.round((busySlots / totalSlots) * 100) : 0;
+    const oldestBacklogMs = state.backlog.length > 0
+      ? state.simTimeMs - state.backlog[0].arrivedAt
+      : 0;
+    const meanWaitMs = state.stats.waits > 0 ? state.stats.totalWaitMs / state.stats.waits : 0;
+
+    els.metricTime.textContent = formatTime(state.simTimeMs);
+    els.metricPlannedConsumers.textContent = String(getPlannedConsumerCount());
+    els.metricConsumers.textContent = String(state.consumers.length);
+    els.metricStartingConsumers.textContent = String(state.pendingConsumers.length);
+    els.metricBacklog.textContent = String(state.backlog.length);
+    els.metricBusySlots.textContent = busySlots + '/' + totalSlots;
+    els.metricUtilization.textContent = utilization + '%';
+    els.metricOldestBacklog.textContent = formatTime(oldestBacklogMs);
+    els.metricArrivalRate.textContent = rates.arrivalRate.toFixed(2) + '/s';
+    els.metricDispatchRate.textContent = rates.dispatchRate.toFixed(2) + '/s';
+    els.metricEwmaArrivalRate.textContent = state.scaler.ewmaArrivalRate.toFixed(2) + '/s';
+    els.metricEwmaDispatchRate.textContent = state.scaler.ewmaDispatchRate.toFixed(2) + '/s';
+    els.metricSyncMatches.textContent = String(state.stats.syncMatches);
+    els.metricNoSyncMatches.textContent = String(state.stats.noSyncMatches);
+    els.metricCompleted.textContent = String(state.stats.completed);
+    els.metricMeanWait.textContent = formatTime(meanWaitMs);
+    els.slotSummary.textContent = busySlots + ' busy, ' + Math.max(0, totalSlots - busySlots) +
+      ' free, ' + getPlannedConsumerCount() + ' planned, ' +
+      state.pendingConsumers.length + ' starting, ' + state.backlog.length + ' backlog';
+  }
+
+  function renderConsumers() {
+    if (state.consumers.length === 0 && state.pendingConsumers.length === 0) {
+      els.consumersList.innerHTML = '<div class="empty-state">No consumers are running.</div>';
+      return;
+    }
+    const activeHtml = state.consumers.map(consumer => {
+      const busy = consumer.slots.filter(slot => slot !== null).length;
+      const slots = consumer.slots.map(slot => {
+        if (!slot) return '<span class="slot free" title="free"></span>';
+        const elapsed = state.simTimeMs - slot.startedAt;
+        const remaining = Math.max(0, slot.durationMs - elapsed);
+        const cls = slot.source === 'backlog' ? 'slot backlog' : 'slot busy';
+        return '<span class="' + cls + '" title="task #' + slot.taskId + ', remaining ' + formatTime(remaining) + '"></span>';
+      }).join('');
+      return '<article class="consumer">' +
+        '<div class="consumer-header">' +
+        '<span class="consumer-name">Consumer #' + consumer.id + '</span>' +
+        '<span class="consumer-meta">' + busy + '/' + consumer.slots.length + ' slots</span>' +
+        '</div>' +
+        '<div class="slots">' + slots + '</div>' +
+        '</article>';
+    }).join('');
+    const pendingHtml = state.pendingConsumers.map(consumer => {
+      const remaining = Math.max(0, consumer.readyAt - state.simTimeMs);
+      return '<article class="consumer pending">' +
+        '<div class="consumer-header">' +
+        '<span class="consumer-name">Consumer #' + consumer.id + '</span>' +
+        '<span class="consumer-meta">starting, ready in ' + formatTime(remaining) + '</span>' +
+        '</div>' +
+        '<div class="slots"><span class="slot pending" title="starting"></span></div>' +
+        '</article>';
+    }).join('');
+    els.consumersList.innerHTML = activeHtml + pendingHtml;
+  }
+
+  function renderHistory() {
+    const showMatches = els.showMatchEvents.checked;
+    const visible = state.history.filter(entry => showMatches || entry.kind !== 'match');
+    if (visible.length === 0) {
+      els.history.innerHTML = '<div class="empty-state">No scaler events yet.</div>';
+      return;
+    }
+    els.history.innerHTML = visible.slice(0, 150).map(entry => {
+      return '<div class="history-entry ' + entry.className + '">' +
+        '<span class="time">' + formatTime(entry.at) + '</span>' +
+        '<span class="kind">' + entry.kind + '</span>' +
+        '<span class="message">' + entry.message + '</span>' +
+        '</div>';
+    }).join('');
+  }
+
+  function render() {
+    renderMetrics();
+    renderConsumers();
+    renderHistory();
+    renderCharts();
+  }
+
+  function updateRunButton() {
+    els.runPauseBtn.textContent = state.paused ? 'Start' : 'Pause';
+  }
+
+  function animationLoop(now) {
+    if (state.lastFrameAt === null) state.lastFrameAt = now;
+    const deltaRealMs = now - state.lastFrameAt;
+    state.lastFrameAt = now;
+
+    if (!state.paused) {
+      const speed = clamp(param('runSpeed'), 0.1, 500);
+      state.targetTimeMs += deltaRealMs * speed;
+      processUntil(state.targetTimeMs, 5000);
+    }
+    render();
+    window.requestAnimationFrame(animationLoop);
+  }
+
+  function bindEvents() {
+    els.runPauseBtn.addEventListener('click', function () {
+      state.paused = !state.paused;
+      state.targetTimeMs = state.simTimeMs;
+      state.lastFrameAt = null;
+      updateRunButton();
+    });
+    els.stepBtn.addEventListener('click', function () {
+      state.paused = true;
+      updateRunButton();
+      stepOneEvent();
+    });
+    els.resetBtn.addEventListener('click', reset);
+    els.addOneBtn.addEventListener('click', function () {
+      schedule('arrival', state.simTimeMs, { manual: true });
+      processUntil(state.simTimeMs, 1000);
+      render();
+    });
+    els.burstBtn.addEventListener('click', function () {
+      schedule('arrival', state.simTimeMs, { manual: true, count: Math.max(1, intParam('burstSize')) });
+      processUntil(state.simTimeMs, 5000);
+      render();
+    });
+    els.showMatchEvents.addEventListener('change', renderHistory);
+
+    for (const id of ['arrivalRate', 'cadenceSec']) {
+      document.getElementById(id).addEventListener('change', function () {
+        scheduleNextArrival(state.simTimeMs);
+        scheduleNextCadence(state.simTimeMs);
+      });
+    }
+  }
+
+  cacheElements();
+  initCharts();
+  bindEvents();
+  reset();
+  window.requestAnimationFrame(animationLoop);
+})();

--- a/docs/simulators/workerset-ewma/index.html
+++ b/docs/simulators/workerset-ewma/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EWMA queue consumer autoscaling simulator</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <h1>EWMA queue consumer autoscaling simulator</h1>
+      <p>Discrete-event model for sync matches, backlog pressure, and latency-biased scaling decisions.</p>
+    </div>
+    <div class="run-controls" aria-label="Simulation controls">
+      <button type="button" id="runPauseBtn">Start</button>
+      <button type="button" id="stepBtn" class="secondary">Step event</button>
+      <button type="button" id="resetBtn" class="secondary">Reset</button>
+    </div>
+  </header>
+
+  <details class="rules" open>
+    <summary>Scaling rules</summary>
+    <div class="rule-grid">
+      <section>
+        <h2>No-sync decision</h2>
+        <p>Every arrival first tries a sync match into a free slot. If every slot is busy, the item enters backlog and the algorithm immediately increments the planned consumer count, subject only to scale-up cooldown and max consumers. New consumers begin accepting work after the configured spin-up delay.</p>
+      </section>
+      <section>
+        <h2>Cadence decision</h2>
+        <p>Every cadence tick the algorithm computes one desired consumer count from EWMA arrivals, backlog catch-up, estimated per-consumer capacity, utilization target, and Halfin-Whitt spare capacity. When the queue and raw rate windows are empty, residual EWMA arrival and dispatch rates snap to zero before the target is computed.</p>
+      </section>
+      <section>
+        <h2>Scale down</h2>
+        <p>The planned consumer count is decremented when desired capacity is below current capacity, no no-sync match has happened recently, and scale-down cooldown has elapsed. If active capacity is stopped, in-flight work is returned to backlog.</p>
+      </section>
+    </div>
+  </details>
+
+  <div class="layout">
+    <aside class="panel config-panel">
+      <section>
+        <h2>Workload</h2>
+        <label class="control">
+          <span>Arrival rate (/s)</span>
+          <input id="arrivalRate" type="number" min="0" max="500" step="0.1" value="2" />
+        </label>
+        <label class="control">
+          <span>Arrival burst size</span>
+          <input id="burstSize" type="number" min="1" max="1000" step="1" value="25" />
+        </label>
+        <label class="control">
+          <span>Run speed (x)</span>
+          <input id="runSpeed" type="number" min="0.1" max="500" step="1" value="10" />
+        </label>
+        <div class="button-row">
+          <button type="button" id="addOneBtn" class="secondary">Add one</button>
+          <button type="button" id="burstBtn" class="secondary">Burst</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Task Duration</h2>
+        <label class="control">
+          <span>Normal mean (s)</span>
+          <input id="durationMeanSec" type="number" min="0.1" max="600" step="0.1" value="7.5" />
+        </label>
+        <label class="control">
+          <span>Std dev (s)</span>
+          <input id="durationStdDevSec" type="number" min="0" max="300" step="0.1" value="1.25" />
+        </label>
+        <label class="control">
+          <span>Clamp min (s)</span>
+          <input id="durationMinSec" type="number" min="0.1" max="600" step="0.1" value="5" />
+        </label>
+        <label class="control">
+          <span>Clamp max (s)</span>
+          <input id="durationMaxSec" type="number" min="0.1" max="600" step="0.1" value="10" />
+        </label>
+      </section>
+
+      <section>
+        <h2>Simulator Capacity</h2>
+        <label class="control">
+          <span>Initial consumer count</span>
+          <input id="initialConsumers" type="number" min="0" max="500" step="1" value="1" />
+        </label>
+        <label class="control">
+          <span>Slots per consumer</span>
+          <input id="slotsPerConsumer" type="number" min="1" max="100" step="1" value="5" />
+        </label>
+        <label class="control">
+          <span>Consumer spin-up (s)</span>
+          <input id="consumerSpinUpSec" type="number" min="0" max="600" step="0.5" value="2" />
+        </label>
+      </section>
+
+      <section>
+        <h2>Measurement</h2>
+        <label class="control">
+          <span>Rate window (s)</span>
+          <input id="rateWindowSec" type="number" min="1" max="600" step="1" value="30" />
+        </label>
+      </section>
+
+      <section>
+        <h2>Scaler</h2>
+        <label class="control">
+          <span>Min consumers</span>
+          <input id="minConsumers" type="number" min="0" max="500" step="1" value="0" />
+        </label>
+        <label class="control">
+          <span>Max consumers</span>
+          <input id="maxConsumers" type="number" min="1" max="500" step="1" value="30" />
+        </label>
+        <label class="control">
+          <span>Cadence (s)</span>
+          <input id="cadenceSec" type="number" min="1" max="600" step="1" value="30" />
+        </label>
+        <label class="control">
+          <span>EWMA alpha (%)</span>
+          <input id="ewmaAlphaPct" type="number" min="1" max="100" step="1" value="45" />
+        </label>
+        <label class="control">
+          <span>Initial per-consumer capacity (/s)</span>
+          <input id="initialPerConsumerCapacity" type="number" min="0.01" max="100" step="0.1" value="2.0" />
+        </label>
+        <label class="control">
+          <span>Target backlog drain rate (/s)</span>
+          <input id="targetBacklogDrainRate" type="number" min="0" max="100" step="0.1" value="2.0" />
+        </label>
+        <label class="control">
+          <span>Material backlog threshold</span>
+          <input id="materialBacklogThreshold" type="number" min="1" max="10000" step="1" value="1" />
+        </label>
+        <label class="control">
+          <span>Utilization target (%)</span>
+          <input id="utilizationTargetPct" type="number" min="1" max="100" step="1" value="80" />
+        </label>
+        <label class="control">
+          <span>Halfin-Whitt beta</span>
+          <input id="halfinWhittBeta" type="number" min="0" max="10" step="0.1" value="0.5" />
+        </label>
+        <label class="control">
+          <span>Max scale-up step</span>
+          <input id="maxScaleUpStep" type="number" min="1" max="500" step="1" value="4" />
+        </label>
+        <label class="control">
+          <span>Scale-up cooldown (s)</span>
+          <input id="scaleUpCooldownSec" type="number" min="0" max="600" step="0.5" value="2" />
+        </label>
+        <label class="control">
+          <span>Scale-down cooldown (s)</span>
+          <input id="scaleDownCooldownSec" type="number" min="0" max="3600" step="1" value="60" />
+        </label>
+        <label class="control">
+          <span>No-sync quiet (s)</span>
+          <input id="scaleDownQuietSec" type="number" min="0" max="3600" step="1" value="90" />
+        </label>
+      </section>
+    </aside>
+
+    <main class="main">
+      <section class="panel">
+        <h2>Current Scale State</h2>
+        <div class="metrics">
+          <div class="metric"><span>Sim time</span><strong id="metricTime">0.0s</strong></div>
+          <div class="metric"><span>Planned consumers</span><strong id="metricPlannedConsumers">0</strong></div>
+          <div class="metric"><span>Consumers</span><strong id="metricConsumers">0</strong></div>
+          <div class="metric"><span>Starting</span><strong id="metricStartingConsumers">0</strong></div>
+          <div class="metric"><span>Backlog</span><strong id="metricBacklog">0</strong></div>
+          <div class="metric"><span>Busy slots</span><strong id="metricBusySlots">0/0</strong></div>
+          <div class="metric"><span>Utilization</span><strong id="metricUtilization">0%</strong></div>
+          <div class="metric"><span>Oldest backlog</span><strong id="metricOldestBacklog">0.0s</strong></div>
+          <div class="metric"><span>Arrivals</span><strong id="metricArrivalRate">0.00/s</strong></div>
+          <div class="metric"><span>Dispatches</span><strong id="metricDispatchRate">0.00/s</strong></div>
+          <div class="metric"><span>EWMA arrivals</span><strong id="metricEwmaArrivalRate">0.00/s</strong></div>
+          <div class="metric"><span>EWMA dispatches</span><strong id="metricEwmaDispatchRate">0.00/s</strong></div>
+          <div class="metric"><span>Sync matches</span><strong id="metricSyncMatches">0</strong></div>
+          <div class="metric"><span>No-sync matches</span><strong id="metricNoSyncMatches">0</strong></div>
+          <div class="metric"><span>Completed</span><strong id="metricCompleted">0</strong></div>
+          <div class="metric"><span>Mean wait</span><strong id="metricMeanWait">0.0s</strong></div>
+        </div>
+      </section>
+
+      <section class="charts">
+        <div class="panel chart-panel">
+          <div class="panel-heading">
+            <h2>Consumers, Backlog, Slots</h2>
+            <span id="capacityChartLegend"></span>
+          </div>
+          <div class="chart-frame">
+            <canvas id="capacityChart"></canvas>
+          </div>
+        </div>
+        <div class="panel chart-panel">
+          <div class="panel-heading">
+            <h2>Flow Rates</h2>
+            <span id="rateChartLegend"></span>
+          </div>
+          <div class="chart-frame">
+            <canvas id="rateChart"></canvas>
+          </div>
+        </div>
+        <div class="panel chart-panel">
+          <div class="panel-heading">
+            <h2>Slot Utilization</h2>
+            <span id="utilizationChartLegend"></span>
+          </div>
+          <div class="chart-frame">
+            <canvas id="utilizationChart"></canvas>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-heading">
+          <h2>Consumer Processes</h2>
+          <span id="slotSummary">0 slots</span>
+        </div>
+        <div class="consumers" id="consumersList"></div>
+      </section>
+
+      <section class="panel log-panel">
+        <div class="panel-heading">
+          <h2>Event History</h2>
+          <label class="log-toggle">
+            <input id="showMatchEvents" type="checkbox" />
+            <span>show match events</span>
+          </label>
+        </div>
+        <div class="history" id="history"></div>
+      </section>
+    </main>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/simulators/workerset-ewma/styles.css
+++ b/docs/simulators/workerset-ewma/styles.css
@@ -1,0 +1,463 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f2ea;
+  --surface: #fffdf8;
+  --surface-strong: #f7efe1;
+  --ink: #202124;
+  --muted: #687076;
+  --border: #d7d0c2;
+  --grid: #e9e1d2;
+  --teal: #0f766e;
+  --blue: #2563eb;
+  --amber: #b45309;
+  --red: #c2410c;
+  --green: #15803d;
+  --violet: #7c3aed;
+  --shadow: 0 1px 2px rgba(32, 33, 36, 0.06);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 20px;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.45;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 1.35rem;
+  font-weight: 720;
+  letter-spacing: 0;
+}
+
+h2 {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  min-height: 36px;
+  border: 1px solid var(--teal);
+  border-radius: 6px;
+  background: var(--teal);
+  color: white;
+  cursor: pointer;
+  font-size: 0.86rem;
+  font-weight: 700;
+  padding: 0 12px;
+}
+
+button:hover {
+  filter: brightness(1.04);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button.secondary {
+  background: var(--surface);
+  color: var(--ink);
+  border-color: var(--border);
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  max-width: 1560px;
+  margin: 0 auto 14px;
+}
+
+.topbar p {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.run-controls,
+.button-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.rules,
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.rules {
+  max-width: 1560px;
+  margin: 0 auto 16px;
+  padding: 12px 14px;
+}
+
+.rules summary {
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.rule-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+.rule-grid section {
+  border-left: 3px solid var(--teal);
+  padding-left: 12px;
+}
+
+.rule-grid p {
+  color: var(--muted);
+  font-size: 0.84rem;
+  margin-top: 6px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 310px minmax(0, 1fr);
+  gap: 16px;
+  max-width: 1560px;
+  margin: 0 auto;
+}
+
+.panel {
+  padding: 14px;
+}
+
+.config-panel {
+  align-self: start;
+  display: grid;
+  gap: 18px;
+  position: sticky;
+  top: 16px;
+}
+
+.config-panel section {
+  display: grid;
+  gap: 8px;
+}
+
+.control {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) 90px;
+}
+
+.control span,
+.log-toggle span {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.control input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--ink);
+  min-height: 34px;
+  padding: 0 8px;
+}
+
+.control input:focus {
+  border-color: var(--teal);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.12);
+  outline: none;
+}
+
+.button-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.main {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.metrics {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(6, minmax(116px, 1fr));
+  margin-top: 10px;
+}
+
+.metric {
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  min-height: 72px;
+  padding: 10px;
+}
+
+.metric span {
+  color: var(--muted);
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  color: var(--teal);
+  display: block;
+  font-size: 1.32rem;
+  font-weight: 760;
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+}
+
+.charts {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.panel-heading {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.panel-heading span,
+.chart-legend {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.chart-frame {
+  background: #fffaf0;
+  border: 1px solid var(--grid);
+  border-radius: 6px;
+  height: 230px;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.chart-frame canvas {
+  display: block;
+  height: 100% !important;
+  width: 100% !important;
+}
+
+.consumers {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+}
+
+.consumer {
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 10px;
+}
+
+.consumer.pending {
+  border-style: dashed;
+}
+
+.consumer-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.consumer-name {
+  font-size: 0.86rem;
+  font-weight: 750;
+}
+
+.consumer-meta {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.slots {
+  display: grid;
+  gap: 5px;
+  grid-template-columns: repeat(auto-fill, minmax(18px, 1fr));
+}
+
+.slot {
+  aspect-ratio: 1;
+  border-radius: 5px;
+  border: 1px solid rgba(32, 33, 36, 0.08);
+  min-width: 18px;
+}
+
+.slot.free {
+  background: #c7ded7;
+}
+
+.slot.busy {
+  background: var(--amber);
+}
+
+.slot.backlog {
+  background: var(--red);
+}
+
+.slot.pending {
+  background: var(--blue);
+  opacity: 0.65;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
+
+.log-panel {
+  min-height: 260px;
+}
+
+.log-toggle {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.history {
+  display: grid;
+  gap: 6px;
+  max-height: 360px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.history-entry {
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  border-radius: 6px;
+  display: grid;
+  gap: 2px;
+  grid-template-columns: 70px minmax(95px, 140px) minmax(0, 1fr);
+  padding: 8px 10px;
+  background: #fffaf0;
+}
+
+.history-entry .time {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8rem;
+}
+
+.history-entry .kind {
+  font-size: 0.78rem;
+  font-weight: 760;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.history-entry .message {
+  color: var(--ink);
+  font-size: 0.84rem;
+}
+
+.history-entry.scale-up {
+  border-left-color: var(--green);
+}
+
+.history-entry.scale-down {
+  border-left-color: var(--red);
+}
+
+.history-entry.decision {
+  border-left-color: var(--blue);
+}
+
+.history-entry.match {
+  border-left-color: var(--amber);
+}
+
+.history-entry.blocked {
+  border-left-color: var(--violet);
+}
+
+@media (max-width: 1180px) {
+  .layout,
+  .charts,
+  .rule-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .config-panel {
+    position: static;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 12px;
+  }
+
+  .topbar,
+  .panel-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .run-controls {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .history-entry {
+    grid-template-columns: 1fr;
+  }
+
+  .control {
+    grid-template-columns: 1fr 82px;
+  }
+}


### PR DESCRIPTION
Adds a browser-based discrete-event simulator under docs/simulators/service-ewma/ that models the EWMA-based queue consumer scaling algorithm, along with a SPEC.md documenting the algorithm's inputs, state, capacity estimate, no-sync decision, and cadence decision logic.

This EWMA algorithm it so far the best candidate for scaling worker set compute providers.
