### PR TITLE
Adding algorithm for GCP CloudRun WorkerPools and similar compute providers

### DIFF
--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -70,18 +70,14 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, co
 	}
 	defer client.Close()
 
-	op, err := client.UpdateWorkerPool(ctx, &runpb.UpdateWorkerPoolRequest{
+	if _, err = client.UpdateWorkerPool(ctx, &runpb.UpdateWorkerPoolRequest{
 		WorkerPool: &runpb.WorkerPool{
 			Name:    name,
 			Scaling: &runpb.WorkerPoolScaling{ManualInstanceCount: &count},
 		},
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling"}},
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
-	}
-	if _, err = op.Wait(ctx); err != nil {
-		return fmt.Errorf("failed to wait for worker pool %q update: %w", name, err)
 	}
 	return nil
 }

--- a/wci/workflow/iface/map_access.go
+++ b/wci/workflow/iface/map_access.go
@@ -1,6 +1,7 @@
 package iface
 
 import (
+	"math"
 	"strconv"
 
 	"go.temporal.io/api/serviceerror"
@@ -114,6 +115,9 @@ func validateFloat64InMap(m map[string]any, key string, minValidValue float64) e
 	case float64:
 		if val < minValidValue {
 			return serviceerror.NewInvalidArgumentf("%s must be at least %v", key, minValidValue)
+		}
+		if math.IsInf(val, 0) || math.IsNaN(val) {
+			return serviceerror.NewInvalidArgumentf("%s must be a real float", key)
 		}
 	case string:
 		i, err := strconv.ParseFloat(val, 64)

--- a/wci/workflow/scaling_algorithm/rate_based.go
+++ b/wci/workflow/scaling_algorithm/rate_based.go
@@ -1,0 +1,830 @@
+package scalingalgorithm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"math"
+	"time"
+
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+)
+
+const (
+	// configRateBasedMinCountKey is the lower bound on worker count (default: 0).
+	configRateBasedMinCountKey     = "min_count"
+	configRateBasedMinCountDefault = int64(0)
+
+	// configRateBasedMaxCountKey is the upper bound on worker count (default: 30).
+	configRateBasedMaxCountKey     = "max_count"
+	configRateBasedMaxCountDefault = int64(30)
+
+	// configRateBasedInitialCountKey is the worker count assumed when creating the worker
+	// deployment version (default: 0 for the common case of configuring an empty worker pool)
+	configRateBasedInitialCountKey     = "initial_count"
+	configRateBasedInitialCountDefault = int64(0)
+
+	// configRateBasedMetricsPollIntervalMsKey is the interval in milliseconds
+	// between metrics-poll activity invocations. Cooldown values (scale_up_cooldown_ms,
+	// scale_down_cooldown_ms) should not exceed this interval.
+	configRateBasedMetricsPollIntervalMsKey     = "metrics_poll_interval_ms"
+	configRateBasedMetricsPollIntervalMsDefault = int64(60_000)
+
+	// configRateBasedEWMAAlphaKey is the smoothing factor (in (0, 1]) applied to
+	// all three EWMAs — arrival rate, dispatch rate, and per-consumer capacity.
+	// Higher values react faster to fresh samples; lower values smooth more but
+	// lag the true rate. A single alpha is shared deliberately: splitting per
+	// series can let the load and capacity estimates drift apart and
+	// produce oscillating scale decisions.
+	configRateBasedEWMAAlphaKey     = "ewma_alpha"
+	configRateBasedEWMAAlphaDefault = 0.45
+
+	// configRateBasedInitialPerConsumerCapacityKey is the starting estimate, in
+	// tasks per second per worker, for how many tasks one worker can process.
+	configRateBasedInitialPerConsumerCapacityKey     = "initial_per_consumer_capacity"
+	configRateBasedInitialPerConsumerCapacityDefault = 2.0
+
+	// configRateBasedTargetBacklogDrainRateKey is the throughput, in tasks per
+	// second, the algorithm adds to the arrival rate when backlog > 0. Larger
+	// values scale up more aggressively under backlog. Set to 0 to size purely
+	// from arrival rate and never react to backlog.
+	configRateBasedTargetBacklogDrainRateKey     = "target_backlog_drain_rate"
+	configRateBasedTargetBacklogDrainRateDefault = 2.0
+
+	// configRateBasedMaterialBacklogThresholdKey gates per-consumer capacity
+	// sampling on the metrics-poll path: dispatch / planned_count is taken as
+	// an empirical capacity sample only when backlog >= this threshold. Below
+	// the threshold the system may be dispatch-starved rather than
+	// capacity-bound, and that ratio would understate true worker capacity.
+	configRateBasedMaterialBacklogThresholdKey     = "material_backlog_threshold"
+	configRateBasedMaterialBacklogThresholdDefault = int64(50)
+
+	// configRateBasedUtilizationTargetKey is the target average worker
+	// utilization (a fraction in (0, 1]). The utilization sizing model picks
+	// ceil(offered_load / utilization_target); lower values reserve more
+	// headroom per worker.
+	configRateBasedUtilizationTargetKey     = "utilization_target"
+	configRateBasedUtilizationTargetDefault = 0.80
+
+	// configRateBasedHalfinWhittBetaKey is the safety-staffing coefficient in
+	// the Halfin-Whitt square-root staffing rule:
+	//     desired = ceil(offered_load + beta * sqrt(offered_load))
+	// Larger beta reserves more headroom to absorb arrival-rate variance. The
+	// final desired worker count is the maximum of this model and the
+	// utilization-target model, so whichever demands more workers wins.
+	configRateBasedHalfinWhittBetaKey     = "halfin_whitt_beta"
+	configRateBasedHalfinWhittBetaDefault = 0.5
+
+	// configRateBasedMaxScaleUpStepKey caps how many workers a single scale-up
+	// may add, regardless of how much higher the desired count is than the current count.
+	configRateBasedMaxScaleUpStepKey     = "max_scale_up_step"
+	configRateBasedMaxScaleUpStepDefault = int64(4)
+
+	// configRateBasedScaleUpCooldownMsKey is the minimum elapsed time, in
+	// milliseconds, between consecutive scale-up actions. Asymmetric with
+	// scale_down_cooldown_ms: scale-up is short to react to spikes, scale-down
+	// is long to avoid thrashing on transient dips. Must not exceed
+	// metrics_poll_interval_ms.
+	configRateBasedScaleUpCooldownMsKey     = "scale_up_cooldown_ms"
+	configRateBasedScaleUpCooldownMsDefault = int64(2_000)
+
+	// configRateBasedScaleDownCooldownMsKey is the minimum elapsed time, in
+	// milliseconds, between consecutive scale-down actions. See
+	// scale_up_cooldown_ms for details on the asymmetry.
+	configRateBasedScaleDownCooldownMsKey     = "scale_down_cooldown_ms"
+	configRateBasedScaleDownCooldownMsDefault = int64(60_000)
+
+	// configRateBasedNoSyncQuietMsKey is the time, in milliseconds, that must
+	// elapse with no no-sync-match task-add signal before scale-down may fire.
+	// This blocks scale-down while the queue is still seeing sync-match misses
+	// — an early signal that capacity is insufficient, often arriving before
+	// the EWMA rates have caught up.
+	configRateBasedNoSyncQuietMsKey     = "no_sync_quiet_ms"
+	configRateBasedNoSyncQuietMsDefault = int64(90_000)
+
+	stateRateBasedWorkerCount              = "worker_count"
+	stateRateBasedEWMAArrivalRate          = "ewma_arrival_rate"
+	stateRateBasedEWMADispatchRate         = "ewma_dispatch_rate"
+	stateRateBasedEWMAPerConsumerCapacity  = "ewma_per_consumer_capacity"
+	stateRateBasedLastScaleUpTimestamp     = "last_scale_up_time_ms"
+	stateRateBasedLastScaleDownTimestamp   = "last_scale_down_time_ms"
+	stateRateBasedLastNoSyncMatchTimestamp = "last_no_sync_match_time_ms"
+)
+
+var _ ScalingAlgorithm = (*scalingAlgorithmRateBased)(nil)
+
+var rateBasedValidConfigKeys = map[string]struct{}{
+	configRateBasedMinCountKey:                   {},
+	configRateBasedMaxCountKey:                   {},
+	configRateBasedInitialCountKey:               {},
+	configRateBasedMetricsPollIntervalMsKey:      {},
+	configRateBasedEWMAAlphaKey:                  {},
+	configRateBasedInitialPerConsumerCapacityKey: {},
+	configRateBasedTargetBacklogDrainRateKey:     {},
+	configRateBasedMaterialBacklogThresholdKey:   {},
+	configRateBasedUtilizationTargetKey:          {},
+	configRateBasedHalfinWhittBetaKey:            {},
+	configRateBasedMaxScaleUpStepKey:             {},
+	configRateBasedScaleUpCooldownMsKey:          {},
+	configRateBasedScaleDownCooldownMsKey:        {},
+	configRateBasedNoSyncQuietMsKey:              {},
+}
+
+var rateBasedValidStateKeys = map[string]struct{}{
+	stateRateBasedWorkerCount:              {},
+	stateRateBasedEWMAArrivalRate:          {},
+	stateRateBasedEWMADispatchRate:         {},
+	stateRateBasedEWMAPerConsumerCapacity:  {},
+	stateRateBasedLastScaleUpTimestamp:     {},
+	stateRateBasedLastScaleDownTimestamp:   {},
+	stateRateBasedLastNoSyncMatchTimestamp: {},
+}
+
+// rateBasedFiniteFloat64StateKeys names state slots that must hold a finite
+// float64. cleanRateBasedState drops any slot whose stored value violates that
+// invariant so downstream code can treat these slots as trusted.
+var rateBasedFiniteFloat64StateKeys = []string{
+	stateRateBasedEWMAArrivalRate,
+	stateRateBasedEWMADispatchRate,
+	stateRateBasedEWMAPerConsumerCapacity,
+}
+
+// rateBasedNonNegativeInt64StateKeys names state slots that must hold a
+// non-negative int64. cleanRateBasedState drops violators so
+// downstream code can treat these slots as trusted.
+var rateBasedNonNegativeInt64StateKeys = []string{
+	stateRateBasedLastScaleUpTimestamp,
+	stateRateBasedLastScaleDownTimestamp,
+	stateRateBasedLastNoSyncMatchTimestamp,
+}
+
+type (
+	scalingAlgorithmRateBased struct{}
+
+	rateBasedAggregateMetrics struct {
+		backlog      int64
+		arrivalRate  float64
+		dispatchRate float64
+
+		// hasData carries the "this aggregate reflects observed samples, not
+		// missing data" bit.
+		hasData bool
+
+		// droppedQueues names the queue types whose samples were excluded as
+		// non-finite for this poll. The aggregate still summarizes the
+		// remaining queues (hasData may be true).
+		droppedQueues []string
+	}
+)
+
+func init() {
+	RegisterScalingAlgorithm(
+		iface.ScalingAlgorithmRateBased,
+		NewScalingAlgorithmRateBased,
+		iface.ComputeProviderTypeAWSECS,
+		iface.ComputeProviderTypeK8s,
+		iface.ComputeProviderTypeGCPCloudRun,
+	)
+}
+
+func NewScalingAlgorithmRateBased(_ context.Context) (ScalingAlgorithm, error) {
+	return &scalingAlgorithmRateBased{}, nil
+}
+
+func (a *scalingAlgorithmRateBased) CompatibleLaunchStrategies() []computeprovider.LaunchStrategy {
+	return []computeprovider.LaunchStrategy{computeprovider.LaunchStrategyWorkerSet}
+}
+
+func (a *scalingAlgorithmRateBased) ValidateConfig(_ context.Context, config iface.ScalingAlgorithmConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	for k := range config {
+		if _, ok := rateBasedValidConfigKeys[k]; !ok {
+			return fmt.Errorf("unknown config key %q for rate-based scaling algorithm", k)
+		}
+	}
+
+	intFields := []struct {
+		key string
+		min int64
+	}{
+		{configRateBasedMinCountKey, 0},
+		{configRateBasedMaxCountKey, 1},
+		{configRateBasedInitialCountKey, 0},
+		{configRateBasedMetricsPollIntervalMsKey, 30_000},
+		{configRateBasedMaterialBacklogThresholdKey, 1},
+		{configRateBasedMaxScaleUpStepKey, 1},
+		{configRateBasedScaleUpCooldownMsKey, 0},
+		{configRateBasedScaleDownCooldownMsKey, 0},
+		{configRateBasedNoSyncQuietMsKey, 0},
+	}
+	for _, f := range intFields {
+		if err := config.ValidateInt64Field(f.key, f.min); err != nil {
+			return err
+		}
+	}
+
+	floatFields := []struct {
+		key string
+		min float64
+	}{
+		{configRateBasedEWMAAlphaKey, 0},
+		{configRateBasedInitialPerConsumerCapacityKey, 0},
+		{configRateBasedTargetBacklogDrainRateKey, 0},
+		{configRateBasedUtilizationTargetKey, 0},
+		{configRateBasedHalfinWhittBetaKey, 0},
+	}
+	for _, f := range floatFields {
+		if err := config.ValidateFloat64Field(f.key, f.min); err != nil {
+			return err
+		}
+	}
+
+	// Worker counts narrow to int32 at every consumer (ScalingAction.Count,
+	// arithmetic in computeRateBasedDesiredCapacity, persisted worker_count
+	// round-trip). Reject configs that would silently wrap.
+	for _, key := range []string{
+		configRateBasedMinCountKey,
+		configRateBasedMaxCountKey,
+		configRateBasedInitialCountKey,
+		configRateBasedMaxScaleUpStepKey,
+	} {
+		if _, present := config[key]; !present {
+			continue
+		}
+		v := config.GetInt64Field(key, 0)
+		if v > math.MaxInt32 {
+			return fmt.Errorf("%s (%d) must not exceed math.MaxInt32 (%d)", key, v, math.MaxInt32)
+		}
+		if v < 0 {
+			return fmt.Errorf("%s (%d) must be non-negative", key, v)
+		}
+	}
+
+	minCount := config.GetInt64Field(configRateBasedMinCountKey, configRateBasedMinCountDefault)
+	maxCount := config.GetInt64Field(configRateBasedMaxCountKey, configRateBasedMaxCountDefault)
+	if minCount > maxCount {
+		return fmt.Errorf("min_count (%d) must not exceed max_count (%d)", minCount, maxCount)
+	}
+
+	initialCount := config.GetInt64Field(configRateBasedInitialCountKey, configRateBasedInitialCountDefault)
+	if initialCount < minCount || initialCount > maxCount {
+		return fmt.Errorf("initial_count (%d) must be between min_count (%d) and max_count (%d)", initialCount, minCount, maxCount)
+	}
+
+	alpha := config.GetFloat64Field(configRateBasedEWMAAlphaKey, configRateBasedEWMAAlphaDefault)
+	if math.IsNaN(alpha) || alpha <= 0 || alpha > 1 {
+		return fmt.Errorf("ewma_alpha (%v) must be a finite number in (0, 1]", alpha)
+	}
+
+	initialCapacity := config.GetFloat64Field(configRateBasedInitialPerConsumerCapacityKey, configRateBasedInitialPerConsumerCapacityDefault)
+	if !isPositiveFinite(initialCapacity) {
+		return fmt.Errorf("initial_per_consumer_capacity (%v) must be a positive finite number", initialCapacity)
+	}
+
+	utilizationTarget := config.GetFloat64Field(configRateBasedUtilizationTargetKey, configRateBasedUtilizationTargetDefault)
+	if math.IsNaN(utilizationTarget) || utilizationTarget <= 0 || utilizationTarget > 1 {
+		return fmt.Errorf("utilization_target (%v) must be a finite number in (0, 1]", utilizationTarget)
+	}
+
+	pollInterval := config.GetInt64Field(configRateBasedMetricsPollIntervalMsKey, configRateBasedMetricsPollIntervalMsDefault)
+	scaleUpCooldown := config.GetInt64Field(configRateBasedScaleUpCooldownMsKey, configRateBasedScaleUpCooldownMsDefault)
+	if scaleUpCooldown > 0 && pollInterval < scaleUpCooldown {
+		return fmt.Errorf("metrics_poll_interval_ms (%d) must be >= scale_up_cooldown_ms (%d), otherwise the scale-up cooldown blocks every poll", pollInterval, scaleUpCooldown)
+	}
+
+	scaleDownCooldown := config.GetInt64Field(configRateBasedScaleDownCooldownMsKey, configRateBasedScaleDownCooldownMsDefault)
+	if scaleDownCooldown > 0 && pollInterval < scaleDownCooldown {
+		return fmt.Errorf("metrics_poll_interval_ms (%d) must be >= scale_down_cooldown_ms (%d), otherwise the scale-down cooldown blocks every poll", pollInterval, scaleDownCooldown)
+	}
+
+	return nil
+}
+
+func (a *scalingAlgorithmRateBased) ProcessTaskAdd(
+	ctx context.Context,
+	config iface.ScalingAlgorithmConfig,
+	priorState iface.ScalingAlgorithmStatus,
+	request iface.SignalTaskAddRequest,
+) (*TaskAddResponse, error) {
+	logger := safeActivityLogger(ctx)
+
+	if priorState == nil {
+		priorState = iface.ScalingAlgorithmStatus{}
+	}
+	if config == nil {
+		config = iface.ScalingAlgorithmConfig{}
+	}
+
+	actions := []ScalingAction{}
+	nowMs := time.Now().UnixMilli()
+	updatedState := cleanRateBasedState(ctx, priorState)
+	currentCount := currentRateBasedPlannedCount(config, updatedState)
+	updatedState[stateRateBasedWorkerCount] = int64(currentCount)
+
+	if request.IsSyncMatch && request.NoSyncMatchSignalsSinceLast == 0 {
+		logger.Info("Rate-based Task Add Decision", "outcome", "skip_sync_match")
+		return &TaskAddResponse{Actions: actions, Status: updatedState}, nil
+	}
+	deferredAction := ScalingAction{Action: ActionTypeDeferredScalingDecision}
+
+	// Bump stateRateBasedLastNoSyncMatchTimestamp before the cooldown and
+	// max-count gates so even no-op task-add outcomes keep scale-down blocked
+	// on the metrics-poll path for at least `no_sync_quiet` ms.
+	updatedState[stateRateBasedLastNoSyncMatchTimestamp] = nowMs
+
+	// Batched no-sync-match signals that did not produce a scale-up are reported
+	// via ThrottledCount so HandleTaskAddSignal can increment the
+	// scale_up_throttled metric.
+	throttledCount := request.NoSyncMatchSignalsSinceLast
+
+	maxCount := int32(config.GetInt64Field(configRateBasedMaxCountKey, configRateBasedMaxCountDefault))
+	if currentCount >= maxCount {
+		actions = append(actions, deferredAction)
+		logger.Info("Rate-based Task Add Decision", "outcome", "no_action_max_count", "count", currentCount, "no_sync_timestamp_bumped_ms", nowMs)
+		return &TaskAddResponse{Actions: actions, Status: updatedState, ThrottledCount: throttledCount}, nil
+	}
+
+	cooldownMs := config.GetInt64Field(configRateBasedScaleUpCooldownMsKey, configRateBasedScaleUpCooldownMsDefault)
+	lastScaleUpMs := updatedState.GetInt64Field(stateRateBasedLastScaleUpTimestamp, 0)
+	if nowMs-lastScaleUpMs < cooldownMs {
+		actions = append(actions, deferredAction)
+		logger.Info("Rate-based Task Add Decision", "outcome", "no_action_cooldown", "count", currentCount, "last_scale_up", lastScaleUpMs, "no_sync_timestamp_bumped_ms", nowMs)
+		return &TaskAddResponse{Actions: actions, Status: updatedState, ThrottledCount: throttledCount}, nil
+	}
+
+	newCount := currentCount + 1
+	updatedState[stateRateBasedWorkerCount] = int64(newCount)
+	updatedState[stateRateBasedLastScaleUpTimestamp] = nowMs
+	actions = append(actions, ScalingAction{Action: ActionTypeUpdateWorkerSetSize, Count: &newCount})
+	actions = append(actions, deferredAction)
+
+	logger.Info("Rate-based Task Add Decision", "outcome", "scale_up", "count", currentCount)
+
+	// Don't return a ThrottledCount here as we did not throttle, but took action
+	return &TaskAddResponse{Actions: actions, Status: updatedState}, nil
+}
+
+func (a *scalingAlgorithmRateBased) ProcessDeferredScalingDecision(
+	ctx context.Context,
+	config iface.ScalingAlgorithmConfig,
+	priorState iface.ScalingAlgorithmStatus,
+	_ iface.SignalTaskAddRequest,
+	getMetricsSnapshot ScalingMetricsSnapshotGetter,
+) (*TaskAddResponse, error) {
+	logger := safeActivityLogger(ctx)
+	if priorState == nil {
+		priorState = iface.ScalingAlgorithmStatus{}
+	}
+	if config == nil {
+		config = iface.ScalingAlgorithmConfig{}
+	}
+
+	updatedState := cleanRateBasedState(ctx, priorState)
+	currentCount := currentRateBasedPlannedCount(config, updatedState)
+	updatedState[stateRateBasedWorkerCount] = int64(currentCount)
+	actions := []ScalingAction{}
+
+	if getMetricsSnapshot == nil {
+		// Bug: this should not happen, but let's handle it to be defensive
+		err := errors.New("rate-based deferred decision: metrics getter is nil — programming defect in activity dispatcher")
+		logger.Error(err.Error(), "current_count", currentCount)
+		return nil, err
+	}
+	if currentCount <= 0 {
+		logger.Info("Rate-based deferred decision skipped", "current_count", currentCount)
+		return &TaskAddResponse{Actions: actions, Status: updatedState}, nil
+	}
+
+	metricsSnapshot, err := getMetricsSnapshot()
+	if err != nil {
+		logger.Error("Rate-based deferred metrics fetch failed", "error", err, "current_count", currentCount)
+		return nil, fmt.Errorf("rate-based deferred metrics fetch: %w", err)
+	}
+	metrics := aggregateRateBasedMetrics(ctx, metricsSnapshot)
+	previousCapacity := estimatedRateBasedPerConsumerCapacity(config, updatedState)
+
+	// Gate the capacity write on hasData only and ingore the backlog size. This
+	// path is only executed right after a no-sync-match where we should be close
+	// to max utilization.
+	capacityUpdateSkipReason := ""
+	if metrics.hasData {
+		updateRateBasedPerConsumerCapacity(config, updatedState, currentCount, metrics.dispatchRate)
+	} else {
+		capacityUpdateSkipReason = "no_metrics"
+		logger.Warn(
+			"Rate-based deferred decision has no metrics; capacity estimate not updated",
+			"dropped_queues", metrics.droppedQueues,
+			"current_count", currentCount,
+		)
+	}
+	updatedCapacity := estimatedRateBasedPerConsumerCapacity(config, updatedState)
+
+	logger.Info(
+		"Rate-based deferred decision",
+		"current_count", currentCount,
+		"metrics_present", metrics.hasData,
+		"dropped_queues", metrics.droppedQueues,
+		"dispatch_rate", metrics.dispatchRate,
+		"previous_per_consumer_capacity", previousCapacity,
+		"updated_per_consumer_capacity", updatedCapacity,
+		"capacity_update_skip_reason", capacityUpdateSkipReason,
+	)
+	return &TaskAddResponse{Actions: actions, Status: updatedState}, nil
+}
+
+func (a *scalingAlgorithmRateBased) ProcessMetricsPoll(
+	ctx context.Context,
+	config iface.ScalingAlgorithmConfig,
+	priorState iface.ScalingAlgorithmStatus,
+	metricsSnapshot ScalingMetricsSnapshot,
+) (*MetricsPollResponse, error) {
+	logger := safeActivityLogger(ctx)
+	if priorState == nil {
+		priorState = iface.ScalingAlgorithmStatus{}
+	}
+	if config == nil {
+		config = iface.ScalingAlgorithmConfig{}
+	}
+	updatedState := cleanRateBasedState(ctx, priorState)
+
+	pollIntervalMs := config.GetInt64Field(configRateBasedMetricsPollIntervalMsKey, configRateBasedMetricsPollIntervalMsDefault)
+	nextPoll := time.Duration(pollIntervalMs) * time.Millisecond
+	actions := []ScalingAction{}
+
+	metrics := aggregateRateBasedMetrics(ctx, &metricsSnapshot)
+	currentCount := currentRateBasedPlannedCount(config, updatedState)
+	updatedState[stateRateBasedWorkerCount] = int64(currentCount)
+
+	if metrics.hasData {
+		updateRateBasedEWMA(config, updatedState, metrics)
+	} else {
+		logger.Warn(
+			"Rate-based metrics poll has no metrics; EWMA not updated",
+			"dropped_queues", metrics.droppedQueues,
+			"current_count", currentCount,
+		)
+	}
+	idleEWMASnapToZero := snapIdleRateBasedEWMAToZero(updatedState, metrics)
+
+	materialBacklogThreshold := config.GetInt64Field(configRateBasedMaterialBacklogThresholdKey, configRateBasedMaterialBacklogThresholdDefault)
+	previousCapacity := estimatedRateBasedPerConsumerCapacity(config, updatedState)
+	observedCapacity := 0.0
+	capacitySampled := false
+	capacitySampleSkipReason := ""
+
+	if metrics.backlog >= materialBacklogThreshold {
+		if currentCount <= 0 {
+			capacitySampleSkipReason = "planned_count_zero"
+		} else if metrics.dispatchRate <= 0 {
+			capacitySampleSkipReason = "dispatch_rate_zero"
+		} else {
+			observedCapacity = metrics.dispatchRate / float64(currentCount)
+			if isPositiveFinite(observedCapacity) {
+				capacitySampled = true
+				updateRateBasedPerConsumerCapacity(config, updatedState, currentCount, metrics.dispatchRate)
+			} else {
+				// Both operands were already gated as positive-finite (dispatchRate>0
+				// and currentCount>0), so a non-finite quotient is anomalous — most
+				// plausibly an overflow from an extreme dispatchRate.
+				capacitySampleSkipReason = "invalid_observed_capacity"
+				logger.Warn(
+					"Rate-based capacity sample produced a non-finite quotient; capacity estimate not updated",
+					"dispatch_rate", metrics.dispatchRate,
+					"current_count", currentCount,
+					"observed_capacity", observedCapacity,
+				)
+			}
+		}
+	} else {
+		capacitySampleSkipReason = "backlog_below_material_threshold"
+	}
+	updatedCapacity := estimatedRateBasedPerConsumerCapacity(config, updatedState)
+
+	nowMs := time.Now().UnixMilli()
+	desiredCount, desiredLogArgs := computeRateBasedDesiredCapacity(config, updatedState, metrics.backlog)
+
+	scaleUpCooldownMs := config.GetInt64Field(configRateBasedScaleUpCooldownMsKey, configRateBasedScaleUpCooldownMsDefault)
+	lastScaleUpMs := updatedState.GetInt64Field(stateRateBasedLastScaleUpTimestamp, 0)
+	elapsedSinceScaleUpMs := nowMs - lastScaleUpMs
+	noSyncQuietMs := config.GetInt64Field(configRateBasedNoSyncQuietMsKey, configRateBasedNoSyncQuietMsDefault)
+	lastNoSyncMs := updatedState.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0)
+	elapsedSinceNoSyncMs := nowMs - lastNoSyncMs
+	scaleDownCooldownMs := config.GetInt64Field(configRateBasedScaleDownCooldownMsKey, configRateBasedScaleDownCooldownMsDefault)
+	lastScaleDownMs := updatedState.GetInt64Field(stateRateBasedLastScaleDownTimestamp, 0)
+	elapsedSinceScaleDownMs := nowMs - lastScaleDownMs
+	newCount := currentCount
+	scaleDirection := "none"
+	scaleBlockReason := ""
+
+	if desiredCount > currentCount {
+		scaleDirection = "up"
+		if elapsedSinceScaleUpMs >= scaleUpCooldownMs {
+			maxCount := int32(config.GetInt64Field(configRateBasedMaxCountKey, configRateBasedMaxCountDefault))
+			maxStep := int32(config.GetInt64Field(configRateBasedMaxScaleUpStepKey, configRateBasedMaxScaleUpStepDefault))
+			addCount := min(maxStep, desiredCount-currentCount, maxCount-currentCount)
+			if addCount > 0 {
+				newCount = currentCount + addCount
+				updatedState[stateRateBasedWorkerCount] = int64(newCount)
+				updatedState[stateRateBasedLastScaleUpTimestamp] = nowMs
+				actions = append(actions, ScalingAction{Action: ActionTypeUpdateWorkerSetSize, Count: &newCount})
+			} else {
+				scaleBlockReason = "max_count"
+			}
+		} else {
+			scaleBlockReason = "scale_up_cooldown"
+		}
+	} else if desiredCount < currentCount {
+		scaleDirection = "down"
+		if elapsedSinceNoSyncMs >= noSyncQuietMs && elapsedSinceScaleDownMs >= scaleDownCooldownMs {
+			minCount := int32(config.GetInt64Field(configRateBasedMinCountKey, configRateBasedMinCountDefault))
+			newCount = max(minCount, currentCount-1)
+			if newCount != currentCount {
+				updatedState[stateRateBasedWorkerCount] = int64(newCount)
+				updatedState[stateRateBasedLastScaleDownTimestamp] = nowMs
+				actions = append(actions, ScalingAction{Action: ActionTypeUpdateWorkerSetSize, Count: &newCount})
+			} else {
+				scaleBlockReason = "min_count"
+			}
+		} else if elapsedSinceNoSyncMs < noSyncQuietMs {
+			scaleBlockReason = "no_sync_quiet"
+		} else {
+			scaleBlockReason = "scale_down_cooldown"
+		}
+	} else {
+		scaleBlockReason = "desired_equals_current"
+	}
+
+	logArgs := []any{
+		"metrics_present", metrics.hasData,
+		"dropped_queues", metrics.droppedQueues,
+		"backlog", metrics.backlog,
+		"arrival_rate", metrics.arrivalRate,
+		"dispatch_rate", metrics.dispatchRate,
+		"ewma_arrival_rate", updatedState.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0),
+		"ewma_dispatch_rate", updatedState.GetFloat64Field(stateRateBasedEWMADispatchRate, 0),
+		"idle_ewma_snap_to_zero", idleEWMASnapToZero,
+		"previous_per_consumer_capacity", previousCapacity,
+		"observed_per_consumer_capacity", observedCapacity,
+		"updated_per_consumer_capacity", updatedCapacity,
+		"capacity_sampled", capacitySampled,
+		"capacity_sample_skip_reason", capacitySampleSkipReason,
+		"material_backlog_threshold", materialBacklogThreshold,
+		"desired_count", desiredCount,
+		"current_count", currentCount,
+		"new_count", newCount,
+		"scale_direction", scaleDirection,
+		"scale_block_reason", scaleBlockReason,
+		"scale_up_cooldown_ms", scaleUpCooldownMs,
+		"elapsed_since_scale_up_ms", elapsedSinceScaleUpMs,
+		"no_sync_quiet_ms", noSyncQuietMs,
+		"elapsed_since_no_sync_ms", elapsedSinceNoSyncMs,
+		"scale_down_cooldown_ms", scaleDownCooldownMs,
+		"elapsed_since_scale_down_ms", elapsedSinceScaleDownMs,
+		"action_count", len(actions),
+		"next_poll_ms", pollIntervalMs,
+	}
+	logArgs = append(logArgs, desiredLogArgs...)
+	logger.Info("Rate-based metrics-poll decision", logArgs...)
+
+	return &MetricsPollResponse{Actions: actions, Status: updatedState, NextPoll: &nextPoll}, nil
+}
+
+func cleanRateBasedState(ctx context.Context, priorState iface.ScalingAlgorithmStatus) iface.ScalingAlgorithmStatus {
+	logger := safeActivityLogger(ctx)
+	updatedState := maps.Clone(priorState)
+	if updatedState == nil {
+		updatedState = map[string]any{}
+	}
+	for k, raw := range updatedState {
+		if _, ok := rateBasedValidStateKeys[k]; !ok {
+			logger.Warn("Discarding unknown state slot; treating as forward-incompatible state", "key", k, "stored", raw)
+			delete(updatedState, k)
+		}
+	}
+	for _, key := range rateBasedFiniteFloat64StateKeys {
+		raw, ok := updatedState[key]
+		if !ok {
+			continue
+		}
+		v, isFloat := raw.(float64)
+		switch {
+		case !isFloat:
+			logger.Error("Discarding wrong-typed state slot; treating as unset", "key", key, "stored", raw)
+			delete(updatedState, key)
+		case math.IsNaN(v) || math.IsInf(v, 0):
+			logger.Error("Discarding non-finite stored float; treating slot as unset", "key", key, "stored", raw)
+			delete(updatedState, key)
+		}
+	}
+
+	if raw, ok := updatedState[stateRateBasedEWMAPerConsumerCapacity]; ok {
+		if v, isFloat := raw.(float64); isFloat && v <= 0 {
+			logger.Error("Discarding non-positive stored per-consumer capacity; treating slot as unset", "stored", raw)
+			delete(updatedState, stateRateBasedEWMAPerConsumerCapacity)
+		}
+	}
+
+	if raw, ok := updatedState[stateRateBasedWorkerCount]; ok {
+		if !isValidNonNegativeInt32(raw) {
+			logger.Error("Discarding wrong-typed or out-of-range stored worker count; treating slot as unset", "stored", raw)
+			delete(updatedState, stateRateBasedWorkerCount)
+		}
+	}
+
+	for _, key := range rateBasedNonNegativeInt64StateKeys {
+		raw, ok := updatedState[key]
+		if !ok {
+			continue
+		}
+		if !isValidNonNegativeInt64(raw) {
+			logger.Error("Discarding wrong-typed or negative stored timestamp; treating slot as unset", "key", key, "stored", raw)
+			delete(updatedState, key)
+		}
+	}
+	return updatedState
+}
+
+func aggregateRateBasedMetrics(ctx context.Context, metricsSnapshot *ScalingMetricsSnapshot) rateBasedAggregateMetrics {
+	var aggregate rateBasedAggregateMetrics
+	if metricsSnapshot == nil {
+		return aggregate
+	}
+	logger := safeActivityLogger(ctx)
+
+	for _, qt := range []struct {
+		name    string
+		metrics *iface.QueueTypeScalingMetrics
+	}{
+		{"workflow", metricsSnapshot.Workflow},
+		{"activity", metricsSnapshot.Activity},
+		{"nexus", metricsSnapshot.Nexus},
+	} {
+		if qt.metrics == nil {
+			continue
+		}
+		arrival := float64(qt.metrics.LastArrivalRate)
+		dispatch := float64(qt.metrics.LastProcessingRate)
+		backlog := qt.metrics.LastBacklogCount
+
+		if math.IsNaN(arrival) || math.IsInf(arrival, 0) || math.IsNaN(dispatch) || math.IsInf(dispatch, 0) || arrival < 0 || dispatch < 0 || backlog < 0 {
+			logger.Warn("Discarding invalid rate metrics sample as invalid", "queue_type", qt.name, "arrival_rate", arrival, "dispatch_rate", dispatch, "backlog", backlog)
+			aggregate.droppedQueues = append(aggregate.droppedQueues, qt.name)
+			continue
+		}
+		aggregate.hasData = true
+		aggregate.backlog += backlog
+		aggregate.arrivalRate += arrival
+		aggregate.dispatchRate += dispatch
+	}
+	return aggregate
+}
+
+func updateRateBasedEWMA(config iface.ScalingAlgorithmConfig, state iface.ScalingAlgorithmStatus, metrics rateBasedAggregateMetrics) {
+	alpha := config.GetFloat64Field(configRateBasedEWMAAlphaKey, configRateBasedEWMAAlphaDefault)
+	state[stateRateBasedEWMAArrivalRate] = updateRateBasedEWMAValue(state, stateRateBasedEWMAArrivalRate, alpha, metrics.arrivalRate)
+	state[stateRateBasedEWMADispatchRate] = updateRateBasedEWMAValue(state, stateRateBasedEWMADispatchRate, alpha, metrics.dispatchRate)
+}
+
+func updateRateBasedEWMAValue(state iface.ScalingAlgorithmStatus, key string, alpha float64, sample float64) float64 {
+	previous, ok := state[key].(float64)
+	if !ok {
+		return sample
+	}
+	return alpha*sample + (1-alpha)*previous
+}
+
+func snapIdleRateBasedEWMAToZero(state iface.ScalingAlgorithmStatus, metrics rateBasedAggregateMetrics) bool {
+	if !metrics.hasData {
+		return false
+	}
+	if metrics.backlog != 0 || metrics.arrivalRate != 0 || metrics.dispatchRate != 0 {
+		return false
+	}
+	if state.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0) == 0 &&
+		state.GetFloat64Field(stateRateBasedEWMADispatchRate, 0) == 0 {
+		return false
+	}
+
+	state[stateRateBasedEWMAArrivalRate] = float64(0)
+	state[stateRateBasedEWMADispatchRate] = float64(0)
+	return true
+}
+
+func updateRateBasedPerConsumerCapacity(
+	config iface.ScalingAlgorithmConfig,
+	state iface.ScalingAlgorithmStatus,
+	plannedCount int32,
+	dispatchRate float64,
+) {
+	if plannedCount <= 0 || dispatchRate <= 0 {
+		return
+	}
+
+	observedCapacity := dispatchRate / float64(plannedCount)
+	if !isPositiveFinite(observedCapacity) {
+		return
+	}
+
+	alpha := config.GetFloat64Field(configRateBasedEWMAAlphaKey, configRateBasedEWMAAlphaDefault)
+	previousEstimate := estimatedRateBasedPerConsumerCapacity(config, state)
+	state[stateRateBasedEWMAPerConsumerCapacity] = alpha*observedCapacity + (1-alpha)*previousEstimate
+}
+
+func computeRateBasedDesiredCapacity(config iface.ScalingAlgorithmConfig, state iface.ScalingAlgorithmStatus, backlog int64) (int32, []any) {
+	minCount := int32(config.GetInt64Field(configRateBasedMinCountKey, configRateBasedMinCountDefault))
+	maxCount := int32(config.GetInt64Field(configRateBasedMaxCountKey, configRateBasedMaxCountDefault))
+	catchUpRate := 0.0
+	if backlog > 0 {
+		catchUpRate = config.GetFloat64Field(configRateBasedTargetBacklogDrainRateKey, configRateBasedTargetBacklogDrainRateDefault)
+	}
+
+	requiredRate := state.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0) + catchUpRate
+	perConsumerCapacity := estimatedRateBasedPerConsumerCapacity(config, state)
+	offeredLoad := 0.0
+	if requiredRate > 0 {
+		offeredLoad = requiredRate / perConsumerCapacity
+	}
+
+	utilizationDesired := 0.0
+	halfinWhittDesired := 0.0
+	utilizationTarget := config.GetFloat64Field(configRateBasedUtilizationTargetKey, configRateBasedUtilizationTargetDefault)
+	beta := config.GetFloat64Field(configRateBasedHalfinWhittBetaKey, configRateBasedHalfinWhittBetaDefault)
+	if offeredLoad > 0 {
+		utilizationDesired = math.Ceil(offeredLoad / utilizationTarget)
+		halfinWhittDesired = math.Ceil(offeredLoad + beta*math.Sqrt(offeredLoad))
+	}
+
+	rawDesiredFloat := min(max(utilizationDesired, halfinWhittDesired, 0), float64(maxCount))
+	rawDesired := int32(rawDesiredFloat)
+	desiredCount := min(max(rawDesired, minCount), maxCount)
+	logArgs := []any{
+		"min_count", minCount,
+		"max_count", maxCount,
+		"catch_up_rate", catchUpRate,
+		"required_rate", requiredRate,
+		"per_consumer_capacity", perConsumerCapacity,
+		"offered_load", offeredLoad,
+		"utilization_target", utilizationTarget,
+		"halfin_whitt_beta", beta,
+		"utilization_desired", utilizationDesired,
+		"halfin_whitt_desired", halfinWhittDesired,
+		"raw_desired_count", rawDesired,
+	}
+	return desiredCount, logArgs
+}
+
+func currentRateBasedPlannedCount(config iface.ScalingAlgorithmConfig, state iface.ScalingAlgorithmStatus) int32 {
+	if _, ok := state[stateRateBasedWorkerCount]; ok {
+		return int32(state.GetInt64Field(stateRateBasedWorkerCount, 0))
+	}
+	return int32(config.GetInt64Field(configRateBasedInitialCountKey, configRateBasedInitialCountDefault))
+}
+
+func estimatedRateBasedPerConsumerCapacity(config iface.ScalingAlgorithmConfig, state iface.ScalingAlgorithmStatus) float64 {
+	fallback := config.GetFloat64Field(configRateBasedInitialPerConsumerCapacityKey, configRateBasedInitialPerConsumerCapacityDefault)
+	if estimate, ok := state[stateRateBasedEWMAPerConsumerCapacity].(float64); ok && isPositiveFinite(estimate) {
+		return estimate
+	}
+	return fallback
+}
+
+func isPositiveFinite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value > 0
+}
+
+func isValidNonNegativeInt32(raw any) bool {
+	switch v := raw.(type) {
+	case int:
+		return v >= 0 && int64(v) <= math.MaxInt32
+	case int64:
+		return v >= 0 && v <= math.MaxInt32
+	case float64:
+		return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0 && v <= math.MaxInt32 && v == math.Trunc(v)
+	}
+	return false
+}
+
+func isValidNonNegativeInt64(raw any) bool {
+	switch v := raw.(type) {
+	case int:
+		return v >= 0
+	case int64:
+		return v >= 0
+	case float64:
+		// math.MaxInt64 (2^63 - 1) rounds up to 2^63 when converted to float64,
+		// so `v <= math.MaxInt64` would admit float64(2^63), whose int64 cast
+		// wraps to MinInt64. Use strict-less-than against float64(MaxInt64)
+		// (== 2^63) to exclude that value. Integer precision in float64 is
+		// exact only up to 2^53; above that, `v == math.Trunc(v)` still
+		// correctly rejects values that round to non-integers, but the
+		// returned value may not be the integer it appears to be. No current
+		// caller reaches 2^53.
+		return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0 && v < float64(math.MaxInt64) && v == math.Trunc(v)
+	}
+	return false
+}

