### PR TITLE
Add deferred task-add scaling action

### DIFF
--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -13,6 +13,12 @@ var (
 	ScaleUpThrottledCount = metrics.NewCounterDef(
 		"worker_controller_instance_scale_up_throttled_count",
 		metrics.WithDescription("The number of times a scale up was throttled for a worker controller instance."))
+	DeferredScalingDecisionCount = metrics.NewCounterDef(
+		"worker_controller_instance_deferred_scaling_decision_count",
+		metrics.WithDescription("The number of times a deferred scaling decision was dispatched for a worker controller instance."))
+	DeferredScalingDecisionMetricsPullFailedCount = metrics.NewCounterDef(
+		"worker_controller_instance_deferred_scaling_decision_metrics_pull_failed_count",
+		metrics.WithDescription("The number of deferred scaling decision invocations whose lazy metrics-snapshot pull failed."))
 
 	WorkflowErrorCount = metrics.NewCounterDef(
 		"worker_controller_instance_workflow_error_count",
@@ -83,6 +89,9 @@ const (
 	SkippedReasonAlgorithmUnavailable SkippedReason = "algorithm_unavailable"
 	SkippedReasonAlgorithmFailed      SkippedReason = "algorithm_failed"
 	SkippedReasonNoMatchingScaler     SkippedReason = "no_matching_scaler"
+	SkippedReasonInvalidCount         SkippedReason = "invalid_count"
+	SkippedReasonNoSourceRequest      SkippedReason = "no_source_request"
+	SkippedReasonTaskTypeMismatch     SkippedReason = "task_type_mismatch"
 )
 
 const (
@@ -101,17 +110,19 @@ const (
 	ActivityTypeInvokeWorkersToRegisterTaskQueues ActivityType = "invoke_workers_to_register_task_queues"
 	ActivityTypeValidateSpec                      ActivityType = "validate_spec"
 	ActivityTypePullStats                         ActivityType = "pull_stats"
+	ActivityTypeHandleDeferredScalingDecision     ActivityType = "handle_deferred_scaling_decision"
 )
 
 const (
-	SignalTypeTaskAdd                = "task_add"
-	UpdateTypeValidateSpec           = "validate_spec"
-	UpdateTypeUpdateInstance         = "update_instance"
-	UpdateTypeDeleteInstance         = "delete_instance"
-	OperationTypePullStats           = "pull_stats"
-	OperationTypeValidateSpec        = "validate_spec"
-	OperationTypeInvokeWorker        = "invoke_worker"
-	OperationTypeUpdateWorkerSetSize = "update_worker_set_size"
-	ScaleUpTriggerTypeMetricsPoll    = "metrics_poll"
-	ScaleUpTriggerTypeTaskAdd        = "task_add"
+	SignalTypeTaskAdd                    = "task_add"
+	UpdateTypeValidateSpec               = "validate_spec"
+	UpdateTypeUpdateInstance             = "update_instance"
+	UpdateTypeDeleteInstance             = "delete_instance"
+	OperationTypePullStats               = "pull_stats"
+	OperationTypeValidateSpec            = "validate_spec"
+	OperationTypeInvokeWorker            = "invoke_worker"
+	OperationTypeUpdateWorkerSetSize     = "update_worker_set_size"
+	OperationTypeDeferredScalingDecision = "deferred_scaling_decision"
+	ScaleUpTriggerTypeMetricsPoll        = "metrics_poll"
+	ScaleUpTriggerTypeTaskAdd            = "task_add"
 )

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -3,11 +3,12 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/auto-scaled-workers/wci/client"
@@ -80,6 +81,22 @@ type (
 		Actions              []scalingalgorithm.ScalingAction        `json:"actions,omitempty"`
 	}
 
+	HandleDeferredScalingDecisionActivityRequest struct {
+		RequestContext
+
+		Request         iface.SignalTaskAddRequest `json:"request"`
+		ScalingGroupKey string                     `json:"scaling_group_key"`
+
+		ScalingGroupSpec   iface.ScalingGroupSpec       `json:"scaling_group_spec"`
+		EffectiveTaskTypes []enumspb.TaskQueueType      `json:"effective_task_types"`
+		ScalingStatus      iface.ScalingAlgorithmStatus `json:"scaling_status"`
+	}
+
+	HandleDeferredScalingDecisionActivityResponse struct {
+		UpdatedScalingStatus iface.ScalingAlgorithmStatus     `json:"scaling_status"`
+		Actions              []scalingalgorithm.ScalingAction `json:"actions,omitempty"`
+	}
+
 	PullStatsActivityRequest struct {
 		RequestContext
 
@@ -140,7 +157,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 		provider, err := computeprovider.GetComputeProvider(timeoutCtx, entry.Compute.ProviderType, a.dc)
 		if err != nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-			return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument")
+			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
 		if provider == nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
@@ -150,18 +167,18 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 		config := map[string]any{}
 		if err := sdk.PreferProtoDataConverter.FromPayload(entry.Compute.Config, &config); err != nil {
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
-			return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument")
+			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
 		if err := provider.ValidateConfig(timeoutCtx, config); err != nil {
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
-			return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument")
+			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
 
 		if entry.Scaling != nil {
 			scalingAlgo, err := scalingalgorithm.GetScalingAlgorithm(timeoutCtx, entry.Scaling.ScalingAlgorithm, a.dc)
 			if err != nil {
 				recordError(wcimetrics.ErrorTypeAlgorithmFailed)
-				return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument")
+				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 			}
 			if scalingAlgo == nil {
 				recordError(wcimetrics.ErrorTypeAlgorithmUnavailable)
@@ -171,11 +188,11 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 			config := map[string]any{}
 			if err := sdk.PreferProtoDataConverter.FromPayload(entry.Scaling.Config, &config); err != nil {
 				recordError(wcimetrics.ErrorTypeInvalidRequest)
-				return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument")
+				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 			}
 			if err := scalingAlgo.ValidateConfig(timeoutCtx, config); err != nil {
 				recordError(wcimetrics.ErrorTypeInvalidRequest)
-				return temporal.NewApplicationError(fmt.Sprintf("%s: %s", key, err), "InvalidArgument")
+				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err), "InvalidArgument", err)
 			}
 
 			compatibleLaunchStrategies := scalingAlgo.CompatibleLaunchStrategies()
@@ -202,7 +219,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 		provider, err := computeprovider.GetComputeProvider(ctx, v.Compute.ProviderType, a.dc)
 		if err != nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-			return temporal.NewApplicationError(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument")
+			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 		}
 		if provider == nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
@@ -213,12 +230,12 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 			config := map[string]any{}
 			if err := sdk.PreferProtoDataConverter.FromPayload(v.Compute.Config, &config); err != nil {
 				recordError(wcimetrics.ErrorTypeInvalidRequest)
-				return temporal.NewApplicationError(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument")
+				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 			}
 
 			if err := provider.InvokeWorker(ctx, config); err != nil {
 				recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-				return temporal.NewApplicationError(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed")
+				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
 			}
 		}
 	}
@@ -251,14 +268,14 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 	config := map[string]any{}
 	if err := sdk.PreferProtoDataConverter.FromPayload(req.ComputeConfig.Config, &config); err != nil {
 		recordError(wcimetrics.ErrorTypeInvalidRequest)
-		return temporal.NewApplicationError(err.Error(), "InvalidArgument")
+		return temporal.NewApplicationErrorWithCause(err.Error(), "InvalidArgument", err)
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, startNewWorkerInstanceTimeout)
 	defer cancel()
 	if err := provider.InvokeWorker(timeoutCtx, config); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-		return temporal.NewApplicationError(err.Error(), "InvokeWorkerFailed")
+		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
 
 	recordSuccess()
@@ -289,18 +306,84 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 	config := map[string]any{}
 	if err := sdk.PreferProtoDataConverter.FromPayload(req.ComputeConfig.Config, &config); err != nil {
 		recordError(wcimetrics.ErrorTypeInvalidRequest)
-		return temporal.NewApplicationError(err.Error(), "InvalidArgument")
+		return temporal.NewApplicationErrorWithCause(err.Error(), "InvalidArgument", err)
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, updateWorkerSetSizeTimeout)
 	defer cancel()
 	if err := provider.UpdateWorkerSetSize(timeoutCtx, config, req.UpdatedSize); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-		return temporal.NewApplicationError(err.Error(), "InvokeWorkerFailed")
+		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
 
 	recordSuccess()
 	return nil
+}
+
+func (a *Activities) HandleDeferredScalingDecision(ctx context.Context, req HandleDeferredScalingDecisionActivityRequest) (*HandleDeferredScalingDecisionActivityResponse, error) {
+	logger := activity.GetLogger(ctx)
+	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeHandleDeferredScalingDecision)
+	recordError, recordSkipped, recordSuccess := newActivityRecorders(metricsHandler)
+
+	scalingStatus := maps.Clone(req.ScalingStatus)
+
+	if !slices.Contains(req.EffectiveTaskTypes, req.Request.TaskQueueType) {
+		logger.Warn("Deferred scaling decision does not match scaling group task types", "scaling_group_key", req.ScalingGroupKey, "task_queue_type", req.Request.TaskQueueType)
+		recordSkipped(wcimetrics.SkippedReasonTaskTypeMismatch)
+		return &HandleDeferredScalingDecisionActivityResponse{UpdatedScalingStatus: scalingStatus}, nil
+	}
+
+	scalingAlgo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, req.ScalingGroupSpec)
+	if err != nil {
+		logger.Warn("failed to get scaling algorithm for deferred scaling decision", "error", err, "scaling_group_key", req.ScalingGroupKey)
+		recordSkipped(wcimetrics.SkippedReasonAlgorithmUnavailable)
+		return &HandleDeferredScalingDecisionActivityResponse{UpdatedScalingStatus: scalingStatus}, nil
+	}
+
+	getCachedMetricsSnapshot := sync.OnceValues(func() (*scalingalgorithm.ScalingMetricsSnapshot, error) {
+		metricsSnapshot, err := a.pullScalingMetricsSnapshot(ctx, req.NamespaceName, req.DeploymentName, req.DeploymentBuildID)
+		if err != nil {
+			metricsHandler.Counter(wcimetrics.DeferredScalingDecisionMetricsPullFailedCount.Name()).Inc(1)
+			logger.Error("failed to pull deferred scaling decision metrics snapshot", "error", err)
+			return nil, err
+		}
+		return metricsSnapshot, nil
+	})
+
+	getScalingMetricsSnapshot := func() (*scalingalgorithm.ScalingMetricsSnapshot, error) {
+		metricsSnapshot, err := getCachedMetricsSnapshot()
+		if err != nil {
+			return nil, err
+		}
+		return filterScalingMetricsSnapshotByTaskTypes(metricsSnapshot, req.EffectiveTaskTypes), nil
+	}
+
+	response, err := scalingAlgo.ProcessDeferredScalingDecision(ctx, scalingConfig, scalingStatus, req.Request, getScalingMetricsSnapshot)
+	if err != nil {
+		logger.Error("failed to process deferred scaling decision", "error", err, "scaling_group_key", req.ScalingGroupKey)
+		recordError(wcimetrics.ErrorTypeAlgorithmFailed)
+		return nil, temporal.NewApplicationErrorWithCause(err.Error(), "AlgorithmFailed", err)
+	}
+	if response == nil {
+		logger.Error("deferred scaling decision returned nil response", "scaling_group_key", req.ScalingGroupKey)
+		recordSkipped(wcimetrics.SkippedReasonAlgorithmFailed)
+		return &HandleDeferredScalingDecisionActivityResponse{UpdatedScalingStatus: scalingStatus}, nil
+	}
+
+	updatedActions := []scalingalgorithm.ScalingAction{}
+	for _, act := range response.Actions {
+		// Reject nested deferred actions: chaining them would grow workflow history
+		// unbounded as each deferred dispatch schedules another activity.
+		if act.Action == scalingalgorithm.ActionTypeDeferredScalingDecision {
+			logger.Error("deferred scaling decision response contained a nested deferred action; dropping", "scaling_group_key", req.ScalingGroupKey)
+			continue
+		}
+		act.ScalingGroupKey = req.ScalingGroupKey
+		updatedActions = append(updatedActions, act)
+	}
+
+	recordSuccess()
+	return &HandleDeferredScalingDecisionActivityResponse{Actions: updatedActions, UpdatedScalingStatus: response.Status}, nil
 }
 
 func (a *Activities) HandleTaskAddSignal(ctx context.Context, req HandleTaskAddSignalActivityRequest) (*HandleTaskAddSignalActivityResponse, error) {
@@ -386,50 +469,11 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 		}, nil
 	}
 
-	deploymentVersionDetails, err := a.workflowserviceClient.DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
-		Namespace: req.NamespaceName,
-		DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
-			DeploymentName: req.DeploymentName,
-			BuildId:        req.DeploymentBuildID,
-		},
-		ReportTaskQueueStats: true,
-	})
+	metricsSnapshot, err := a.pullScalingMetricsSnapshot(ctx, req.NamespaceName, req.DeploymentName, req.DeploymentBuildID)
 	if err != nil {
 		recordError(wcimetrics.ErrorTypeDescribeWorkerDeploymentVersionFailed)
-		return nil, err
+		return nil, temporal.NewApplicationErrorWithCause(err.Error(), "PullScalingMetricsSnapshotFailed", err)
 	}
