### PR TITLE
Add worker set size metric and minor cleanups

### DIFF
--- a/wci/client/client.go
+++ b/wci/client/client.go
@@ -131,7 +131,7 @@ var _ Client = (*clientImpl)(nil)
 
 func (d *clientImpl) UpdateTaskQueueName(ctx context.Context, newTaskQueueName string) error {
 	if len(newTaskQueueName) == 0 {
-		return fmt.Errorf("Invalid task queue name")
+		return fmt.Errorf("invalid task queue name")
 	}
 
 	d.controllerTaskQueueName = newTaskQueueName
@@ -413,8 +413,7 @@ func (d *clientImpl) DeleteWorkerControllerInstance(
 		},
 	)
 	if err != nil {
-		var notFound *serviceerror.NotFound
-		if errors.As(err, &notFound) {
+		if _, ok := errors.AsType[*serviceerror.NotFound](err); ok {
 			// if the instance doesn't exist, nothing to do
 			return nil
 		}

--- a/wci/client/hook.go
+++ b/wci/client/hook.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"go.temporal.io/api/enums/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -51,7 +50,7 @@ var (
 )
 
 func (thf *taskHookFactoryImpl) Create(details *hooks.TaskHookFactoryCreateDetails) hooks.TaskHook {
-	if details == nil || details.Namespace == nil || details.Partition.Kind() == enums.TASK_QUEUE_KIND_STICKY {
+	if details == nil || details.Namespace == nil || details.Partition.Kind() == enumspb.TASK_QUEUE_KIND_STICKY {
 		return nil
 	}
 

--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -13,6 +13,9 @@ var (
 	ScaleUpThrottledCount = metrics.NewCounterDef(
 		"worker_controller_instance_scale_up_throttled_count",
 		metrics.WithDescription("The number of times a scale up was throttled for a worker controller instance."))
+	SetWorkerSetSizeCount = metrics.NewCounterDef(
+		"worker_controller_instance_set_workerset_size_count",
+		metrics.WithDescription("The number of times the worker set size was updated for a worker controller instance."))
 
 	WorkflowErrorCount = metrics.NewCounterDef(
 		"worker_controller_instance_workflow_error_count",

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -56,7 +56,7 @@ func TestInvokeComputeProviderValidComputeProvider() *computepb.ComputeProvider 
 	}
 }
 
-// TestInvokeComputeProviderInvalidProviderDetails provides an example invalid config for testing code to use
+// TestInvokeComputeProviderInvalidComputeProvider provides an example invalid config for testing code to use
 func TestInvokeComputeProviderInvalidComputeProvider() *computepb.ComputeProvider {
 	providerDetails := map[string]string{
 		configTestInvokeIllegalField: "something",

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -559,6 +559,8 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				// We are not setting stateChanged to true to avoid unneccessary CaNs here.
 			}
 		case scalingalgorithm.ActionTypeUpdateWorkerSetSize:
+			d.metrics.Counter(wcimetrics.SetWorkerSetSizeCount.Name()).Inc(1)
+
 			now := workflow.Now(ctx)
 			if err := workflow.ExecuteActivity(
 				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: UpdateWorkerSetSizeActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),


### PR DESCRIPTION
- Add SetWorkerSetSizeCount counter and increment it when handling UpdateWorkerSetSize actions.
- Use errors.AsType for NotFound check in DeleteWorkerControllerInstance and lowercase the task queue name error string.
- Drop duplicate enums import in hook.go and fix a stale doc comment in test_invoke.go.