--- a/wci/workflow/scaling_algorithm/rate_based_test.go
+++ b/wci/workflow/scaling_algorithm/rate_based_test.go
@@ -1,0 +1,1486 @@
+package scalingalgorithm
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+)
+
+func newRateBased() *scalingAlgorithmRateBased {
+	algo, err := NewScalingAlgorithmRateBased(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	return algo.(*scalingAlgorithmRateBased)
+}
+
+func oldMs() int64 {
+	return time.Now().Add(-time.Hour).UnixMilli()
+}
+
+func staticMetricsSnapshotGetter(snapshot ScalingMetricsSnapshot, callCount *int) ScalingMetricsSnapshotGetter {
+	return func() (*ScalingMetricsSnapshot, error) {
+		if callCount != nil {
+			(*callCount)++
+		}
+		return &snapshot, nil
+	}
+}
+
+func errorMetricsSnapshotGetter(err error, callCount *int) ScalingMetricsSnapshotGetter {
+	return func() (*ScalingMetricsSnapshot, error) {
+		if callCount != nil {
+			(*callCount)++
+		}
+		return nil, err
+	}
+}
+
+func TestRateBasedValidateConfig(t *testing.T) {
+	a := newRateBased()
+	ctx := context.Background()
+
+	t.Run("nil config", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, nil))
+	})
+
+	t.Run("empty config defaults", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{}))
+	})
+
+	t.Run("old scale_down_ratio rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{"scale_down_ratio": float64(0.9)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("min_count greater than max_count", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey: int64(5),
+			configRateBasedMaxCountKey: int64(3),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("initial_count out of range", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(-1)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey:     int64(2),
+			configRateBasedInitialCountKey: int64(1),
+		}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMaxCountKey:     int64(2),
+			configRateBasedInitialCountKey: int64(3),
+		}))
+	})
+
+	t.Run("ewma alpha out of range", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedEWMAAlphaKey: float64(0)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedEWMAAlphaKey: float64(1.1)}))
+	})
+
+	t.Run("initial capacity must be positive", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedInitialPerConsumerCapacityKey: float64(0)}))
+	})
+
+	t.Run("utilization target out of range", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedUtilizationTargetKey: float64(0)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedUtilizationTargetKey: float64(1.1)}))
+	})
+
+	t.Run("positive integer fields", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedMetricsPollIntervalMsKey: int64(0)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedMaterialBacklogThresholdKey: int64(0)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedMaxScaleUpStepKey: int64(0)}))
+	})
+
+	t.Run("non-finite float fields rejected", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedEWMAAlphaKey: math.NaN()}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedInitialPerConsumerCapacityKey: math.NaN()}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedInitialPerConsumerCapacityKey: math.Inf(1)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedUtilizationTargetKey: math.NaN()}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedTargetBacklogDrainRateKey: math.NaN()}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedTargetBacklogDrainRateKey: math.Inf(1)}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedHalfinWhittBetaKey: math.NaN()}))
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{configRateBasedHalfinWhittBetaKey: math.Inf(1)}))
+	})
+
+	t.Run("all spec keys valid", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey:                   int64(1),
+			configRateBasedMaxCountKey:                   int64(10),
+			configRateBasedInitialCountKey:               int64(1),
+			configRateBasedMetricsPollIntervalMsKey:      int64(30_000),
+			configRateBasedEWMAAlphaKey:                  float64(0.5),
+			configRateBasedInitialPerConsumerCapacityKey: float64(2),
+			configRateBasedTargetBacklogDrainRateKey:     float64(1),
+			configRateBasedMaterialBacklogThresholdKey:   int64(1),
+			configRateBasedUtilizationTargetKey:          float64(0.8),
+			configRateBasedHalfinWhittBetaKey:            float64(0.5),
+			configRateBasedMaxScaleUpStepKey:             int64(4),
+			configRateBasedScaleUpCooldownMsKey:          int64(0),
+			configRateBasedScaleDownCooldownMsKey:        int64(0),
+			configRateBasedNoSyncQuietMsKey:              int64(0),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("scale_up_cooldown exceeding poll interval rejected", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMetricsPollIntervalMsKey: int64(30_000),
+			configRateBasedScaleUpCooldownMsKey:     int64(60_000),
+		}))
+	})
+
+	t.Run("scale_down_cooldown exceeding poll interval rejected", func(t *testing.T) {
+		require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMetricsPollIntervalMsKey: int64(30_000),
+			configRateBasedScaleDownCooldownMsKey:   int64(120_000),
+		}))
+	})
+
+	t.Run("cooldown equal to poll interval accepted", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMetricsPollIntervalMsKey: int64(60_000),
+			configRateBasedScaleUpCooldownMsKey:     int64(60_000),
+			configRateBasedScaleDownCooldownMsKey:   int64(60_000),
+		}))
+	})
+
+	t.Run("defaults pass cross-field validation", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{}))
+	})
+
+	t.Run("worker-count int fields rejected when above MaxInt32", func(t *testing.T) {
+		for _, key := range []string{
+			configRateBasedMinCountKey,
+			configRateBasedMaxCountKey,
+			configRateBasedInitialCountKey,
+			configRateBasedMaxScaleUpStepKey,
+		} {
+			require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{key: int64(math.MaxInt32) + 1}), "expected %s above MaxInt32 to be rejected", key)
+		}
+	})
+
+	t.Run("worker-count int fields accepted at MaxInt32 boundary", func(t *testing.T) {
+		require.NoError(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{
+			configRateBasedMaxCountKey: int64(math.MaxInt32),
+		}))
+	})
+
+	t.Run("fields with lower bounds reject below-bound values", func(t *testing.T) {
+		for _, tc := range []struct {
+			key   string
+			value any
+		}{
+			{configRateBasedMinCountKey, int64(-1)},
+			{configRateBasedMaxCountKey, int64(0)},
+			{configRateBasedInitialCountKey, int64(-1)},
+			{configRateBasedMetricsPollIntervalMsKey, int64(0)},
+			{configRateBasedMaterialBacklogThresholdKey, int64(0)},
+			{configRateBasedMaxScaleUpStepKey, int64(0)},
+			{configRateBasedScaleUpCooldownMsKey, int64(-1)},
+			{configRateBasedScaleDownCooldownMsKey, int64(-1)},
+			{configRateBasedNoSyncQuietMsKey, int64(-1)},
+			{configRateBasedEWMAAlphaKey, float64(-0.1)},
+			{configRateBasedInitialPerConsumerCapacityKey, float64(-1)},
+			{configRateBasedTargetBacklogDrainRateKey, float64(-0.1)},
+			{configRateBasedUtilizationTargetKey, float64(-0.1)},
+			{configRateBasedHalfinWhittBetaKey, float64(-0.1)},
+		} {
+			require.Error(t, a.ValidateConfig(ctx, iface.ScalingAlgorithmConfig{tc.key: tc.value}), "expected %s=%v to be rejected by lower-bound validation", tc.key, tc.value)
+		}
+	})
+}
+
+func TestRateBasedCompatibleLaunchStrategies(t *testing.T) {
+	a := newRateBased()
+	assert.Equal(t, []computeprovider.LaunchStrategy{computeprovider.LaunchStrategyWorkerSet}, a.CompatibleLaunchStrategies())
+}
+
+func TestRateBasedDefaultRegistration(t *testing.T) {
+	// init() registers the algorithm as the default for these compute providers.
+	// A regression that dropped one of the mappings would silently route the
+	// affected provider to a different algorithm (or none).
+	ctx := context.Background()
+	for _, providerType := range []iface.ComputeProviderType{
+		iface.ComputeProviderTypeAWSECS,
+		iface.ComputeProviderTypeK8s,
+		iface.ComputeProviderTypeGCPCloudRun,
+	} {
+		algo, err := GetDefaultScalingAlgorithmForComputeProvider(ctx, providerType)
+		require.NoError(t, err, "provider %s", providerType)
+		require.NotNil(t, algo, "provider %s must have a default algorithm registered", providerType)
+		_, ok := algo.(*scalingAlgorithmRateBased)
+		assert.True(t, ok, "provider %s must default to scalingAlgorithmRateBased, got %T", providerType, algo)
+	}
+}
+
+func TestRateBasedProcessTaskAdd(t *testing.T) {
+	a := newRateBased()
+	ctx := context.Background()
+
+	t.Run("sync match no batched no-sync", func(t *testing.T) {
+		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 0}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.NotContains(t, resp.Status, stateRateBasedLastNoSyncMatchTimestamp)
+	})
+
+	t.Run("no-sync scales up without capacity update", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(2),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(0.5),
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false}
+
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(3), *resp.Actions[0].Count)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.Nil(t, resp.Actions[1].Count)
+		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.NotZero(t, resp.Status.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0))
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity)
+		assert.Equal(t, 0, resp.ThrottledCount)
+	})
+
+	t.Run("no-sync uses initial count when worker count is missing", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey: int64(2),
+			configRateBasedMaxCountKey:     int64(5),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false}
+
+		resp, err := a.ProcessTaskAdd(ctx, cfg, nil, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(3), *resp.Actions[0].Count)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.Nil(t, resp.Actions[1].Count)
+		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("existing worker count overrides initial count", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(4),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey: int64(1),
+			configRateBasedMaxCountKey:     int64(10),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false}
+
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(5), *resp.Actions[0].Count)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.Nil(t, resp.Actions[1].Count)
+		assert.Equal(t, int64(5), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("no-sync within cooldown preserves existing capacity", func(t *testing.T) {
+		originalScaleUpMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(2),
+			stateRateBasedLastScaleUpTimestamp:    originalScaleUpMs,
+			stateRateBasedEWMAPerConsumerCapacity: float64(10),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:         float64(0.5),
+			configRateBasedScaleUpCooldownMsKey: int64(30_000),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, NoSyncMatchSignalsSinceLast: 3}
+
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[0].Action)
+		assert.Nil(t, resp.Actions[0].Count)
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.InDelta(t, 10.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+		// The cooldown-blocked path must not bump LastScaleUpTimestamp; otherwise
+		// the cooldown would self-extend with every burst signal and a legitimate
+		// scale-up could never fire.
+		assert.Equal(t, originalScaleUpMs, resp.Status.GetInt64Field(stateRateBasedLastScaleUpTimestamp, 0))
+		// The no-sync-match timestamp must be bumped even on the cooldown-blocked
+		// path: it blocks scale-down on the metrics-poll path for at least
+		// no_sync_quiet_ms, which is the load-bearing reason the bump is placed
+		// above the cooldown gate in ProcessTaskAdd.
+		assert.NotZero(t, resp.Status.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0))
+		// Batched no-sync-match signals must surface via ThrottledCount so the
+		// scale_up_throttled metric reflects suppressed scale-ups.
+		assert.Equal(t, 3, resp.ThrottledCount)
+	})
+
+	t.Run("at max count records no-sync but no scale-up", func(t *testing.T) {
+		originalScaleUpMs := oldMs()
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(5),
+			stateRateBasedLastScaleUpTimestamp: originalScaleUpMs,
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMaxCountKey:                   int64(5),
+			configRateBasedEWMAAlphaKey:                  float64(0.5),
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, NoSyncMatchSignalsSinceLast: 2}
+
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[0].Action)
+		assert.Nil(t, resp.Actions[0].Count)
+		assert.NotZero(t, resp.Status.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0))
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity)
+		// The max-count short-circuit must not write LastScaleUpTimestamp:
+		// no scale-up occurred, so the cooldown clock must not be reset.
+		assert.Equal(t, originalScaleUpMs, resp.Status.GetInt64Field(stateRateBasedLastScaleUpTimestamp, 0))
+		assert.Equal(t, 2, resp.ThrottledCount)
+	})
+
+	t.Run("no-sync with zero planned workers skips metrics callback", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(0),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false}
+
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity)
+	})
+
+	t.Run("no-sync scale-up still requests deferred sampling", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(2),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false}
+
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(3), *resp.Actions[0].Count)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.Nil(t, resp.Actions[1].Count)
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity)
+	})
+
+	t.Run("batched no-sync scales only once", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(1),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 3}
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, state, event)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 2)
+		assert.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(2), *resp.Actions[0].Count)
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[1].Action)
+		assert.Nil(t, resp.Actions[1].Count)
+		assert.Equal(t, 0, resp.ThrottledCount)
+	})
+
+	t.Run("non-finite and wrong-typed slots are persisted as absent across rounds", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(2),
+			stateRateBasedEWMAArrivalRate:         "garbage",
+			stateRateBasedEWMADispatchRate:        int64(99),
+			stateRateBasedEWMAPerConsumerCapacity: math.NaN(),
+		}
+
+		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{configRateBasedMaxCountKey: int64(10)}, state, iface.SignalTaskAddRequest{IsSyncMatch: true})
+		require.NoError(t, err)
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAArrivalRate, "wrong-typed arrival slot must not survive into persisted state")
+		assert.NotContains(t, resp.Status, stateRateBasedEWMADispatchRate, "wrong-typed dispatch slot must not survive into persisted state")
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity, "non-finite capacity slot must not survive into persisted state")
+	})
+}
+
+func TestRateBasedProcessDeferredScalingDecision(t *testing.T) {
+	a := newRateBased()
+	ctx := context.Background()
+
+	t.Run("samples per-consumer capacity", func(t *testing.T) {
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(2),
+			stateRateBasedEWMAPerConsumerCapacity: float64(10),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastProcessingRate: 8},
+		}
+		called := 0
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, cfg, priorState, iface.SignalTaskAddRequest{}, staticMetricsSnapshotGetter(snapshot, &called))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Actions)
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.InDelta(t, 7.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("uses initial count when worker count is missing", func(t *testing.T) {
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedEWMAPerConsumerCapacity: float64(10),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey: int64(4),
+			configRateBasedEWMAAlphaKey:    float64(1),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Activity: &iface.QueueTypeScalingMetrics{LastProcessingRate: 8},
+		}
+		called := 0
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, cfg, priorState, iface.SignalTaskAddRequest{}, staticMetricsSnapshotGetter(snapshot, &called))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Actions)
+		assert.Equal(t, int64(4), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.InDelta(t, 2.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("zero planned count skips metrics", func(t *testing.T) {
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(0),
+			stateRateBasedEWMAPerConsumerCapacity: float64(10),
+		}
+		called := 0
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, iface.ScalingAlgorithmConfig{}, priorState, iface.SignalTaskAddRequest{}, staticMetricsSnapshotGetter(ScalingMetricsSnapshot{}, &called))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Actions)
+		assert.Equal(t, int64(0), resp.Status.GetInt64Field(stateRateBasedWorkerCount, -1))
+		assert.InDelta(t, 10.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+		assert.Equal(t, 0, called)
+	})
+
+	t.Run("zero dispatch keeps capacity estimate", func(t *testing.T) {
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(2),
+			stateRateBasedEWMAPerConsumerCapacity: float64(10),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastProcessingRate: 0},
+		}
+		called := 0
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, iface.ScalingAlgorithmConfig{}, priorState, iface.SignalTaskAddRequest{}, staticMetricsSnapshotGetter(snapshot, &called))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Actions)
+		assert.InDelta(t, 10.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("metrics error returns nil response and propagates err", func(t *testing.T) {
+		expectedErr := errors.New("metrics unavailable")
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount: int64(2),
+			"legacy_state":            int64(1),
+		}
+		called := 0
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, iface.ScalingAlgorithmConfig{}, priorState, iface.SignalTaskAddRequest{}, errorMetricsSnapshotGetter(expectedErr, &called))
+
+		require.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, resp)
+		assert.Equal(t, 1, called)
+	})
+
+	t.Run("nil metrics getter returns an error", func(t *testing.T) {
+		priorState := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount: int64(2),
+		}
+
+		resp, err := a.ProcessDeferredScalingDecision(ctx, iface.ScalingAlgorithmConfig{}, priorState, iface.SignalTaskAddRequest{}, nil)
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+	})
+}
+
+func TestRateBasedProcessMetricsPoll(t *testing.T) {
+	a := newRateBased()
+	ctx := context.Background()
+
+	t.Run("all nil metrics default poll", func(t *testing.T) {
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		require.NotNil(t, resp.NextPoll)
+		assert.Equal(t, 60*time.Second, *resp.NextPoll)
+		// With no contributing queues the EWMA update is gated off; the slots
+		// must stay absent rather than be silently stamped to zero, which would
+		// be indistinguishable from "we observed zero load" downstream.
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAArrivalRate)
+		assert.NotContains(t, resp.Status, stateRateBasedEWMADispatchRate)
+	})
+
+	t.Run("custom poll interval", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configRateBasedMetricsPollIntervalMsKey: int64(5000)}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		require.NotNil(t, resp.NextPoll)
+		assert.Equal(t, 5*time.Second, *resp.NextPoll)
+	})
+
+	t.Run("missing worker count initializes from config", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey:     int64(3),
+			configRateBasedMaxCountKey:     int64(10),
+			configRateBasedInitialCountKey: int64(3),
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("first cadence initializes ewma rates", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: int64(1)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 5, LastProcessingRate: 4},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, float64(5), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0))
+		assert.Equal(t, float64(4), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0))
+	})
+
+	t.Run("later cadence smooths ewma rates", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:      int64(1),
+			stateRateBasedEWMAArrivalRate:  float64(4),
+			stateRateBasedEWMADispatchRate: float64(2),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(0.25),
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 8, LastProcessingRate: 4},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.InDelta(t, 5.0, resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 0.0001)
+		assert.InDelta(t, 2.5, resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 0.0001)
+	})
+
+	t.Run("fully idle cadence snaps ewma rates to zero before scale-down", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(2),
+			stateRateBasedEWMAArrivalRate:          float64(1),
+			stateRateBasedEWMADispatchRate:         float64(0.5),
+			stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+			stateRateBasedLastScaleDownTimestamp:   oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(0.5),
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(1), *resp.Actions[0].Count)
+		assert.Equal(t, int64(1), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.Equal(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, -1))
+		assert.Equal(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, -1))
+	})
+
+	t.Run("raw dispatch prevents idle ewma snap-to-zero", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:      int64(1),
+			stateRateBasedEWMAArrivalRate:  float64(4),
+			stateRateBasedEWMADispatchRate: float64(2),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(0.25),
+			configRateBasedInitialPerConsumerCapacityKey: float64(10),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastProcessingRate: 4},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.InDelta(t, 3.0, resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 0.0001)
+		assert.InDelta(t, 2.5, resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 0.0001)
+	})
+
+	t.Run("material backlog samples per-consumer capacity", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(4),
+			stateRateBasedEWMAPerConsumerCapacity:  float64(10),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                float64(0.5),
+			configRateBasedMaterialBacklogThresholdKey: int64(5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 8},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.InDelta(t, 6.0, resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 0.0001)
+	})
+
+	t.Run("below material backlog does not sample capacity", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(4),
+			stateRateBasedEWMAPerConsumerCapacity:  float64(10),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                float64(0.5),
+			configRateBasedMaterialBacklogThresholdKey: int64(5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 4, LastProcessingRate: 8},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Equal(t, float64(10), resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0))
+	})
+
+	t.Run("desired capacity scale-up uses max step", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(2),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(2),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(0.8),
+			configRateBasedHalfinWhittBetaKey:            float64(0.5),
+			configRateBasedMaxScaleUpStepKey:             int64(4),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 20},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(6), *resp.Actions[0].Count)
+		assert.Equal(t, int64(6), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.NotZero(t, resp.Status.GetInt64Field(stateRateBasedLastScaleUpTimestamp, 0))
+	})
+
+	t.Run("scale-up cooldown blocks cadence scale-up", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(2),
+			stateRateBasedLastScaleUpTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(2),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(0.8),
+			configRateBasedHalfinWhittBetaKey:            float64(0.5),
+			configRateBasedScaleUpCooldownMsKey:          int64(60_000),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 20},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("desired capacity scale-up clamps to max count", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(4),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMaxCountKey:                   int64(5),
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(0.5),
+			configRateBasedHalfinWhittBetaKey:            float64(1),
+			configRateBasedMaxScaleUpStepKey:             int64(10),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 100},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		assert.Equal(t, int32(5), *resp.Actions[0].Count)
+	})
+
+	t.Run("cadence scale-up compares against initial count", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey:               int64(2),
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMaxScaleUpStepKey:             int64(2),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 5},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(4), *resp.Actions[0].Count)
+		assert.Equal(t, int64(4), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("scale-down removes one worker", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(3),
+			stateRateBasedEWMAArrivalRate:          float64(0),
+			stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+			stateRateBasedLastScaleDownTimestamp:   oldMs(),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(2), *resp.Actions[0].Count)
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		assert.NotZero(t, resp.Status.GetInt64Field(stateRateBasedLastScaleDownTimestamp, 0))
+	})
+
+	t.Run("cadence scale-down compares against initial count", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey: int64(3),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(2), *resp.Actions[0].Count)
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("scale-down quiet period blocks removal", func(t *testing.T) {
+		originalScaleDownMs := oldMs()
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(3),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+			stateRateBasedLastScaleDownTimestamp:   originalScaleDownMs,
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		// Quiet-period block must not bump LastScaleDownTimestamp; otherwise every
+		// failed poll would silently delay every future scale-down by another cooldown.
+		assert.Equal(t, originalScaleDownMs, resp.Status.GetInt64Field(stateRateBasedLastScaleDownTimestamp, 0))
+	})
+
+	t.Run("scale-down cooldown blocks removal", func(t *testing.T) {
+		originalScaleDownMs := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(3),
+			stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+			stateRateBasedLastScaleDownTimestamp:   originalScaleDownMs,
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		// Cooldown block must leave the timestamp at its prior value so the
+		// cooldown clock doesn't self-extend with each blocked poll.
+		assert.Equal(t, originalScaleDownMs, resp.Status.GetInt64Field(stateRateBasedLastScaleDownTimestamp, 0))
+	})
+
+	t.Run("multi-queue metrics aggregate", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: int64(2)}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(3),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 2, LastProcessingRate: 1},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 4, LastProcessingRate: 2},
+			Nexus:    &iface.QueueTypeScalingMetrics{LastArrivalRate: 0, LastProcessingRate: 0},
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, float64(6), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0))
+		assert.Equal(t, float64(3), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0))
+		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("unknown legacy state is removed", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:   int64(1),
+			"workflow_rate_history_len": int64(1),
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		assert.NotContains(t, resp.Status, "workflow_rate_history_len")
+	})
+
+	t.Run("utilization-target dominates Halfin-Whitt", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(1),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(0.5),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMaxScaleUpStepKey:             int64(100),
+			configRateBasedMaxCountKey:                   int64(100),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 10},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(20), *resp.Actions[0].Count, "offeredLoad=10/1=10, util=ceil(10/0.5)=20, HW=ceil(10)=10; max is 20")
+	})
+
+	t.Run("Halfin-Whitt dominates utilization-target", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(1),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(4),
+			configRateBasedMaxScaleUpStepKey:             int64(100),
+			configRateBasedMaxCountKey:                   int64(100),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 10},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(23), *resp.Actions[0].Count, "offeredLoad=10, util=ceil(10/1)=10, HW=ceil(10+4*sqrt(10))=23; max is 23")
+	})
+
+	t.Run("extreme offered load clamps to max count without int32 overflow", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(1),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(0.5),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMaxScaleUpStepKey:             int64(100),
+			configRateBasedMaxCountKey:                   int64(100),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 1e10},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(100), *resp.Actions[0].Count, "offeredLoad >> MaxInt32 must clamp to max_count, not wrap to min")
+	})
+
+	t.Run("backlog drain rate adds to required rate", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(1),
+			stateRateBasedLastScaleUpTimestamp: oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(4),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMaterialBacklogThresholdKey:   int64(1000),
+			configRateBasedMaxScaleUpStepKey:             int64(100),
+			configRateBasedMaxCountKey:                   int64(100),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(4), *resp.Actions[0].Count, "arrival=0+drain=4 → offered=4 → desired=4")
+	})
+
+	t.Run("zero backlog suppresses drain rate", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(1),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(1),
+			configRateBasedTargetBacklogDrainRateKey:     float64(100),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMinCountKey:                   int64(1),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0, "backlog=0 must suppress drain rate so no scale-up occurs (scale-down blocked by no-sync quiet)")
+	})
+
+	t.Run("non-finite stored capacity recovers to initial", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(1),
+			stateRateBasedLastScaleUpTimestamp:    oldMs(),
+			stateRateBasedEWMAPerConsumerCapacity: math.NaN(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(1),
+			configRateBasedInitialPerConsumerCapacityKey: float64(5),
+			configRateBasedTargetBacklogDrainRateKey:     float64(0),
+			configRateBasedUtilizationTargetKey:          float64(1),
+			configRateBasedHalfinWhittBetaKey:            float64(0),
+			configRateBasedMaxScaleUpStepKey:             int64(100),
+			configRateBasedMaxCountKey:                   int64(100),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 15},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int32(3), *resp.Actions[0].Count, "capacity=NaN must recover to initial=5; offered=15/5=3 → desired=3")
+	})
+
+	t.Run("non-finite stored capacity is scrubbed from persisted state", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(1),
+			stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+			stateRateBasedLastScaleDownTimestamp:   oldMs(),
+			stateRateBasedEWMAPerConsumerCapacity:  math.Inf(1),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey:                 int64(1),
+			configRateBasedMaxCountKey:                 int64(10),
+			configRateBasedMaterialBacklogThresholdKey: int64(1000),
+		}
+		snapshot := ScalingMetricsSnapshot{}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity, "polluted capacity slot must be deleted so warning self-heals")
+	})
+
+	t.Run("non-finite stored EWMA rates are scrubbed from persisted state", func(t *testing.T) {
+		for _, polluted := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			state := iface.ScalingAlgorithmStatus{
+				stateRateBasedWorkerCount:              int64(1),
+				stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+				stateRateBasedLastScaleDownTimestamp:   oldMs(),
+				stateRateBasedEWMAArrivalRate:          polluted,
+				stateRateBasedEWMADispatchRate:         polluted,
+			}
+			cfg := iface.ScalingAlgorithmConfig{
+				configRateBasedMinCountKey: int64(1),
+				configRateBasedMaxCountKey: int64(10),
+			}
+			snapshot := ScalingMetricsSnapshot{}
+
+			resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+			require.NoError(t, err)
+			assert.NotContains(t, resp.Status, stateRateBasedEWMAArrivalRate, "polluted arrival-rate slot (%v) must be deleted", polluted)
+			assert.NotContains(t, resp.Status, stateRateBasedEWMADispatchRate, "polluted dispatch-rate slot (%v) must be deleted", polluted)
+		}
+	})
+
+	t.Run("non-positive finite stored capacity is scrubbed from persisted state", func(t *testing.T) {
+		for _, polluted := range []float64{-3, 0} {
+			state := iface.ScalingAlgorithmStatus{
+				stateRateBasedWorkerCount:              int64(1),
+				stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+				stateRateBasedLastScaleDownTimestamp:   oldMs(),
+				stateRateBasedEWMAPerConsumerCapacity:  polluted,
+			}
+			cfg := iface.ScalingAlgorithmConfig{
+				configRateBasedMinCountKey:                 int64(1),
+				configRateBasedMaxCountKey:                 int64(10),
+				configRateBasedMaterialBacklogThresholdKey: int64(1000),
+			}
+			snapshot := ScalingMetricsSnapshot{}
+
+			resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+			require.NoError(t, err)
+			assert.NotContains(t, resp.Status, stateRateBasedEWMAPerConsumerCapacity, "non-positive capacity %v must be deleted from persisted state", polluted)
+		}
+	})
+
+	t.Run("non-finite arrival rate sample does not poison EWMA and does not contaminate other queues", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:     int64(2),
+			stateRateBasedEWMAArrivalRate: float64(7),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		// Workflow's NaN arrival drops the whole workflow queue (including its
+		// backlog), so Activity's finite sample is what feeds the EWMA. This both
+		// proves NaN doesn't propagate AND that per-queue-type isolation holds:
+		// a single bad queue must not bail out the whole aggregation loop.
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: float32(math.NaN()), LastProcessingRate: 3},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: 4, LastProcessingRate: 2},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		stored := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
+		require.False(t, math.IsNaN(stored), "NaN sample must not be stored")
+		assert.InDelta(t, 0.5*4+0.5*7, stored, 0.0001, "Workflow NaN dropped; EWMA blends prior 7 with only Activity's arrival rate 4")
+	})
+
+	t.Run("non-finite dispatch rate sample does not poison EWMA", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:      int64(2),
+			stateRateBasedEWMADispatchRate: float64(7),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: 3, LastProcessingRate: float32(math.NaN())},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: 4, LastProcessingRate: 2},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		stored := resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, math.NaN())
+		require.False(t, math.IsNaN(stored), "NaN dispatch sample must not be stored")
+		assert.InDelta(t, 0.5*2+0.5*7, stored, 0.0001, "Workflow NaN dropped; dispatch EWMA blends prior 7 with only Activity's dispatch rate 2")
+	})
+
+	t.Run("positive infinity rate sample is rejected like NaN", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:     int64(2),
+			stateRateBasedEWMAArrivalRate: float64(7),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: float32(math.Inf(1)), LastProcessingRate: 3},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: 4, LastProcessingRate: 2},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		stored := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
+		require.False(t, math.IsNaN(stored) || math.IsInf(stored, 0), "+Inf sample must not be stored")
+		assert.InDelta(t, 0.5*4+0.5*7, stored, 0.0001, "Workflow +Inf dropped; EWMA blends prior 7 with only Activity's arrival rate 4")
+	})
+
+	t.Run("non-finite queue's backlog is excluded from material-backlog gate", func(t *testing.T) {
+		const priorCapacity = float64(7)
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:             int64(2),
+			stateRateBasedEWMAPerConsumerCapacity: priorCapacity,
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey:                  float64(0.5),
+			configRateBasedMaterialBacklogThresholdKey:   int64(100),
+			configRateBasedInitialPerConsumerCapacityKey: float64(priorCapacity),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1000, LastArrivalRate: float32(math.NaN()), LastProcessingRate: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 1, LastArrivalRate: 4, LastProcessingRate: 2},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		stored := resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, math.NaN())
+		assert.Equal(t, priorCapacity, stored, "Workflow's backlog must drop with its NaN rates; gate must not trip; capacity slot must stay at prior value")
+	})
+
+	t.Run("metrics-outage poll preserves prior EWMA (all queues rejected as non-finite)", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:      int64(2),
+			stateRateBasedEWMAArrivalRate:  float64(5),
+			stateRateBasedEWMADispatchRate: float64(3),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 10, LastArrivalRate: float32(math.NaN()), LastProcessingRate: float32(math.NaN())},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		storedArrival := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
+		storedDispatch := resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, math.NaN())
+		assert.Equal(t, float64(5), storedArrival, "prior arrival EWMA must be preserved verbatim on outage poll")
+		assert.Equal(t, float64(3), storedDispatch, "prior dispatch EWMA must be preserved verbatim on outage poll")
+	})
+
+	t.Run("metrics-outage poll preserves prior EWMA (no contributing queues)", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:      int64(2),
+			stateRateBasedEWMAArrivalRate:  float64(5),
+			stateRateBasedEWMADispatchRate: float64(3),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedEWMAAlphaKey: float64(0.5),
+		}
+		snapshot := ScalingMetricsSnapshot{}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		storedArrival := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
+		storedDispatch := resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, math.NaN())
+		assert.Equal(t, float64(5), storedArrival, "prior arrival EWMA must be preserved verbatim when no queue contributed")
+		assert.Equal(t, float64(3), storedDispatch, "prior dispatch EWMA must be preserved verbatim when no queue contributed")
+	})
+
+	t.Run("at min count with idle metrics emits no action", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int64(1),
+			stateRateBasedLastNoSyncMatchTimestamp: oldMs(),
+			stateRateBasedLastScaleDownTimestamp:   oldMs(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMinCountKey: int64(1),
+		}
+		snapshot := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{},
+		}
+
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
+		require.NoError(t, err)
+		assert.Len(t, resp.Actions, 0)
+		assert.Equal(t, int64(1), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+	})
+
+	t.Run("invalid worker_count slot is scrubbed and read falls back to initial", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			polluted any
+		}{
+			{"wrong-typed string", "garbage"},
+			{"negative int", int(-1)},
+			{"negative int64", int64(-5)},
+			{"above MaxInt32", int64(math.MaxInt32) + 1},
+			{"NaN float", math.NaN()},
+			{"fractional float64", float64(3.7)},
+			{"float64 above MaxInt32", float64(math.MaxInt32) + 100},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				state := iface.ScalingAlgorithmStatus{
+					stateRateBasedWorkerCount:              tc.polluted,
+					stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+				}
+				cfg := iface.ScalingAlgorithmConfig{
+					configRateBasedInitialCountKey: int64(3),
+					configRateBasedMinCountKey:     int64(1),
+				}
+
+				resp, err := a.ProcessMetricsPoll(ctx, cfg, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+				require.NoError(t, err)
+				assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, -1), "initial_count must be used when worker_count slot is invalid")
+			})
+		}
+	})
+
+	t.Run("plain int worker_count is accepted", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              int(5),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(99), configRateBasedMinCountKey: int64(1)}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), resp.Status.GetInt64Field(stateRateBasedWorkerCount, -1), "int-typed worker_count must be honored")
+	})
+
+	t.Run("integer-valued float64 worker_count is accepted", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:              float64(5),
+			stateRateBasedLastNoSyncMatchTimestamp: time.Now().UnixMilli(),
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedInitialCountKey: int64(99),
+			configRateBasedMinCountKey:     int64(1),
+		}
+		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), resp.Status.GetInt64Field(stateRateBasedWorkerCount, -1), "integer-valued float64 must be honored, not replaced by initial_count")
+	})
+
+	t.Run("invalid timestamp slots are scrubbed so cooldown gate does not fail open", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			polluted any
+		}{
+			{"string", "garbage"},
+			{"negative int", int(-1)},
+			{"negative int64", int64(-1)},
+			{"NaN float64", math.NaN()},
+			{"+Inf float64", math.Inf(1)},
+			{"fractional float64", float64(1.5)},
+
+			// float64(math.MaxInt64) rounds up to 2^63 (MaxInt64 isn't exactly
+			// representable as float64). Casting that to int64 wraps to
+			// MinInt64. The cleaner's `< float64(math.MaxInt64)` guard
+			// excludes this value; a regression to `<=` would re-introduce
+			// the wrap-to-MinInt64 bug while compiling cleanly.
+			{"float64 at MaxInt64 (2^63 wrap)", float64(math.MaxInt64)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				state := iface.ScalingAlgorithmStatus{
+					stateRateBasedWorkerCount:              int64(2),
+					stateRateBasedLastNoSyncMatchTimestamp: tc.polluted,
+					stateRateBasedLastScaleUpTimestamp:     tc.polluted,
+					stateRateBasedLastScaleDownTimestamp:   tc.polluted,
+				}
+				resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{configRateBasedMinCountKey: int64(0)}, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+				require.NoError(t, err)
+				assert.NotContains(t, resp.Status, stateRateBasedLastNoSyncMatchTimestamp, "polluted no-sync timestamp must be deleted from persisted state")
+				assert.NotContains(t, resp.Status, stateRateBasedLastScaleUpTimestamp, "polluted scale-up timestamp must be deleted from persisted state")
+				// Scale-down should have happened (idle metrics, no valid quiet/cooldown blocker, min_count=0).
+				// LastScaleDownTimestamp is written fresh by the scale-down branch, so we can't assert NotContains here.
+				assert.NotEmpty(t, resp.Actions, "scale-down must fire when all blockers' timestamps were polluted and got scrubbed")
+			})
+		}
+	})
+
+	t.Run("integer-valued float64 timestamps are accepted", func(t *testing.T) {
+		freshScaleUp := float64(time.Now().UnixMilli())
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:          int64(2),
+			stateRateBasedLastScaleUpTimestamp: freshScaleUp,
+		}
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedMetricsPollIntervalMsKey: int64(60_000),
+			configRateBasedScaleUpCooldownMsKey:     int64(60_000),
+		}
+		event := iface.SignalTaskAddRequest{IsSyncMatch: false, NoSyncMatchSignalsSinceLast: 1}
+		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
+		require.NoError(t, err)
+		// If the cleaner had dropped the float64 timestamp, lastScaleUpMs would
+		// be 0 and the cooldown gate would fail open, producing a scale-up.
+		require.Len(t, resp.Actions, 1, "fresh float64 scale-up timestamp must block the cooldown gate")
+		assert.Equal(t, ActionTypeDeferredScalingDecision, resp.Actions[0].Action)
+	})
+
+	t.Run("ProcessTaskAdd no_sync bump blocks the next ProcessMetricsPoll scale-down", func(t *testing.T) {
+		state := iface.ScalingAlgorithmStatus{
+			stateRateBasedWorkerCount:            int64(3),
+			stateRateBasedLastScaleUpTimestamp:   oldMs(),
+			stateRateBasedLastScaleDownTimestamp: oldMs(),
+			// Note: no LastNoSyncMatchTimestamp on entry — the only way it gets
+			// set is via the ProcessTaskAdd call later in this test.
+		}
+		// scale_down_cooldown=0 and min_count=1 (below currentCount=3) eliminate
+		// the other two potential block reasons; the only remaining gate that
+		// could prevent scale-down is no_sync_quiet, so a Len==0 assertion below
+		// unambiguously pins the no_sync_quiet contract.
+		cfg := iface.ScalingAlgorithmConfig{
+			configRateBasedNoSyncQuietMsKey:       int64(60_000),
+			configRateBasedMinCountKey:            int64(1),
+			configRateBasedScaleDownCooldownMsKey: int64(0),
+		}
+		taskAddResp, err := a.ProcessTaskAdd(ctx, cfg, state, iface.SignalTaskAddRequest{IsSyncMatch: false, NoSyncMatchSignalsSinceLast: 1})
+		require.NoError(t, err)
+		bumpedNoSyncMs := taskAddResp.Status.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0)
+		require.NotZero(t, bumpedNoSyncMs, "ProcessTaskAdd must bump the no-sync timestamp")
+
+		// Feed the bumped state into ProcessMetricsPoll with idle metrics that
+		// would otherwise trigger scale-down. Block must hold.
+		pollResp, err := a.ProcessMetricsPoll(ctx, cfg, taskAddResp.Status, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
+		require.NoError(t, err)
+		assert.Len(t, pollResp.Actions, 0, "scale-down must be blocked by no_sync_quiet on the poll immediately following a no-sync task-add")
+		assert.Equal(t, taskAddResp.Status.GetInt64Field(stateRateBasedWorkerCount, 0), pollResp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
+		// The cleaner must preserve the bumped no-sync timestamp through the
+		// poll's clean/read cycle, since that timestamp IS the block signal.
+		// A regression that scrubbed it on round-trip would silently undo the
+		// block on every poll.
+		assert.Equal(t, bumpedNoSyncMs, pollResp.Status.GetInt64Field(stateRateBasedLastNoSyncMatchTimestamp, 0), "no-sync timestamp must be preserved verbatim through the poll round-trip")
+	})
+}
+
+func TestRateBasedAggregateMetrics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nil snapshot yields hasData=false and no dropped queues", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, nil)
+		assert.False(t, m.hasData)
+		assert.Empty(t, m.droppedQueues)
+	})
+
+	t.Run("empty snapshot (no queue pointers) yields hasData=false and no dropped queues", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{})
+		assert.False(t, m.hasData)
+		assert.Empty(t, m.droppedQueues)
+	})
+
+	t.Run("all queues finite yields hasData=true and no dropped queues", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 1, LastProcessingRate: 1, LastBacklogCount: 10},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 2, LastProcessingRate: 1, LastBacklogCount: 5},
+			Nexus:    &iface.QueueTypeScalingMetrics{LastArrivalRate: 0, LastProcessingRate: 0},
+		})
+		assert.True(t, m.hasData)
+		assert.Empty(t, m.droppedQueues)
+		assert.Equal(t, int64(15), m.backlog)
+		assert.Equal(t, float64(3), m.arrivalRate)
+		assert.Equal(t, float64(2), m.dispatchRate)
+	})
+
+	t.Run("partial-data poll records dropped queue and keeps hasData=true", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: float32(math.NaN()), LastProcessingRate: 5, LastBacklogCount: 1000},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 4, LastProcessingRate: 2, LastBacklogCount: 1},
+		})
+		assert.True(t, m.hasData, "Activity contributed finite samples")
+		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
+		assert.Equal(t, int64(1), m.backlog, "Workflow's backlog must be excluded along with its NaN rates")
+		assert.Equal(t, float64(4), m.arrivalRate)
+		assert.Equal(t, float64(2), m.dispatchRate)
+	})
+
+	t.Run("all queues rejected yields hasData=false with every queue name listed", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: float32(math.NaN()), LastProcessingRate: 1},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 1, LastProcessingRate: float32(math.Inf(1))},
+			Nexus:    &iface.QueueTypeScalingMetrics{LastArrivalRate: float32(math.Inf(-1)), LastProcessingRate: 1},
+		})
+		assert.False(t, m.hasData)
+		assert.Equal(t, []string{"workflow", "activity", "nexus"}, m.droppedQueues)
+	})
+
+	t.Run("negative arrival rate sample is rejected like NaN", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: -1, LastProcessingRate: 3, LastBacklogCount: 1000},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 4, LastProcessingRate: 2, LastBacklogCount: 1},
+		})
+		assert.True(t, m.hasData, "Activity contributed finite samples")
+		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
+		assert.Equal(t, int64(1), m.backlog, "Workflow's backlog must be excluded along with its negative rate")
+		assert.Equal(t, float64(4), m.arrivalRate)
+		assert.Equal(t, float64(2), m.dispatchRate)
+	})
+
+	t.Run("negative dispatch rate sample is rejected like NaN", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 3, LastProcessingRate: -1, LastBacklogCount: 1000},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 4, LastProcessingRate: 2, LastBacklogCount: 1},
+		})
+		assert.True(t, m.hasData)
+		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
+		assert.Equal(t, int64(1), m.backlog)
+		assert.Equal(t, float64(4), m.arrivalRate)
+		assert.Equal(t, float64(2), m.dispatchRate)
+	})
+
+	t.Run("negative backlog sample is rejected", func(t *testing.T) {
+		m := aggregateRateBasedMetrics(ctx, &ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastArrivalRate: 3, LastProcessingRate: 1, LastBacklogCount: -5},
+			Activity: &iface.QueueTypeScalingMetrics{LastArrivalRate: 4, LastProcessingRate: 2, LastBacklogCount: 10},
+		})
+		assert.True(t, m.hasData)
+		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
+		assert.Equal(t, int64(10), m.backlog, "Activity's backlog stands alone; workflow's negative backlog must be excluded")
+		assert.Equal(t, float64(4), m.arrivalRate, "workflow's arrival rate dropped with its backlog")
+		assert.Equal(t, float64(2), m.dispatchRate)
+	})
+}