-	if deploymentVersionDetails == nil {
-		recordError(wcimetrics.ErrorTypeDescribeWorkerDeploymentVersionFailed)
-		return nil, fmt.Errorf("did not receive details in the describe response")
-	}
-
-	metricsSnapshot := scalingalgorithm.ScalingMetricsSnapshot{
-		Workflow: &iface.QueueTypeScalingMetrics{},
-		Activity: &iface.QueueTypeScalingMetrics{},
-		Nexus:    &iface.QueueTypeScalingMetrics{},
-	}
-	for _, versionedTaskQueue := range deploymentVersionDetails.VersionTaskQueues {
-		if versionedTaskQueue == nil || versionedTaskQueue.Stats == nil {
-			continue
-		}
-
-		switch versionedTaskQueue.Type {
-		case enumspb.TASK_QUEUE_TYPE_WORKFLOW:
-			metricsSnapshot.Workflow.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
-			metricsSnapshot.Workflow.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
-			metricsSnapshot.Workflow.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
-		case enumspb.TASK_QUEUE_TYPE_ACTIVITY:
-			metricsSnapshot.Activity.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
-			metricsSnapshot.Activity.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
-			metricsSnapshot.Activity.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
-		case enumspb.TASK_QUEUE_TYPE_NEXUS:
-			metricsSnapshot.Nexus.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
-			metricsSnapshot.Nexus.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
-			metricsSnapshot.Nexus.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
-		}
-	}
-
-	logger.Info("Pull Stats Results", "workflow_count", metricsSnapshot.Workflow.LastBacklogCount, "activity_count", metricsSnapshot.Activity.LastBacklogCount, "nexus_count", metricsSnapshot.Nexus.LastBacklogCount)
 
 	totalBacklog := metricsSnapshot.Workflow.LastBacklogCount +
 		metricsSnapshot.Activity.LastBacklogCount +
@@ -445,15 +489,9 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 		scalingStatus := req.ScalingStatus[key]
 		scalingGroupEffectiveTaskTypes := req.Spec.EffectiveTaskTypesForGroup(key)
 
-		scalingMetricsSnapshot := metricsSnapshot
-		if !slices.Contains(scalingGroupEffectiveTaskTypes, enumspb.TASK_QUEUE_TYPE_WORKFLOW) {
-			scalingMetricsSnapshot.Workflow = nil
-		}
-		if !slices.Contains(scalingGroupEffectiveTaskTypes, enumspb.TASK_QUEUE_TYPE_ACTIVITY) {
-			scalingMetricsSnapshot.Activity = nil
-		}
-		if !slices.Contains(scalingGroupEffectiveTaskTypes, enumspb.TASK_QUEUE_TYPE_NEXUS) {
-			scalingMetricsSnapshot.Nexus = nil
+		scalingMetricsSnapshot := filterScalingMetricsSnapshotByTaskTypes(metricsSnapshot, scalingGroupEffectiveTaskTypes)
+		if scalingMetricsSnapshot == nil {
+			scalingMetricsSnapshot = &scalingalgorithm.ScalingMetricsSnapshot{}
 		}
 
 		scalingAlgo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, entry)
@@ -468,7 +506,7 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 
 		logger.Debug("Loaded scaling algo", "scaling_algo", scalingAlgo, "config", scalingConfig)
 
-		response, err := scalingAlgo.ProcessMetricsPoll(ctx, scalingConfig, scalingStatus, scalingMetricsSnapshot)
+		response, err := scalingAlgo.ProcessMetricsPoll(ctx, scalingConfig, scalingStatus, *scalingMetricsSnapshot)
 		if err != nil {
 			logger.Error("failed to process metrics poll", "error", err)
 
@@ -480,6 +518,11 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 
 		updatedScalingStatus[key] = response.Status
 		for _, act := range response.Actions {
+			// Reject nested deferred actions as metric polls have no reason to defer things
+			if act.Action == scalingalgorithm.ActionTypeDeferredScalingDecision {
+				logger.Error("metrics-poll response contained a deferred scaling decision; dropping", "scaling_group_key", key)
+				continue
+			}
 			act.ScalingGroupKey = key
 			actions = append(actions, act)
 		}

--- a/wci/workflow/activities_test.go
+++ b/wci/workflow/activities_test.go
@@ -1,0 +1,855 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	scalingalgorithm "go.temporal.io/auto-scaled-workers/wci/workflow/scaling_algorithm"
+	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/sdk"
+	"google.golang.org/grpc"
+)
+
+func newTestSignalTaskAddEvent() iface.SignalTaskAddRequest {
+	return iface.SignalTaskAddRequest{
+		TaskQueueName:               "test-queue",
+		TaskQueueType:               enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+		IsSyncMatch:                 true,
+		NoSyncMatchSignalsSinceLast: 2,
+	}
+}
+
+func newTestScalingGroupSpec(taskType enumspb.TaskQueueType, scalingConfig, computeConfig *commonpb.Payload) iface.ScalingGroupSpec {
+	return iface.ScalingGroupSpec{
+		TaskTypes: []enumspb.TaskQueueType{taskType},
+		Compute: iface.ComputeProviderSpec{
+			ProviderType: iface.ComputeProviderTypeTestWorkerSet,
+			Config:       computeConfig,
+		},
+		Scaling: &iface.ScalingAlgorithmSpec{
+			ScalingAlgorithm: testDeferredScalingDecisionScalingAlgorithm,
+			Config:           scalingConfig,
+		},
+	}
+}
+
+const testDeferredScalingDecisionScalingAlgorithm iface.ScalingAlgorithmType = "test-deferred-scaling-decision"
+
+var currentDeferredScalingDecisionTestAlgorithm *deferredScalingDecisionTestAlgorithm
+
+func init() {
+	scalingalgorithm.RegisterScalingAlgorithm(testDeferredScalingDecisionScalingAlgorithm, func(context.Context) (scalingalgorithm.ScalingAlgorithm, error) {
+		return currentDeferredScalingDecisionTestAlgorithm, nil
+	})
+}
+
+type deferredScalingDecisionTestAlgorithm struct {
+	processCalls        int
+	deferredCalls       int
+	processEvent        iface.SignalTaskAddRequest
+	deferredEvent       iface.SignalTaskAddRequest
+	deferredPriorStatus iface.ScalingAlgorithmStatus
+
+	deferredErr     error
+	deferredNilResp bool
+
+	// deferredHook, if non-nil, is invoked from ProcessDeferredScalingDecision before constructing the
+	// response. Tests use it to exercise the metrics-snapshot getter contract.
+	deferredHook func(getMetricsSnapshot scalingalgorithm.ScalingMetricsSnapshotGetter)
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) CompatibleLaunchStrategies() []computeprovider.LaunchStrategy {
+	return []computeprovider.LaunchStrategy{computeprovider.LaunchStrategyWorkerSet}
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) ValidateConfig(context.Context, iface.ScalingAlgorithmConfig) error {
+	return nil
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) ProcessTaskAdd(
+	_ context.Context,
+	_ iface.ScalingAlgorithmConfig,
+	_ iface.ScalingAlgorithmStatus,
+	event iface.SignalTaskAddRequest,
+) (*scalingalgorithm.TaskAddResponse, error) {
+	a.processCalls++
+	a.processEvent = event
+	return &scalingalgorithm.TaskAddResponse{
+		Actions: []scalingalgorithm.ScalingAction{
+			{Action: scalingalgorithm.ActionTypeDeferredScalingDecision},
+		},
+		Status: iface.ScalingAlgorithmStatus{"phase": "process"},
+	}, nil
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) ProcessDeferredScalingDecision(
+	_ context.Context,
+	_ iface.ScalingAlgorithmConfig,
+	priorStatus iface.ScalingAlgorithmStatus,
+	event iface.SignalTaskAddRequest,
+	getMetricsSnapshot scalingalgorithm.ScalingMetricsSnapshotGetter,
+) (*scalingalgorithm.TaskAddResponse, error) {
+	a.deferredCalls++
+	a.deferredEvent = event
+	a.deferredPriorStatus = priorStatus
+	if a.deferredHook != nil {
+		a.deferredHook(getMetricsSnapshot)
+	}
+	if a.deferredErr != nil {
+		return nil, a.deferredErr
+	}
+	if a.deferredNilResp {
+		return nil, nil
+	}
+	count := int32(4)
+	return &scalingalgorithm.TaskAddResponse{
+		Actions: []scalingalgorithm.ScalingAction{
+			// Nested deferred actions interspersed with a real action: the activity must
+			// drop all of them, since deferred actions cannot themselves chain into more
+			// deferred work.
+			{Action: scalingalgorithm.ActionTypeDeferredScalingDecision},
+			{Action: scalingalgorithm.ActionTypeUpdateWorkerSetSize, Count: &count},
+			{Action: scalingalgorithm.ActionTypeDeferredScalingDecision},
+			{Action: scalingalgorithm.ActionTypeDeferredScalingDecision},
+		},
+		Status: iface.ScalingAlgorithmStatus{"phase": "deferred"},
+	}, nil
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) ProcessMetricsPoll(context.Context, iface.ScalingAlgorithmConfig, iface.ScalingAlgorithmStatus, scalingalgorithm.ScalingMetricsSnapshot) (*scalingalgorithm.MetricsPollResponse, error) {
+	return &scalingalgorithm.MetricsPollResponse{}, nil
+}
+
+func TestFilterScalingMetricsSnapshotByTaskTypes(t *testing.T) {
+	snapshot := &scalingalgorithm.ScalingMetricsSnapshot{
+		Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1},
+		Activity: &iface.QueueTypeScalingMetrics{
+			LastBacklogCount:   2,
+			LastArrivalRate:    3,
+			LastProcessingRate: 4,
+		},
+		Nexus: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
+	}
+
+	activitySnapshot := filterScalingMetricsSnapshotByTaskTypes(snapshot, []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_ACTIVITY})
+	assert.Nil(t, activitySnapshot.Workflow)
+	require.NotNil(t, activitySnapshot.Activity)
+	assert.Equal(t, int64(2), activitySnapshot.Activity.LastBacklogCount)
+	assert.Nil(t, activitySnapshot.Nexus)
+
+	workflowSnapshot := filterScalingMetricsSnapshotByTaskTypes(snapshot, []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW})
+	require.NotNil(t, workflowSnapshot.Workflow)
+	assert.Equal(t, int64(1), workflowSnapshot.Workflow.LastBacklogCount)
+	assert.Nil(t, workflowSnapshot.Activity)
+	assert.Nil(t, workflowSnapshot.Nexus)
+
+	// Caller's snapshot must not be mutated.
+	require.NotNil(t, snapshot.Workflow)
+	require.NotNil(t, snapshot.Activity)
+	require.NotNil(t, snapshot.Nexus)
+
+	// Surviving inner pointers must be independently owned: mutating the filtered view
+	// must not affect the source snapshot.
+	assert.NotSame(t, snapshot.Activity, activitySnapshot.Activity, "filter must deep-copy surviving inner pointers")
+	activitySnapshot.Activity.LastBacklogCount = 999
+	assert.Equal(t, int64(2), snapshot.Activity.LastBacklogCount, "mutating the filtered view must not bleed into the source")
+
+	assert.Nil(t, filterScalingMetricsSnapshotByTaskTypes(nil, []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW}))
+}
+
+func TestHandleTaskAddSignalReturnsDeferredAction(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	event := newTestSignalTaskAddEvent()
+	priorStatus := map[string]iface.ScalingAlgorithmStatus{
+		"workflow": {"phase": "prior"},
+		"activity": {"phase": "untouched"},
+	}
+
+	activities := NewActivities(nil, nil, nil)
+	req := HandleTaskAddSignalActivityRequest{
+		Request: event,
+		Spec: &iface.WorkerControllerInstanceSpec{
+			ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+				"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+				"activity": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_ACTIVITY, scalingConfigPayload, nil),
+			},
+		},
+		ScalingStatus: priorStatus,
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.HandleTaskAddSignal)
+	encodedResp, err := env.ExecuteActivity(activities.HandleTaskAddSignal, req)
+
+	require.NoError(t, err)
+	var resp HandleTaskAddSignalActivityResponse
+	require.NoError(t, encodedResp.Get(&resp))
+	assert.Equal(t, 1, algo.processCalls)
+	assert.Equal(t, 0, algo.deferredCalls)
+	assert.Equal(t, event, algo.processEvent)
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "process"}, resp.UpdatedScalingStatus["workflow"])
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "untouched"}, resp.UpdatedScalingStatus["activity"])
+
+	require.Len(t, resp.Actions, 1)
+	assert.Equal(t, scalingalgorithm.ActionTypeDeferredScalingDecision, resp.Actions[0].Action)
+	assert.Equal(t, "workflow", resp.Actions[0].ScalingGroupKey)
+	assert.Nil(t, resp.Actions[0].Count)
+}
+
+func TestHandleDeferredScalingDecisionProcessesAction(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	event := newTestSignalTaskAddEvent()
+	priorStatus := iface.ScalingAlgorithmStatus{"phase": "process"}
+
+	activities := NewActivities(nil, nil, nil)
+	req := HandleDeferredScalingDecisionActivityRequest{
+		Request:            event,
+		ScalingGroupKey:    "workflow",
+		ScalingGroupSpec:   newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+		EffectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+		ScalingStatus:      priorStatus,
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.HandleDeferredScalingDecision)
+	encodedResp, err := env.ExecuteActivity(activities.HandleDeferredScalingDecision, req)
+
+	require.NoError(t, err)
+	var resp HandleDeferredScalingDecisionActivityResponse
+	require.NoError(t, encodedResp.Get(&resp))
+	assert.Equal(t, 0, algo.processCalls)
+	assert.Equal(t, 1, algo.deferredCalls)
+	assert.Equal(t, event, algo.deferredEvent)
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "process"}, algo.deferredPriorStatus)
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "deferred"}, resp.UpdatedScalingStatus)
+
+	for _, act := range resp.Actions {
+		assert.NotEqual(t, scalingalgorithm.ActionTypeDeferredScalingDecision, act.Action, "nested deferred actions must be dropped")
+	}
+	var updateActions []scalingalgorithm.ScalingAction
+	for _, act := range resp.Actions {
+		if act.Action == scalingalgorithm.ActionTypeUpdateWorkerSetSize {
+			updateActions = append(updateActions, act)
+		}
+	}
+	require.Len(t, updateActions, 1)
+	assert.Equal(t, "workflow", updateActions[0].ScalingGroupKey)
+	require.NotNil(t, updateActions[0].Count)
+	assert.Equal(t, int32(4), *updateActions[0].Count)
+}
+
+func TestHandleDeferredScalingDecisionDropsOnInputErrors(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	priorStatus := iface.ScalingAlgorithmStatus{"phase": "prior"}
+	workflowGroup := newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil)
+	unknownAlgoGroup := iface.ScalingGroupSpec{
+		TaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+		Compute:   iface.ComputeProviderSpec{ProviderType: iface.ComputeProviderTypeTestWorkerSet},
+		Scaling: &iface.ScalingAlgorithmSpec{
+			ScalingAlgorithm: iface.ScalingAlgorithmType("does-not-exist"),
+			Config:           scalingConfigPayload,
+		},
+	}
+
+	cases := []struct {
+		name               string
+		scalingGroupSpec   iface.ScalingGroupSpec
+		effectiveTaskTypes []enumspb.TaskQueueType
+		taskType           enumspb.TaskQueueType
+		algoSetup          func(a *deferredScalingDecisionTestAlgorithm)
+		expectAlgoCalled   bool
+	}{
+		{
+			name:               "task type mismatch",
+			scalingGroupSpec:   workflowGroup,
+			effectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+			taskType:           enumspb.TASK_QUEUE_TYPE_ACTIVITY,
+		},
+		{
+			name:               "scaling algorithm factory unknown",
+			scalingGroupSpec:   unknownAlgoGroup,
+			effectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+			taskType:           enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+		},
+		{
+			name:               "algorithm returns nil response",
+			scalingGroupSpec:   workflowGroup,
+			effectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+			taskType:           enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+			algoSetup:          func(a *deferredScalingDecisionTestAlgorithm) { a.deferredNilResp = true },
+			expectAlgoCalled:   true,
+		},
+	}
+
+	activities := NewActivities(nil, nil, nil)
+	var suite testsuite.WorkflowTestSuite
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			*algo = deferredScalingDecisionTestAlgorithm{}
+			if tc.algoSetup != nil {
+				tc.algoSetup(algo)
+			}
+
+			event := newTestSignalTaskAddEvent()
+			event.TaskQueueType = tc.taskType
+
+			env := suite.NewTestActivityEnvironment()
+			env.RegisterActivity(activities.HandleDeferredScalingDecision)
+			encodedResp, err := env.ExecuteActivity(activities.HandleDeferredScalingDecision, HandleDeferredScalingDecisionActivityRequest{
+				Request:            event,
+				ScalingGroupKey:    "workflow",
+				ScalingGroupSpec:   tc.scalingGroupSpec,
+				EffectiveTaskTypes: tc.effectiveTaskTypes,
+				ScalingStatus:      priorStatus,
+			})
+			require.NoError(t, err, "activity must return nil error on silent-drop branches")
+
+			var resp HandleDeferredScalingDecisionActivityResponse
+			require.NoError(t, encodedResp.Get(&resp))
+			assert.Empty(t, resp.Actions)
+			assert.Equal(t, priorStatus, resp.UpdatedScalingStatus)
+			if tc.expectAlgoCalled {
+				assert.Equal(t, 1, algo.deferredCalls, "algorithm ProcessDeferredScalingDecision should have been called")
+			} else {
+				assert.Equal(t, 0, algo.deferredCalls, "algorithm ProcessDeferredScalingDecision must not be called")
+			}
+		})
+	}
+}
+
+func TestHandleDeferredScalingDecisionPropagatesAlgorithmError(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	deferredErr := errors.New("simulated deferred algorithm failure")
+	algo.deferredErr = deferredErr
+
+	activities := NewActivities(nil, nil, nil)
+	req := HandleDeferredScalingDecisionActivityRequest{
+		Request:            newTestSignalTaskAddEvent(),
+		ScalingGroupKey:    "workflow",
+		ScalingGroupSpec:   newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+		EffectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+		ScalingStatus:      iface.ScalingAlgorithmStatus{"phase": "prior"},
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.HandleDeferredScalingDecision)
+	_, err = env.ExecuteActivity(activities.HandleDeferredScalingDecision, req)
+
+	require.Error(t, err, "algorithm error must be propagated so the workflow-side retry policy can re-attempt")
+	assert.Contains(t, err.Error(), deferredErr.Error(), "propagated error must wrap the original algorithm error")
+	assert.Equal(t, 1, algo.deferredCalls, "algorithm ProcessDeferredScalingDecision should have been called once")
+}
+
+func TestHandleActionsProcessesDeferredScalingDecision(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+	computeConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(map[string]any{})
+	require.NoError(t, err)
+
+	activities := NewActivities(nil, nil, nil)
+	event := newTestSignalTaskAddEvent()
+	args := &iface.WorkerControllerInstanceWorkflowArgs{
+		NamespaceName:  "test-namespace",
+		DeploymentName: "test-deployment",
+		BuildId:        "test-build",
+		State: &iface.WorkerControllerInstanceLocalState{
+			Spec: &iface.WorkerControllerInstanceSpec{
+				ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+					"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, computeConfigPayload),
+				},
+			},
+			ScalingStatus: map[string]iface.ScalingAlgorithmStatus{
+				"workflow": {"phase": "process"},
+			},
+		},
+	}
+	action := scalingalgorithm.ScalingAction{
+		ScalingGroupKey: "workflow",
+		Action:          scalingalgorithm.ActionTypeDeferredScalingDecision,
+	}
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs, action scalingalgorithm.ScalingAction, event iface.SignalTaskAddRequest) (map[string]iface.ScalingAlgorithmStatus, error) {
+		runner := &WorkflowRunner{
+			WorkerControllerInstanceWorkflowArgs: args,
+			a:                                    activities,
+			logger:                               sdkworkflow.GetLogger(ctx),
+			metrics:                              sdkworkflow.GetMetricsHandler(ctx),
+		}
+		runner.handleActions(ctx, []scalingalgorithm.ScalingAction{action}, &event)
+		return runner.State.ScalingStatus, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+	env.RegisterActivity(activities.HandleDeferredScalingDecision)
+
+	var updateRequests []UpdateWorkerSetSizeActivityRequest
+	env.OnActivity(activities.UpdateWorkerSetSize, mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*UpdateWorkerSetSizeActivityRequest)
+			updateRequests = append(updateRequests, *req)
+		})
+
+	env.ExecuteWorkflow(testWorkflow, args, action, event)
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var status map[string]iface.ScalingAlgorithmStatus
+	require.NoError(t, env.GetWorkflowResult(&status))
+	assert.Equal(t, 0, algo.processCalls)
+	assert.Equal(t, 1, algo.deferredCalls)
+	assert.Equal(t, event, algo.deferredEvent)
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "process"}, algo.deferredPriorStatus)
+	assert.Equal(t, iface.ScalingAlgorithmStatus{"phase": "deferred"}, status["workflow"])
+
+	require.Len(t, updateRequests, 1, "deferred response's UpdateWorkerSetSize action must be dispatched")
+	assert.Equal(t, int32(4), updateRequests[0].UpdatedSize)
+	require.NotNil(t, updateRequests[0].ComputeConfig)
+	assert.Equal(t, iface.ComputeProviderTypeTestWorkerSet, updateRequests[0].ComputeConfig.ProviderType)
+}
+
+func TestHandleActionsDropsDeferredActionGuards(t *testing.T) {
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	event := newTestSignalTaskAddEvent()
+	count := int32(7)
+
+	cases := []struct {
+		name           string
+		action         scalingalgorithm.ScalingAction
+		taskAddRequest *iface.SignalTaskAddRequest
+	}{
+		{
+			name: "count must not be set",
+			action: scalingalgorithm.ScalingAction{
+				ScalingGroupKey: "workflow",
+				Action:          scalingalgorithm.ActionTypeDeferredScalingDecision,
+				Count:           &count,
+			},
+			taskAddRequest: &event,
+		},
+		{
+			name: "source task-add request must be present",
+			action: scalingalgorithm.ScalingAction{
+				ScalingGroupKey: "workflow",
+				Action:          scalingalgorithm.ActionTypeDeferredScalingDecision,
+			},
+			taskAddRequest: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			algo := &deferredScalingDecisionTestAlgorithm{}
+			currentDeferredScalingDecisionTestAlgorithm = algo
+			t.Cleanup(func() {
+				currentDeferredScalingDecisionTestAlgorithm = nil
+			})
+
+			activities := NewActivities(nil, nil, nil)
+			args := &iface.WorkerControllerInstanceWorkflowArgs{
+				NamespaceName:  "test-namespace",
+				DeploymentName: "test-deployment",
+				BuildId:        "test-build",
+				State: &iface.WorkerControllerInstanceLocalState{
+					Spec: &iface.WorkerControllerInstanceSpec{
+						ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+							"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+						},
+					},
+					ScalingStatus: map[string]iface.ScalingAlgorithmStatus{
+						"workflow": {"phase": "process"},
+					},
+				},
+			}
+			testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs, action scalingalgorithm.ScalingAction, taskAddRequest *iface.SignalTaskAddRequest) error {
+				runner := &WorkflowRunner{
+					WorkerControllerInstanceWorkflowArgs: args,
+					a:                                    activities,
+					logger:                               sdkworkflow.GetLogger(ctx),
+					metrics:                              sdkworkflow.GetMetricsHandler(ctx),
+				}
+				runner.handleActions(ctx, []scalingalgorithm.ScalingAction{action}, taskAddRequest)
+				return nil
+			}
+
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(testWorkflow)
+
+			// Mock the activity so a regression that lets the action through doesn't
+			// fail with "activity not registered" — which would mask the real
+			// signal we're checking for.
+			var deferredCalls int
+			env.OnActivity(activities.HandleDeferredScalingDecision, mock.Anything, mock.Anything).
+				Return(&HandleDeferredScalingDecisionActivityResponse{}, nil).
+				Run(func(mock.Arguments) {
+					deferredCalls++
+				})
+
+			env.ExecuteWorkflow(testWorkflow, args, tc.action, tc.taskAddRequest)
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+
+			assert.Equal(t, 0, deferredCalls, "deferred scaling decision must be dropped without scheduling HandleDeferredScalingDecision")
+			assert.Equal(t, 0, algo.deferredCalls, "scaling algorithm ProcessDeferredScalingDecision must not be invoked when the action is dropped at dispatch")
+		})
+	}
+}
+
+// TestHandleNoSyncMatchSignalAppliesStatusBeforeDeferredDispatch pins the ordering
+// contract documented on handleActions: callers must persist UpdatedScalingStatus
+// to d.State.ScalingStatus *before* invoking handleActions, so the deferred scaling decision
+// case forwards the freshly-computed status (not the pre-process snapshot). A
+// regression that reverts the ordering would silently forward stale state.
+func TestHandleNoSyncMatchSignalAppliesStatusBeforeDeferredDispatch(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	activities := NewActivities(nil, nil, nil)
+	event := newTestSignalTaskAddEvent()
+	args := &iface.WorkerControllerInstanceWorkflowArgs{
+		NamespaceName:  "test-namespace",
+		DeploymentName: "test-deployment",
+		BuildId:        "test-build",
+		State: &iface.WorkerControllerInstanceLocalState{
+			Spec: &iface.WorkerControllerInstanceSpec{
+				ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+					"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+				},
+			},
+			ScalingStatus: map[string]iface.ScalingAlgorithmStatus{
+				"workflow": {"phase": "pre-process"},
+			},
+		},
+	}
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs, event iface.SignalTaskAddRequest) (map[string]iface.ScalingAlgorithmStatus, error) {
+		runner := &WorkflowRunner{
+			WorkerControllerInstanceWorkflowArgs: args,
+			a:                                    activities,
+			logger:                               sdkworkflow.GetLogger(ctx),
+			metrics:                              sdkworkflow.GetMetricsHandler(ctx),
+		}
+		runner.handleNoSyncMatchSignal(ctx, &event)
+		return runner.State.ScalingStatus, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+	env.RegisterActivity(activities.HandleTaskAddSignal)
+
+	var deferredRequests []HandleDeferredScalingDecisionActivityRequest
+	env.OnActivity(activities.HandleDeferredScalingDecision, mock.Anything, mock.Anything).
+		Return(&HandleDeferredScalingDecisionActivityResponse{}, nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(HandleDeferredScalingDecisionActivityRequest)
+			deferredRequests = append(deferredRequests, req)
+		})
+
+	env.ExecuteWorkflow(testWorkflow, args, event)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	require.Len(t, deferredRequests, 1, "no-sync-match signal must dispatch one deferred scaling decision activity")
+	assert.Equal(t,
+		iface.ScalingAlgorithmStatus{"phase": "process"},
+		deferredRequests[0].ScalingStatus,
+		"deferred activity must receive the post-process status; a stale 'pre-process' value here means the caller dispatched before persisting resp.UpdatedScalingStatus",
+	)
+}
+
+// TestPullStatsAppliesStatusBeforeHandleActions mirrors
+// TestHandleNoSyncMatchSignalAppliesStatusBeforeDeferredDispatch for the metrics-poll path:
+// pullStatsAndUpdate must persist resp.UpdatedScalingStatus into d.State.ScalingStatus
+// *before* invoking handleActions. We observe this by mocking InvokeWorker as a
+// synchronous mid-dispatch probe and reading runner.State.ScalingStatus from the
+// activity's Run callback — if the assignment were reordered after handleActions, the
+// probe would observe the pre-poll status.
+func TestPullStatsAppliesStatusBeforeHandleActions(t *testing.T) {
+	algo := &deferredScalingDecisionTestAlgorithm{}
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+	computeConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(map[string]any{})
+	require.NoError(t, err)
+
+	activities := NewActivities(nil, nil, nil)
+	args := &iface.WorkerControllerInstanceWorkflowArgs{
+		NamespaceName:  "test-namespace",
+		DeploymentName: "test-deployment",
+		BuildId:        "test-build",
+		State: &iface.WorkerControllerInstanceLocalState{
+			Spec: &iface.WorkerControllerInstanceSpec{
+				ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+					"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, computeConfigPayload),
+				},
+			},
+			ScalingStatus: map[string]iface.ScalingAlgorithmStatus{
+				"workflow": {"phase": "pre-poll"},
+			},
+		},
+	}
+
+	var runner *WorkflowRunner
+	var observedStatusAtDispatch map[string]iface.ScalingAlgorithmStatus
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) (map[string]iface.ScalingAlgorithmStatus, error) {
+		runner = &WorkflowRunner{
+			WorkerControllerInstanceWorkflowArgs: args,
+			a:                                    activities,
+			logger:                               sdkworkflow.GetLogger(ctx),
+			metrics:                              sdkworkflow.GetMetricsHandler(ctx),
+		}
+		runner.pullStatsAndUpdate(ctx)
+		return runner.State.ScalingStatus, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+
+	postPollStatus := map[string]iface.ScalingAlgorithmStatus{
+		"workflow": {"phase": "post-poll"},
+	}
+	env.OnActivity(activities.PullStats, mock.Anything, mock.Anything).
+		Return(&PullStatsActivityResponse{
+			UpdatedScalingStatus: postPollStatus,
+			Actions: []scalingalgorithm.ScalingAction{
+				{ScalingGroupKey: "workflow", Action: scalingalgorithm.ActionTypeInvokeWorker},
+			},
+			NextPollSeconds: 30,
+		}, nil)
+	env.OnActivity(activities.InvokeWorker, mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			observedStatusAtDispatch = maps.Clone(runner.State.ScalingStatus)
+		})
+
+	env.ExecuteWorkflow(testWorkflow, args)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	assert.Equal(t,
+		iface.ScalingAlgorithmStatus{"phase": "post-poll"},
+		observedStatusAtDispatch["workflow"],
+		"InvokeWorker must observe the post-poll status: pullStatsAndUpdate must assign resp.UpdatedScalingStatus to d.State.ScalingStatus before invoking handleActions",
+	)
+}
+
+// fakeWorkflowServiceClient intercepts DescribeWorkerDeploymentVersion. Other methods on the
+// embedded interface are nil and will panic if invoked — by design, so a test reaching them
+// instead of the intended call fails loudly.
+type fakeWorkflowServiceClient struct {
+	workflowservice.WorkflowServiceClient
+	describeCalls int
+	describeFn    func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error)
+}
+
+func (f *fakeWorkflowServiceClient) DescribeWorkerDeploymentVersion(_ context.Context, in *workflowservice.DescribeWorkerDeploymentVersionRequest, _ ...grpc.CallOption) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+	f.describeCalls++
+	if f.describeFn == nil {
+		return nil, errors.New("fakeWorkflowServiceClient.describeFn not configured")
+	}
+	return f.describeFn(in)
+}
+
+func newDescribeResponseWithWorkflowBacklog(count int64) *workflowservice.DescribeWorkerDeploymentVersionResponse {
+	return &workflowservice.DescribeWorkerDeploymentVersionResponse{
+		VersionTaskQueues: []*workflowservice.DescribeWorkerDeploymentVersionResponse_VersionTaskQueue{
+			{
+				Name:  "test-queue",
+				Type:  enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+				Stats: &taskqueuepb.TaskQueueStats{ApproximateBacklogCount: count},
+			},
+		},
+	}
+}
+
+// runDeferredActivityWithFakeClient is a helper that wires a fakeWorkflowServiceClient into
+// Activities and runs HandleDeferredScalingDecision once for the "workflow" scaling group.
+func runDeferredActivityWithFakeClient(t *testing.T, algo *deferredScalingDecisionTestAlgorithm, fake *fakeWorkflowServiceClient) (*HandleDeferredScalingDecisionActivityResponse, error) {
+	t.Helper()
+	currentDeferredScalingDecisionTestAlgorithm = algo
+	t.Cleanup(func() {
+		currentDeferredScalingDecisionTestAlgorithm = nil
+	})
+
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+
+	activities := NewActivities(nil, nil, fake)
+	req := HandleDeferredScalingDecisionActivityRequest{
+		RequestContext: RequestContext{
+			NamespaceName:     "test-namespace",
+			DeploymentName:    "test-deployment",
+			DeploymentBuildID: "test-build",
+		},
+		Request:            newTestSignalTaskAddEvent(),
+		ScalingGroupKey:    "workflow",
+		ScalingGroupSpec:   newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, nil),
+		EffectiveTaskTypes: []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW},
+		ScalingStatus:      iface.ScalingAlgorithmStatus{"phase": "prior"},
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.HandleDeferredScalingDecision)
+	encodedResp, err := env.ExecuteActivity(activities.HandleDeferredScalingDecision, req)
+	if err != nil {
+		return nil, err
+	}
+	var resp HandleDeferredScalingDecisionActivityResponse
+	require.NoError(t, encodedResp.Get(&resp))
+	return &resp, nil
+}
+
+// TestHandleDeferredScalingDecisionMemoizesMetricsSnapshot pins the sync.OnceValues contract on the
+// success path: an algorithm that calls getMetricsSnapshot multiple times must see a single
+// underlying RPC and identical, pre-filtered results on every call.
+func TestHandleDeferredScalingDecisionMemoizesMetricsSnapshot(t *testing.T) {
+	fake := &fakeWorkflowServiceClient{
+		describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+			return newDescribeResponseWithWorkflowBacklog(42), nil
+		},
+	}
+
+	type call struct {
+		snap *scalingalgorithm.ScalingMetricsSnapshot
+		err  error
+	}
+	var calls []call
+	algo := &deferredScalingDecisionTestAlgorithm{
+		deferredHook: func(getMetricsSnapshot scalingalgorithm.ScalingMetricsSnapshotGetter) {
+			for range 3 {
+				snap, err := getMetricsSnapshot()
+				calls = append(calls, call{snap: snap, err: err})
+			}
+		},
+	}
+
+	_, err := runDeferredActivityWithFakeClient(t, algo, fake)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, fake.describeCalls, "DescribeWorkerDeploymentVersion must be called exactly once across all getter invocations")
+	require.Len(t, calls, 3)
+	for i, c := range calls {
+		require.NoError(t, c.err, "call %d", i)
+		require.NotNil(t, c.snap, "call %d", i)
+		require.NotNil(t, c.snap.Workflow, "call %d: workflow filter must retain workflow stats", i)
+		assert.Equal(t, int64(42), c.snap.Workflow.LastBacklogCount, "call %d", i)
+		assert.Nil(t, c.snap.Activity, "call %d: activity must be filtered out for workflow-only group", i)
+		assert.Nil(t, c.snap.Nexus, "call %d: nexus must be filtered out for workflow-only group", i)
+	}
+	// Isolation: each call returns an independently-owned snapshot. The describeCalls == 1
+	// assertion above already proves the cache is shared upstream; here we verify that the
+	// inner pointers are not aliased between sibling returns, so a mutation on one cannot
+	// corrupt another.
+	assert.NotSame(t, calls[0].snap.Workflow, calls[1].snap.Workflow, "filter must deep-copy inner stats so each getter call returns an independently-owned snapshot")
+	calls[0].snap.Workflow.LastBacklogCount = 999
+	assert.Equal(t, int64(42), calls[1].snap.Workflow.LastBacklogCount, "mutating one returned snapshot must not bleed into another")
+	assert.Equal(t, int64(42), calls[2].snap.Workflow.LastBacklogCount, "mutating one returned snapshot must not bleed into another")
+}
+
+// TestHandleDeferredScalingDecisionMemoizesMetricsSnapshotErrorSticky pins the sync.OnceValues
+// contract on the error path: a first-call failure is cached for the activity invocation, the
+// underlying RPC must not be retried within the same call, and DeferredScalingDecisionMetricsPullFailedCount
+// fires exactly once.
+func TestHandleDeferredScalingDecisionMemoizesMetricsSnapshotErrorSticky(t *testing.T) {
+	pullErr := errors.New("simulated describe failure")
+	fake := &fakeWorkflowServiceClient{
+		describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+			return nil, pullErr
+		},
+	}
+
+	type call struct {
+		snap *scalingalgorithm.ScalingMetricsSnapshot
+		err  error
+	}
+	var calls []call
+	algo := &deferredScalingDecisionTestAlgorithm{
+		deferredHook: func(getMetricsSnapshot scalingalgorithm.ScalingMetricsSnapshotGetter) {
+			for range 3 {
+				snap, err := getMetricsSnapshot()
+				calls = append(calls, call{snap: snap, err: err})
+			}
+		},
+	}
+
+	_, err := runDeferredActivityWithFakeClient(t, algo, fake)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, fake.describeCalls, "DescribeWorkerDeploymentVersion must be called exactly once even when it fails: errors are sticky")
+	require.Len(t, calls, 3)
+	for i, c := range calls {
+		assert.Nil(t, c.snap, "call %d", i)
+		require.Error(t, c.err, "call %d", i)
+		assert.ErrorIs(t, c.err, pullErr, "call %d: cached error must equal the original RPC error", i)
+	}
+}

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -165,6 +165,10 @@ func (a *scalingAlgorithmNoSync) ProcessTaskAdd(ctx context.Context, config ifac
 	return &TaskAddResponse{Actions: actions, Status: updatedState, ThrottledCount: throttledCount}, nil
 }
 