--- a/wci/workflow/scaling_algorithm/safe_activity_logger.go
+++ b/wci/workflow/scaling_algorithm/safe_activity_logger.go
@@ -2,26 +2,76 @@ package scalingalgorithm
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
 
 	"go.temporal.io/sdk/activity"
 	sdklog "go.temporal.io/sdk/log"
 )
 
 type (
-	noopLogger struct{}
+	fallbackLogger struct{}
 )
 
+var fallbackStdlibLogger = log.New(os.Stderr, "scalingalgorithm: ", log.LstdFlags)
+
 func safeActivityLogger(ctx context.Context) (logger sdklog.Logger) {
-	logger = noopLogger{}
 	defer func() {
-		if recover() != nil {
-			logger = noopLogger{}
-		}
+		logger = normalizeSDKLogger(logger, recover())
 	}()
-	return activity.GetLogger(ctx)
+	logger = activity.GetLogger(ctx)
+	return
 }
 
-func (noopLogger) Debug(string, ...interface{}) {}
-func (noopLogger) Info(string, ...interface{})  {}
-func (noopLogger) Warn(string, ...interface{})  {}
-func (noopLogger) Error(string, ...interface{}) {}
+// normalizeSDKLogger installs the fallback when activity.GetLogger either
+// panicked (typical: called outside an activity context) or returned nil
+// (permitted by the ActivityOutboundInterceptor contract — a custom interceptor
+// could legitimately return nil). Both paths would otherwise nil-panic callers
+// at the next .Info/.Warn call.
+func normalizeSDKLogger(logger sdklog.Logger, recovered any) sdklog.Logger {
+	if recovered != nil {
+		fallbackStdlibLogger.Printf("ERROR safeActivityLogger: activity.GetLogger panicked, using fallback: %v", recovered)
+		return fallbackLogger{}
+	}
+	if logger == nil {
+		fallbackStdlibLogger.Printf("ERROR safeActivityLogger: activity.GetLogger returned nil, using fallback")
+		return fallbackLogger{}
+	}
+	return logger
+}
+
+func (fallbackLogger) Debug(msg string, keyvals ...any) {
+	fallbackStdlibLogger.Printf("DEBUG %s%s", msg, formatLoggerKeyvals(keyvals))
+}
+
+func (fallbackLogger) Info(msg string, keyvals ...any) {
+	fallbackStdlibLogger.Printf("INFO  %s%s", msg, formatLoggerKeyvals(keyvals))
+}
+
+func (fallbackLogger) Warn(msg string, keyvals ...any) {
+	fallbackStdlibLogger.Printf("WARN  %s%s", msg, formatLoggerKeyvals(keyvals))
+}
+
+func (fallbackLogger) Error(msg string, keyvals ...any) {
+	fallbackStdlibLogger.Printf("ERROR %s%s", msg, formatLoggerKeyvals(keyvals))
+}
+
+func formatLoggerKeyvals(keyvals []any) string {
+	if len(keyvals) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i := 0; i < len(keyvals); i += 2 {
+		b.WriteString(" ")
+		if i+1 < len(keyvals) {
+			fmt.Fprintf(&b, "%v=%v", keyvals[i], keyvals[i+1])
+		} else {
+			// Caller passed an odd number of keyvals — the sdklog.Logger
+			// convention is pairs.
+			fmt.Fprintf(&b, "%v=!BADKV", keyvals[i])
+		}
+	}
+	return b.String()
+}