+func (a *scalingAlgorithmNoSync) ProcessDeferredScalingDecision(_ context.Context, _ iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, _ iface.SignalTaskAddRequest, _ ScalingMetricsSnapshotGetter) (*TaskAddResponse, error) {
+	return &TaskAddResponse{Actions: []ScalingAction{}, Status: priorState}, nil
+}
+
 func (a *scalingAlgorithmNoSync) ProcessMetricsPoll(ctx context.Context, config iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, metricsSnapshot ScalingMetricsSnapshot) (*MetricsPollResponse, error) {
 	updatedState := maps.Clone(priorState)
 	actions := []ScalingAction{}

--- a/wci/workflow/scaling_algorithm/no_sync_match_test.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match_test.go
@@ -20,6 +20,14 @@ func newNoSync() *scalingAlgorithmNoSync {
 	return algo.(*scalingAlgorithmNoSync)
 }
 
+func failScalingMetricsSnapshotGetter(t *testing.T) ScalingMetricsSnapshotGetter {
+	t.Helper()
+	return func() (*ScalingMetricsSnapshot, error) {
+		t.Fatalf("no-sync scaling algorithm should not request task-add metrics")
+		return &ScalingMetricsSnapshot{}, nil
+	}
+}
+
 func TestNoSyncValidateConfig(t *testing.T) {
 	a := newNoSync()
 	ctx := context.Background()
@@ -204,6 +212,20 @@ func TestNoSyncCompatibleLaunchStrategies(t *testing.T) {
 	strategies := a.CompatibleLaunchStrategies()
 	require.Len(t, strategies, 1)
 	assert.Equal(t, computeprovider.LaunchStrategyInvoke, strategies[0])
+}
+
+func TestNoSyncProcessDeferredScalingDecisionNoop(t *testing.T) {
+	a := newNoSync()
+	ctx := context.Background()
+	priorState := iface.ScalingAlgorithmStatus{"custom": int64(1)}
+	event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+
+	resp, err := a.ProcessDeferredScalingDecision(ctx, iface.ScalingAlgorithmConfig{}, priorState, event, failScalingMetricsSnapshotGetter(t))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Actions)
+	assert.Equal(t, priorState, resp.Status)
 }
 
 func TestNoSyncProcessMetricsPoll(t *testing.T) {

--- a/wci/workflow/scaling_algorithm/registry.go
+++ b/wci/workflow/scaling_algorithm/registry.go
@@ -30,6 +30,11 @@ type (
 		Nexus    *iface.QueueTypeScalingMetrics `json:"nexus,omitempty"`
 	}
 
+	// ScalingMetricsSnapshotGetter fetches a metrics snapshot lazily, memoising both the
+	// snapshot and any error for the lifetime of a single activity invocation, so callers
+	// can invoke it zero or more times without incurring extra RPCs.
+	ScalingMetricsSnapshotGetter func() (*ScalingMetricsSnapshot, error)
+
 	TaskAddResponse struct {
 		// Actions contains the list of scaling actions to take as a result of the analysis
 		Actions []ScalingAction
@@ -60,19 +65,38 @@ type (
 		// to be taken (e.g. scale-up or down) and return an adjusted status.
 		ProcessTaskAdd(ctx context.Context, config iface.ScalingAlgorithmConfig, priorStatus iface.ScalingAlgorithmStatus, event iface.SignalTaskAddRequest) (*TaskAddResponse, error)
 
+		// ProcessDeferredScalingDecision handles deferred scaling decisions requested by a prior
+		// ActionTypeDeferredScalingDecision action. event is forwarded verbatim from the original
+		// task-add signal. The snapshot returned by getMetricsSnapshot is pre-filtered to the
+		// scaling group's effective task types (fields outside that set are nil); see the
+		// ScalingMetricsSnapshotGetter type for caching and read-only semantics.
+		//
+		// Why this exists: ProcessTaskAdd runs as a local activity to keep the signal-handler
+		// path fast, but local activities cannot use the metrics API (it issues a query against
+		// the same workflow, which would deadlock). Algorithms that need a metrics snapshot — or
+		// any other higher-latency processing — emit ActionTypeDeferredScalingDecision to push
+		// that work into this normal activity, where the snapshot is available.
+		//
+		// The returned Actions MUST NOT contain ActionTypeDeferredScalingDecision: deferred
+		// actions cannot themselves chain into more deferred work.
+		ProcessDeferredScalingDecision(ctx context.Context, config iface.ScalingAlgorithmConfig, priorStatus iface.ScalingAlgorithmStatus, event iface.SignalTaskAddRequest, getMetricsSnapshot ScalingMetricsSnapshotGetter) (*TaskAddResponse, error)
+
 		// ProcessMetricsPoll handles the results of regular queue metrics polls. It only recieves data
 		// for task queue types the scaling algorithm is responsible for. Can return a set of actions to
 		// take as a result, as well as updated scaling status and when to poll again at the latest.
 		//
 		// Note: the next invocation might be earlier than the provided time, if other algorithms requested
 		// a higher frequency.
+		//
+		// The returned Actions MUST NOT contain ActionTypeDeferredScalingDecision as it is not supported.
 		ProcessMetricsPoll(ctx context.Context, config iface.ScalingAlgorithmConfig, priorStatus iface.ScalingAlgorithmStatus, metricsSnapshot ScalingMetricsSnapshot) (*MetricsPollResponse, error)
 	}
 )
 
 const (
-	ActionTypeInvokeWorker        ActionType = "invoke-worker"
-	ActionTypeUpdateWorkerSetSize ActionType = "update-worker-set-size"
+	ActionTypeInvokeWorker            ActionType = "invoke-worker"
+	ActionTypeUpdateWorkerSetSize     ActionType = "update-worker-set-size"
+	ActionTypeDeferredScalingDecision ActionType = "deferred-scaling-decision"
 )
 
 var (

--- a/wci/workflow/scaling_metrics_snapshot.go
+++ b/wci/workflow/scaling_metrics_snapshot.go
@@ -1,0 +1,89 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	scalingalgorithm "go.temporal.io/auto-scaled-workers/wci/workflow/scaling_algorithm"
+	"go.temporal.io/sdk/activity"
+)
+
+func (a *Activities) pullScalingMetricsSnapshot(ctx context.Context, namespaceName string, deploymentName string, deploymentBuildID string) (*scalingalgorithm.ScalingMetricsSnapshot, error) {
+	logger := activity.GetLogger(ctx)
+
+	deploymentVersionDetails, err := a.workflowserviceClient.DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
+		Namespace: namespaceName,
+		DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        deploymentBuildID,
+		},
+		ReportTaskQueueStats: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if deploymentVersionDetails == nil {
+		return nil, fmt.Errorf("did not receive details in the describe response")
+	}
+
+	metricsSnapshot := scalingalgorithm.ScalingMetricsSnapshot{
+		Workflow: &iface.QueueTypeScalingMetrics{},
+		Activity: &iface.QueueTypeScalingMetrics{},
+		Nexus:    &iface.QueueTypeScalingMetrics{},
+	}
+	for _, versionedTaskQueue := range deploymentVersionDetails.VersionTaskQueues {
+		if versionedTaskQueue == nil || versionedTaskQueue.Stats == nil {
+			continue
+		}
+
+		switch versionedTaskQueue.Type {
+		case enumspb.TASK_QUEUE_TYPE_WORKFLOW:
+			metricsSnapshot.Workflow.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
+			metricsSnapshot.Workflow.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
+			metricsSnapshot.Workflow.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
+		case enumspb.TASK_QUEUE_TYPE_ACTIVITY:
+			metricsSnapshot.Activity.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
+			metricsSnapshot.Activity.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
+			metricsSnapshot.Activity.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
+		case enumspb.TASK_QUEUE_TYPE_NEXUS:
+			metricsSnapshot.Nexus.LastBacklogCount += versionedTaskQueue.Stats.ApproximateBacklogCount
+			metricsSnapshot.Nexus.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
+			metricsSnapshot.Nexus.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
+		}
+	}
+
+	logger.Info("Pulled scaling metrics snapshot", "workflow_count", metricsSnapshot.Workflow.LastBacklogCount, "activity_count", metricsSnapshot.Activity.LastBacklogCount, "nexus_count", metricsSnapshot.Nexus.LastBacklogCount)
+
+	return &metricsSnapshot, nil
+}
+
+func filterScalingMetricsSnapshotByTaskTypes(metricsSnapshot *scalingalgorithm.ScalingMetricsSnapshot, taskTypes []enumspb.TaskQueueType) *scalingalgorithm.ScalingMetricsSnapshot {
+	if metricsSnapshot == nil {
+		return nil
+	}
+
+	cloneStats := func(src *iface.QueueTypeScalingMetrics) *iface.QueueTypeScalingMetrics {
+		if src == nil {
+			return nil
+		}
+		clone := *src
+		return &clone
+	}
+
+	filtered := scalingalgorithm.ScalingMetricsSnapshot{}
+	if slices.Contains(taskTypes, enumspb.TASK_QUEUE_TYPE_WORKFLOW) {
+		filtered.Workflow = cloneStats(metricsSnapshot.Workflow)
+	}
+	if slices.Contains(taskTypes, enumspb.TASK_QUEUE_TYPE_ACTIVITY) {
+		filtered.Activity = cloneStats(metricsSnapshot.Activity)
+	}
+	if slices.Contains(taskTypes, enumspb.TASK_QUEUE_TYPE_NEXUS) {
+		filtered.Nexus = cloneStats(metricsSnapshot.Nexus)
+	}
+	return &filtered
+}

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	ValidateSpecActivityTimeout                 = 15 * time.Second
-	PullStatsActivityTimeout                    = 15 * time.Second
-	HandleTaskAddSignalActivityTimeout          = 15 * time.Second
-	InvokeWorkerActivityTimeout                 = 2 * time.Minute
-	UpdateWorkerSetSizeActivityTimeout          = 2 * time.Minute
-	RegisterTaskQueuesViaWorkersActivityTimeout = 30 * time.Second
+	ValidateSpecActivityTimeout                  = 15 * time.Second
+	PullStatsActivityTimeout                     = 15 * time.Second
+	HandleTaskAddSignalActivityTimeout           = 15 * time.Second
+	HandleDeferredScalingDecisionActivityTimeout = 15 * time.Second
+	InvokeWorkerActivityTimeout                  = 2 * time.Minute
+	UpdateWorkerSetSizeActivityTimeout           = 2 * time.Minute
+	RegisterTaskQueuesViaWorkersActivityTimeout  = 30 * time.Second
 
 	periodicValidationInterval = 6 * time.Hour
 )
@@ -493,10 +494,12 @@ func (d *WorkflowRunner) pullStatsAndUpdate(ctx workflow.Context) time.Duration 
 			wcimetrics.OperationTagName: wcimetrics.OperationTypePullStats,
 		}).Counter(wcimetrics.Operations.Name()).Inc(1)
 
-		d.handleActions(ctx, resp.Actions)
+		// Apply the updated status before handleActions for consistency between this
+		// and the no-sync-match path
 		if resp.UpdatedScalingStatus != nil {
 			d.State.ScalingStatus = resp.UpdatedScalingStatus
 		}
+		d.handleActions(ctx, resp.Actions, nil)
 
 		return time.Duration(resp.NextPollSeconds) * time.Second
 	}
@@ -580,14 +583,25 @@ func (d *WorkflowRunner) handleNoSyncMatchSignal(ctx workflow.Context, req *ifac
 
 		d.logger.Debug("Completed match-signal processing", "action_count", len(resp.Actions), "sync_match", req.IsSyncMatch, "no_sync_match_batch", req.NoSyncMatchSignalsSinceLast)
 
-		d.handleActions(ctx, resp.Actions)
+		// Apply the updated status before handleActions: deferred scaling decisions read
+		// d.State.ScalingStatus when forwarding it to their follow-up activity, and must
+		// see the freshly-computed status rather than the pre-process snapshot.
 		if resp.UpdatedScalingStatus != nil {
 			d.State.ScalingStatus = resp.UpdatedScalingStatus
 		}
+		d.handleActions(ctx, resp.Actions, req)
 	}
 }
 