--- a/wci/workflow/scaling_algorithm/safe_activity_logger_test.go
+++ b/wci/workflow/scaling_algorithm/safe_activity_logger_test.go
@@ -1,0 +1,121 @@
+package scalingalgorithm
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdklog "go.temporal.io/sdk/log"
+)
+
+func TestFormatLoggerKeyvals(t *testing.T) {
+	t.Run("empty keyvals returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", formatLoggerKeyvals(nil))
+		assert.Equal(t, "", formatLoggerKeyvals([]any{}))
+	})
+
+	t.Run("single pair", func(t *testing.T) {
+		assert.Equal(t, " k=v", formatLoggerKeyvals([]any{"k", "v"}))
+	})
+
+	t.Run("multiple pairs preserve order and use %v formatting", func(t *testing.T) {
+		assert.Equal(t, " a=1 b=2.5", formatLoggerKeyvals([]any{"a", 1, "b", 2.5}))
+	})
+
+	t.Run("odd trailing key surfaces as !BADKV", func(t *testing.T) {
+		// Documented contract: callers passing an odd-length keyvals slice get
+		// the orphan key marked with the !BADKV token so log-parsing systems
+		// can alert on malformed call sites instead of seeing a silent `key=`.
+		assert.Equal(t, " k1=v1 orphan=!BADKV", formatLoggerKeyvals([]any{"k1", "v1", "orphan"}))
+	})
+}
+
+func TestFallbackLoggerLevelsRouteToStderrLogger(t *testing.T) {
+	// Redirect the package-level fallback writer to capture output; restoring
+	// at cleanup prevents cross-test pollution.
+	var buf bytes.Buffer
+	original := fallbackStdlibLogger.Writer()
+	fallbackStdlibLogger.SetOutput(&buf)
+	t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
+
+	l := fallbackLogger{}
+	cases := []struct {
+		name     string
+		levelTag string
+		emit     func()
+	}{
+		{"Debug", "DEBUG", func() { l.Debug("hello", "k", "v") }},
+		{"Info", "INFO", func() { l.Info("hello", "k", "v") }},
+		{"Warn", "WARN", func() { l.Warn("hello", "k", "v") }},
+		{"Error", "ERROR", func() { l.Error("hello", "k", "v") }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf.Reset()
+			c.emit()
+			out := buf.String()
+			assert.Contains(t, out, c.levelTag)
+			assert.Contains(t, out, "hello")
+			assert.Contains(t, out, "k=v")
+		})
+	}
+}
+
+func TestNormalizeSDKLogger(t *testing.T) {
+	t.Run("panic value installs fallback and surfaces the recovered value", func(t *testing.T) {
+		var buf bytes.Buffer
+		original := fallbackStdlibLogger.Writer()
+		fallbackStdlibLogger.SetOutput(&buf)
+		t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
+
+		result := normalizeSDKLogger(nil, "boom-distinctive-marker")
+		assert.IsType(t, fallbackLogger{}, result)
+		out := buf.String()
+		assert.Contains(t, out, "panicked", "format string must mention the panic")
+		assert.Contains(t, out, "boom-distinctive-marker", "recovered value must appear via %v so future drift in the format string fails this test")
+	})
+
+	t.Run("nil logger with no panic installs fallback", func(t *testing.T) {
+		var buf bytes.Buffer
+		original := fallbackStdlibLogger.Writer()
+		fallbackStdlibLogger.SetOutput(&buf)
+		t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
+
+		var nilLogger sdklog.Logger
+		result := normalizeSDKLogger(nilLogger, nil)
+		assert.IsType(t, fallbackLogger{}, result)
+		assert.Contains(t, buf.String(), "returned nil")
+	})
+
+	t.Run("non-nil logger with no panic passes through silently", func(t *testing.T) {
+		var buf bytes.Buffer
+		original := fallbackStdlibLogger.Writer()
+		fallbackStdlibLogger.SetOutput(&buf)
+		t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
+
+		input := fallbackLogger{}
+		result := normalizeSDKLogger(input, nil)
+		assert.Equal(t, input, result)
+		assert.Empty(t, buf.String(), "happy path must not write to the fallback")
+	})
+}
+
+func TestSafeActivityLoggerFallsBackOutsideActivityContext(t *testing.T) {
+	var buf bytes.Buffer
+	original := fallbackStdlibLogger.Writer()
+	fallbackStdlibLogger.SetOutput(&buf)
+	t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
+
+	logger := safeActivityLogger(context.Background())
+	require.NotNil(t, logger)
+	assert.Contains(t, buf.String(), "panicked")
+
+	buf.Reset()
+	logger.Warn("downstream", "k", "v")
+	downstream := buf.String()
+	assert.Contains(t, downstream, "WARN")
+	assert.Contains(t, downstream, "downstream")
+	assert.Contains(t, downstream, "k=v")
+}


### PR DESCRIPTION
## What was changed
Introduce a rate-based scaling algorithm that sizes the worker pool from EWMA-smoothed arrival, dispatch, and per-consumer capacity estimates. Desired worker count is the maximum of a utilization-target model and a Halfin-Whitt
square-root staffing model, bounded by min/max count, capped per scale-up step, and gated by asymmetric scale-up/scale-down cooldowns plus a no-sync-match quiet period. Includes unit tests covering the sizing and scaling decisions

This is an implementation of the algorithm in https://github.com/temporalio/temporal-auto-scaled-workers/pull/54

## Why?
The existing scaling algorithm makes a set of assumption that are true for Lambda, but not for other compute providers like GCP CloudRun or AWS ECS. This adds a new scaling algorithm more suited to these other compute providers.