-func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingalgorithm.ScalingAction) {
+// handleActions dispatches scaling actions returned by the scaling algorithm.
+//
+// ScalingStatus is treated as intent, not confirmation: callers must persist
+// resp.UpdatedScalingStatus into d.State.ScalingStatus before invoking this
+// function. The deferred scaling decision case forwards d.State.ScalingStatus to its
+// follow-up activity and so must see the freshly-computed status. If a
+// dispatched action subsequently fails, the persisted status is not rolled
+// back.
+func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingalgorithm.ScalingAction, taskAddRequest *iface.SignalTaskAddRequest) {
 	if d.State == nil || d.State.Spec == nil {
 		return
 	}
@@ -600,11 +614,64 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 
 		spec, specOk := d.State.Spec.ScalingGroupSpecs[action.ScalingGroupKey]
 		if !specOk {
-			d.logger.Warn("No compute provider spec for scale up action", "scale_group_id", action.ScalingGroupKey)
+			d.logger.Warn("No compute provider spec for scale up action", "scaling_group_key", action.ScalingGroupKey)
 			continue
 		}
 
 		switch action.Action {
+		case scalingalgorithm.ActionTypeDeferredScalingDecision:
+			if action.Count != nil {
+				d.logger.Warn("Deferred scaling decision must not carry a count; dropping action", "scaling_group_key", action.ScalingGroupKey, "count", *action.Count)
+				d.metrics.WithTags(map[string]string{
+					wcimetrics.OperationTagName:  wcimetrics.OperationTypeDeferredScalingDecision,
+					wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonInvalidCount),
+				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				continue
+			}
+			if taskAddRequest == nil {
+				d.logger.Error("Deferred scaling decision cannot be handled without source task-add request; dropping (only ProcessTaskAdd may return ActionTypeDeferredScalingDecision)", "scaling_group_key", action.ScalingGroupKey)
+				d.metrics.WithTags(map[string]string{
+					wcimetrics.OperationTagName:  wcimetrics.OperationTypeDeferredScalingDecision,
+					wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonNoSourceRequest),
+				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				continue
+			}
+
+			d.metrics.Counter(wcimetrics.DeferredScalingDecisionCount.Name()).Inc(1)
+
+			var resp HandleDeferredScalingDecisionActivityResponse
+			if err := workflow.ExecuteActivity(
+				workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: HandleDeferredScalingDecisionActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 2}}),
+				d.a.HandleDeferredScalingDecision,
+				HandleDeferredScalingDecisionActivityRequest{
+					RequestContext: d.requestContext(),
+
+					Request:         *taskAddRequest,
+					ScalingGroupKey: action.ScalingGroupKey,
+
+					ScalingGroupSpec:   spec,
+					EffectiveTaskTypes: d.State.Spec.EffectiveTaskTypesForGroup(action.ScalingGroupKey),
+					ScalingStatus:      d.State.ScalingStatus[action.ScalingGroupKey],
+				},
+			).Get(ctx, &resp); err != nil {
+				d.logger.Error("Failed to process deferred scaling decision", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "scaling_group_key", action.ScalingGroupKey, "error", err)
+				d.metrics.WithTags(map[string]string{
+					wcimetrics.OperationTagName:         wcimetrics.OperationTypeDeferredScalingDecision,
+					wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
+					wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
+				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+			} else {
+
+				if resp.UpdatedScalingStatus != nil {
+					d.State.ScalingStatus[action.ScalingGroupKey] = resp.UpdatedScalingStatus
+				}
+				d.handleActions(ctx, resp.Actions, nil)
+
+				d.metrics.WithTags(map[string]string{
+					wcimetrics.OperationTagName: wcimetrics.OperationTypeDeferredScalingDecision,
+				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+			}
+
 		case scalingalgorithm.ActionTypeInvokeWorker:
 			if action.Count != nil && *action.Count != 1 {
 				d.logger.Warn("Invalid count for action type invoke worker received", "count", *action.Count)


### PR DESCRIPTION
Introduces a new `deferred-process-task-add` scaling action that lets algorithms request follow-up task-add processing with access to a metrics snapshot. The workflow handles the action by executing a new `HandleDeferredTaskAddAction` activity, which invokes the algorithm's `DeferredProcessTaskAdd` hook with a cached, task-type-filtered metrics snapshot getter.

Also adds:
- `DeferredProcessTaskAddCount` metric.
- Default no-op `DeferredProcessTaskAdd` implementation on the no-sync-match algorithm.
- Helpers in `scaling_metrics_snapshot.go` for filtering and caching metrics snapshots.
- Activity and algorithm tests covering the new path.

State updates from scaling responses are now applied before dispatching follow-up actions so deferred handlers see the latest status.

Background: for efficiency reasons the ProcessTaskAdd hook is run in a local activity. Unfortunately, that cannot access the metrics (as the metrics API is dependent on making a query to this same workflow so we get a circular dependency). The deferred hook allows offloading that, as well as any other higher latency processing into a “normal” activity.