### PR TITLE
COM-163: Added support for GCP impersonation chain.

### DIFF
--- a/wci/fx.go
+++ b/wci/fx.go
@@ -4,6 +4,7 @@ package wci
 import (
 	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/auto-scaled-workers/wci/workercomponent"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
@@ -53,6 +54,15 @@ var Module = fx.Options(
 	fx.Provide(ServiceResolverProvider),
 	fx.Provide(NewService),
 	fx.Provide(PerNamespaceWorkerManagerProvider),
+	fx.Provide(func() computeprovider.ImpersonationChainProvider {
+		return computeprovider.NoopImpersonationChainProvider{}
+	}),
+	// Install the (possibly fx.Decorate-replaced) chain provider into the
+	// compute_provider package singleton, where the GCP Cloud Run provider
+	// reads it. fx resolves the decorated value before this Invoke fires.
+	fx.Invoke(func(p computeprovider.ImpersonationChainProvider) {
+		computeprovider.SetImpersonationChainProvider(p)
+	}),
 	fx.Invoke(ServiceLifetimeHooks),
 )
 

--- a/wci/fx.go
+++ b/wci/fx.go
@@ -54,14 +54,14 @@ var Module = fx.Options(
 	fx.Provide(ServiceResolverProvider),
 	fx.Provide(NewService),
 	fx.Provide(PerNamespaceWorkerManagerProvider),
-	fx.Provide(func() computeprovider.ImpersonationChainProvider {
-		return computeprovider.NoopImpersonationChainProvider{}
+	fx.Provide(func() computeprovider.GCPImpersonationChainProvider {
+		return computeprovider.NoopGCPImpersonationChainProvider{}
 	}),
 	// Install the (possibly fx.Decorate-replaced) chain provider into the
 	// compute_provider package singleton, where the GCP Cloud Run provider
 	// reads it. fx resolves the decorated value before this Invoke fires.
-	fx.Invoke(func(p computeprovider.ImpersonationChainProvider) {
-		computeprovider.SetImpersonationChainProvider(p)
+	fx.Invoke(func(p computeprovider.GCPImpersonationChainProvider) {
+		computeprovider.SetGCPImpersonationChainProvider(p)
 	}),
 	fx.Invoke(ServiceLifetimeHooks),
 )

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -40,13 +40,11 @@ type (
 		workflowserviceClient workflowservice.WorkflowServiceClient
 	}
 
-	// RequestContext carries the namespace/deployment identity tags shared by every
-	// activity request type.
-	RequestContext struct {
-		NamespaceName     string `json:"namespace_name"`
-		DeploymentName    string `json:"deployment_name"`
-		DeploymentBuildID string `json:"deployment_build_id"`
-	}
+	// RequestContext aliases the compute-provider request context so activity
+	// request types can embed it while compute providers consume the same type
+	// directly. The alias keeps it defined in compute_provider (which the
+	// ComputeProvider interface depends on) without an import cycle.
+	RequestContext = computeprovider.RequestContext
 
 	ValidateSpecRequest struct {
 		RequestContext
@@ -116,23 +114,15 @@ type (
 	}
 )
 
-// invocationContext projects the request's identity into the form the compute
-// providers consume.
-func (r RequestContext) invocationContext() computeprovider.InvocationContext {
-	return computeprovider.InvocationContext{
-		Namespace:      r.NamespaceName,
-		DeploymentName: r.DeploymentName,
-		BuildID:        r.DeploymentBuildID,
-	}
-}
-
 // metricsHandler returns the activity-side MetricsHandler pre-tagged with the
-// namespace/deployment identity and the supplied activity type.
-func (r RequestContext) metricsHandler(ctx context.Context, activityType wcimetrics.ActivityType) sdkclient.MetricsHandler {
+// namespace/deployment identity and the supplied activity type. It is a free
+// function because RequestContext is an alias of a compute_provider type, so
+// methods can't be declared on it from this package.
+func metricsHandler(ctx context.Context, rc RequestContext, activityType wcimetrics.ActivityType) sdkclient.MetricsHandler {
 	return activity.GetMetricsHandler(ctx).WithTags(map[string]string{
-		wcimetrics.NamespaceTag:               r.NamespaceName,
-		wcimetrics.WorkerDeploymentNameTag:    r.DeploymentName,
-		wcimetrics.WorkerDeploymentBuildIDTag: r.DeploymentBuildID,
+		wcimetrics.NamespaceTag:               rc.NamespaceName,
+		wcimetrics.WorkerDeploymentNameTag:    rc.DeploymentName,
+		wcimetrics.WorkerDeploymentBuildIDTag: rc.DeploymentBuildID,
 		wcimetrics.ActivityTypeTag:            string(activityType),
 	})
 }
@@ -161,7 +151,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 	}
 
 	logger := activity.GetLogger(ctx)
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeValidateSpec)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeValidateSpec)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, validateSpecTimeout)
@@ -183,7 +173,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
-		if err := provider.ValidateConfig(timeoutCtx, req.invocationContext(), config); err != nil {
+		if err := provider.ValidateConfig(timeoutCtx, req.RequestContext, config); err != nil {
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
@@ -226,7 +216,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 		return temporal.NewApplicationError("Invalid activity request", "InternalError")
 	}
 
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeInvokeWorkersToRegisterTaskQueues)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeInvokeWorkersToRegisterTaskQueues)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
 	for k, v := range req.ScalingGroupSpecs {
@@ -247,7 +237,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 			}
 
-			if err := provider.InvokeWorker(ctx, req.invocationContext(), config); err != nil {
+			if err := provider.InvokeWorker(ctx, req.RequestContext, config); err != nil {
 				recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
 			}
@@ -264,7 +254,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 	}
 
 	logger := activity.GetLogger(ctx)
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeInvokeWorker)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeInvokeWorker)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
 	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.dc)
@@ -287,7 +277,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, startNewWorkerInstanceTimeout)
 	defer cancel()
-	if err := provider.InvokeWorker(timeoutCtx, req.invocationContext(), config); err != nil {
+	if err := provider.InvokeWorker(timeoutCtx, req.RequestContext, config); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
@@ -302,7 +292,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 	}
 
 	logger := activity.GetLogger(ctx)
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeUpdateWorkerSetSize)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeUpdateWorkerSetSize)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
 	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.dc)
@@ -325,7 +315,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, updateWorkerSetSizeTimeout)
 	defer cancel()
-	if err := provider.UpdateWorkerSetSize(timeoutCtx, req.invocationContext(), config, req.UpdatedSize); err != nil {
+	if err := provider.UpdateWorkerSetSize(timeoutCtx, req.RequestContext, config, req.UpdatedSize); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
@@ -336,7 +326,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 
 func (a *Activities) HandleDeferredScalingDecision(ctx context.Context, req HandleDeferredScalingDecisionActivityRequest) (*HandleDeferredScalingDecisionActivityResponse, error) {
 	logger := activity.GetLogger(ctx)
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeHandleDeferredScalingDecision)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeHandleDeferredScalingDecision)
 	recordError, recordSkipped, recordSuccess := newActivityRecorders(metricsHandler)
 
 	scalingStatus := maps.Clone(req.ScalingStatus)
@@ -407,7 +397,7 @@ func (a *Activities) HandleTaskAddSignal(ctx context.Context, req HandleTaskAddS
 		updatedScalingStatus = map[string]iface.ScalingAlgorithmStatus{}
 	}
 
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypeHandleTaskAddSignal)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeHandleTaskAddSignal)
 	_, recordSkipped, recordSuccess := newActivityRecorders(metricsHandler)
 
 	if req.Spec == nil {
@@ -471,7 +461,7 @@ func (a *Activities) PullStats(ctx context.Context, req *PullStatsActivityReques
 	}
 
 	logger := activity.GetLogger(ctx)
-	metricsHandler := req.metricsHandler(ctx, wcimetrics.ActivityTypePullStats)
+	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypePullStats)
 	recordError, recordSkipped, recordSuccess := newActivityRecorders(metricsHandler)
 
 	if !a.workerControllerEnabled() {

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -116,6 +116,16 @@ type (
 	}
 )
 
+// invocationContext projects the request's identity into the form the compute
+// providers consume.
+func (r RequestContext) invocationContext() computeprovider.InvocationContext {
+	return computeprovider.InvocationContext{
+		Namespace:      r.NamespaceName,
+		DeploymentName: r.DeploymentName,
+		BuildID:        r.DeploymentBuildID,
+	}
+}
+
 // metricsHandler returns the activity-side MetricsHandler pre-tagged with the
 // namespace/deployment identity and the supplied activity type.
 func (r RequestContext) metricsHandler(ctx context.Context, activityType wcimetrics.ActivityType) sdkclient.MetricsHandler {
@@ -127,7 +137,11 @@ func (r RequestContext) metricsHandler(ctx context.Context, activityType wcimetr
 	})
 }
 
-func NewActivities(namespace *namespace.Namespace, dc *dynamicconfig.Collection, workflowserviceClient workflowservice.WorkflowServiceClient) *Activities {
+func NewActivities(
+	namespace *namespace.Namespace,
+	dc *dynamicconfig.Collection,
+	workflowserviceClient workflowservice.WorkflowServiceClient,
+) *Activities {
 	return &Activities{
 		dc:                    dc,
 		namespace:             namespace,
@@ -169,7 +183,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
-		if err := provider.ValidateConfig(timeoutCtx, config); err != nil {
+		if err := provider.ValidateConfig(timeoutCtx, req.invocationContext(), config); err != nil {
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
@@ -233,7 +247,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 			}
 
-			if err := provider.InvokeWorker(ctx, config); err != nil {
+			if err := provider.InvokeWorker(ctx, req.invocationContext(), config); err != nil {
 				recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
 			}
@@ -273,7 +287,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, startNewWorkerInstanceTimeout)
 	defer cancel()
-	if err := provider.InvokeWorker(timeoutCtx, config); err != nil {
+	if err := provider.InvokeWorker(timeoutCtx, req.invocationContext(), config); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
@@ -311,7 +325,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, updateWorkerSetSizeTimeout)
 	defer cancel()
-	if err := provider.UpdateWorkerSetSize(timeoutCtx, config, req.UpdatedSize); err != nil {
+	if err := provider.UpdateWorkerSetSize(timeoutCtx, req.invocationContext(), config, req.UpdatedSize); err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -48,7 +48,7 @@ func (p *awsECSComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
+func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig) error {
 	if p.requireRoleAndExternalID {
 		if roleARN, _ := cfg[configAWSECSRole].(string); roleARN == "" {
 			return fmt.Errorf("ECS compute provider requires %q to be configured", configAWSECSRole)
@@ -88,11 +88,11 @@ func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, _ Invocation
 	return nil
 }
 
-func (p *awsECSComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
+func (p *awsECSComputeProvider) InvokeWorker(_ context.Context, _ RequestContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig, size int32) error {
+func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig, size int32) error {
 	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -48,7 +48,7 @@ func (p *awsECSComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, cfg ComputeProviderConfig) error {
+func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
 	if p.requireRoleAndExternalID {
 		if roleARN, _ := cfg[configAWSECSRole].(string); roleARN == "" {
 			return fmt.Errorf("ECS compute provider requires %q to be configured", configAWSECSRole)
@@ -88,11 +88,11 @@ func (p *awsECSComputeProvider) ValidateConfig(ctx context.Context, cfg ComputeP
 	return nil
 }
 
-func (p *awsECSComputeProvider) InvokeWorker(ctx context.Context, cfg ComputeProviderConfig) error {
+func (p *awsECSComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, cfg ComputeProviderConfig, size int32) error {
+func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig, size int32) error {
 	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -145,7 +145,7 @@ func TestAWSECSValidateConfig_MissingRole_ReturnsError(t *testing.T) {
 		// no role
 	}
 
-	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when role is missing, got nil")
 	}
 }
@@ -159,7 +159,7 @@ func TestAWSECSValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when external ID is missing, got nil")
 	}
 }
@@ -174,7 +174,7 @@ func TestAWSECSValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *testing
 		// no role or external ID
 	}
 
-	err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg)
+	err := p.ValidateConfig(context.Background(), RequestContext{}, cfg)
 	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
 	if err != nil && (err.Error() == `ECS compute provider requires "role" to be configured` ||
 		err.Error() == `ECS compute provider requires "role_external_id" to be configured`) {

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -145,7 +145,7 @@ func TestAWSECSValidateConfig_MissingRole_ReturnsError(t *testing.T) {
 		// no role
 	}
 
-	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
 		t.Fatal("expected error when role is missing, got nil")
 	}
 }
@@ -159,7 +159,7 @@ func TestAWSECSValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
 		t.Fatal("expected error when external ID is missing, got nil")
 	}
 }
@@ -174,7 +174,7 @@ func TestAWSECSValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *testing
 		// no role or external ID
 	}
 
-	err := p.ValidateConfig(context.Background(), cfg)
+	err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg)
 	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
 	if err != nil && (err.Error() == `ECS compute provider requires "role" to be configured` ||
 		err.Error() == `ECS compute provider requires "role_external_id" to be configured`) {

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -46,7 +46,7 @@ func (p *awsLambdaComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
+func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig) error {
 	if p.requireRoleAndExternalID {
 		if roleARN, _ := cfg[configAWSLambdaRole].(string); roleARN == "" {
 			return fmt.Errorf("AWS Lambda compute provider requires %q to be configured", configAWSLambdaRole)
@@ -74,7 +74,7 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ Invocat
 	return nil
 }
 
-func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
+func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig) error {
 	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, _ Invocatio
 	return nil
 }
 
-func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
+func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ RequestContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -46,7 +46,7 @@ func (p *awsLambdaComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, cfg ComputeProviderConfig) error {
+func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
 	if p.requireRoleAndExternalID {
 		if roleARN, _ := cfg[configAWSLambdaRole].(string); roleARN == "" {
 			return fmt.Errorf("AWS Lambda compute provider requires %q to be configured", configAWSLambdaRole)
@@ -74,7 +74,7 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, cfg Compu
 	return nil
 }
 
-func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, cfg ComputeProviderConfig) error {
+func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, _ InvocationContext, cfg ComputeProviderConfig) error {
 	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, cfg Compute
 	return nil
 }
 
-func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+func (p *awsLambdaComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -95,7 +95,7 @@ func TestAWSLambdaValidateConfig_MissingRole_ReturnsError(t *testing.T) {
 		// no role
 	}
 
-	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
 		t.Fatal("expected error when role is missing, got nil")
 	}
 }
@@ -108,7 +108,7 @@ func TestAWSLambdaValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.ValidateConfig(context.Background(), cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
 		t.Fatal("expected error when external ID is missing, got nil")
 	}
 }
@@ -122,7 +122,7 @@ func TestAWSLambdaValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *test
 		// no role or external ID
 	}
 
-	err := p.ValidateConfig(context.Background(), cfg)
+	err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg)
 	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
 	if err != nil && (err.Error() == `AWS Lambda compute provider requires "role" to be configured` ||
 		err.Error() == `AWS Lambda compute provider requires "role_external_id" to be configured`) {

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -95,7 +95,7 @@ func TestAWSLambdaValidateConfig_MissingRole_ReturnsError(t *testing.T) {
 		// no role
 	}
 
-	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when role is missing, got nil")
 	}
 }
@@ -108,7 +108,7 @@ func TestAWSLambdaValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when external ID is missing, got nil")
 	}
 }
@@ -122,7 +122,7 @@ func TestAWSLambdaValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *test
 		// no role or external ID
 	}
 
-	err := p.ValidateConfig(context.Background(), InvocationContext{}, cfg)
+	err := p.ValidateConfig(context.Background(), RequestContext{}, cfg)
 	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
 	if err != nil && (err.Error() == `AWS Lambda compute provider requires "role" to be configured` ||
 		err.Error() == `AWS Lambda compute provider requires "role_external_id" to be configured`) {

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -47,8 +47,8 @@ func (p *gcpCloudRunComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error {
-	client, name, err := p.buildClientAndParams(ctx, ic, config)
+func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, rc RequestContext, config ComputeProviderConfig) error {
+	client, name, err := p.buildClientAndParams(ctx, rc, config)
 	if err != nil {
 		return err
 	}
@@ -60,12 +60,12 @@ func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, ic Invo
 	return nil
 }
 
-func (p *gcpCloudRunComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
+func (p *gcpCloudRunComputeProvider) InvokeWorker(_ context.Context, _ RequestContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, ic InvocationContext, config ComputeProviderConfig, count int32) error {
-	client, name, err := p.buildClientAndParams(ctx, ic, config)
+func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc RequestContext, config ComputeProviderConfig, count int32) error {
+	client, name, err := p.buildClientAndParams(ctx, rc, config)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, ic
 }
 
 // buildClientAndParams creates a Cloud Run WorkerPoolsClient and constructs the fully-qualified worker pool name.
-func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) (*run.WorkerPoolsClient, string, error) {
+func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, rc RequestContext, config ComputeProviderConfig) (*run.WorkerPoolsClient, string, error) {
 	name, err := getNameFromConfig(config)
 	if err != nil {
 		return nil, "", err
@@ -101,8 +101,8 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, i
 			candidates = append(candidates, emails)
 		}
 
-		delegates, err := getImpersonationChainProvider().ResolveChain(ctx, ResolveChainInput{
-			Namespace:          ic.Namespace,
+		delegates, err := getGCPImpersonationChainProvider().ResolveChain(ctx, ResolveChainInput{
+			Namespace:          rc.NamespaceName,
 			GlobalSACandidates: candidates,
 		})
 		if err != nil {
@@ -144,7 +144,7 @@ func getNameFromConfig(config ComputeProviderConfig) (string, error) {
 }
 
 type (
-	ImpersonationChainProvider interface {
+	GCPImpersonationChainProvider interface {
 		// ResolveChain returns the ordered impersonation delegates for the
 		// given namespace. An empty/nil result means direct impersonation
 		// (cell SA → customer SA, no intermediaries).
@@ -156,18 +156,18 @@ type (
 		GlobalSACandidates [][]string
 	}
 
-	NoopImpersonationChainProvider struct{}
+	NoopGCPImpersonationChainProvider struct{}
 )
 
 var (
 	chainProviderMu sync.RWMutex
-	chainProvider   ImpersonationChainProvider = NoopImpersonationChainProvider{}
+	chainProvider   GCPImpersonationChainProvider = NoopGCPImpersonationChainProvider{}
 )
 
-// SetImpersonationChainProvider installs the process-wide chain provider used by
+// SetGCPImpersonationChainProvider installs the process-wide chain provider used by
 // the GCP Cloud Run compute provider. Called once at startup; defaults to the
 // no-op impl. A nil provider is ignored so the default is preserved.
-func SetImpersonationChainProvider(p ImpersonationChainProvider) {
+func SetGCPImpersonationChainProvider(p GCPImpersonationChainProvider) {
 	chainProviderMu.Lock()
 	defer chainProviderMu.Unlock()
 	if p != nil {
@@ -175,14 +175,14 @@ func SetImpersonationChainProvider(p ImpersonationChainProvider) {
 	}
 }
 
-// getImpersonationChainProvider returns the process-wide chain provider.
-func getImpersonationChainProvider() ImpersonationChainProvider {
+// getGCPImpersonationChainProvider returns the process-wide chain provider.
+func getGCPImpersonationChainProvider() GCPImpersonationChainProvider {
 	chainProviderMu.RLock()
 	defer chainProviderMu.RUnlock()
 	return chainProvider
 }
 
-func (NoopImpersonationChainProvider) ResolveChain(_ context.Context, input ResolveChainInput) ([]string, error) {
+func (NoopGCPImpersonationChainProvider) ResolveChain(_ context.Context, input ResolveChainInput) ([]string, error) {
 	delegates := make([]string, 0, len(input.GlobalSACandidates))
 	for _, step := range input.GlobalSACandidates {
 		if len(step) == 0 {

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"sync"
 
 	run "cloud.google.com/go/run/apiv2"
 	runpb "cloud.google.com/go/run/apiv2/runpb"
@@ -46,8 +47,8 @@ func (p *gcpCloudRunComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, config ComputeProviderConfig) error {
-	client, name, err := p.buildClientAndParams(ctx, config)
+func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error {
+	client, name, err := p.buildClientAndParams(ctx, ic, config)
 	if err != nil {
 		return err
 	}
@@ -59,12 +60,12 @@ func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, config 
 	return nil
 }
 
-func (p *gcpCloudRunComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+func (p *gcpCloudRunComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, config ComputeProviderConfig, count int32) error {
-	client, name, err := p.buildClientAndParams(ctx, config)
+func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, ic InvocationContext, config ComputeProviderConfig, count int32) error {
+	client, name, err := p.buildClientAndParams(ctx, ic, config)
 	if err != nil {
 		return err
 	}
@@ -83,35 +84,29 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, co
 }
 
 // buildClientAndParams creates a Cloud Run WorkerPoolsClient and constructs the fully-qualified worker pool name.
-func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, config ComputeProviderConfig) (*run.WorkerPoolsClient, string, error) {
-	project, ok := config[configGCPCloudRunProject].(string)
-	if !ok || project == "" {
-		return nil, "", fmt.Errorf("project not found in config")
+func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) (*run.WorkerPoolsClient, string, error) {
+	name, err := getNameFromConfig(config)
+	if err != nil {
+		return nil, "", err
 	}
-	region, ok := config[configGCPCloudRunRegion].(string)
-	if !ok || region == "" {
-		return nil, "", fmt.Errorf("region not found in config")
-	}
-	workerPool, ok := config[configGCPCloudRunWorkerPool].(string)
-	if !ok || workerPool == "" {
-		return nil, "", fmt.Errorf("worker_pool not found in config")
-	}
-	name := fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, workerPool)
 
 	var opts []option.ClientOption
 	if serviceAccount, ok := config[configGCPCloudRunServiceAccount].(string); ok && serviceAccount != "" {
-		delegates := []string{}
+		candidates := make([][]string, 0, len(p.intermediaryServiceAccounts))
 		for _, step := range p.intermediaryServiceAccounts {
-			if len(step) == 0 {
-				continue
+			emails := make([]string, 0, len(step))
+			for _, req := range step {
+				emails = append(emails, req.ServiceAccountEmail)
 			}
+			candidates = append(candidates, emails)
+		}
 
-			req := step[rand.Intn(len(step))]
-			if req.ServiceAccountEmail == "" {
-				return nil, "", fmt.Errorf("invalid empty intermediary service account email")
-			}
-
-			delegates = append(delegates, req.ServiceAccountEmail)
+		delegates, err := getImpersonationChainProvider().ResolveChain(ctx, ResolveChainInput{
+			Namespace:          ic.Namespace,
+			GlobalSACandidates: candidates,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to resolve impersonation chain: %w", err)
 		}
 
 		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
@@ -130,4 +125,74 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, c
 		return nil, "", fmt.Errorf("failed to create Cloud Run client: %w", err)
 	}
 	return client, name, nil
+}
+
+func getNameFromConfig(config ComputeProviderConfig) (string, error) {
+	project, ok := config[configGCPCloudRunProject].(string)
+	if !ok || project == "" {
+		return "", fmt.Errorf("project not found in config")
+	}
+	region, ok := config[configGCPCloudRunRegion].(string)
+	if !ok || region == "" {
+		return "", fmt.Errorf("region not found in config")
+	}
+	workerPool, ok := config[configGCPCloudRunWorkerPool].(string)
+	if !ok || workerPool == "" {
+		return "", fmt.Errorf("worker_pool not found in config")
+	}
+	return fmt.Sprintf("projects/%s/locations/%s/workerPools/%s", project, region, workerPool), nil
+}
+
+type (
+	ImpersonationChainProvider interface {
+		// ResolveChain returns the ordered impersonation delegates for the
+		// given namespace. An empty/nil result means direct impersonation
+		// (cell SA → customer SA, no intermediaries).
+		ResolveChain(ctx context.Context, input ResolveChainInput) ([]string, error)
+	}
+
+	ResolveChainInput struct {
+		Namespace          string
+		GlobalSACandidates [][]string
+	}
+
+	NoopImpersonationChainProvider struct{}
+)
+
+var (
+	chainProviderMu sync.RWMutex
+	chainProvider   ImpersonationChainProvider = NoopImpersonationChainProvider{}
+)
+
+// SetImpersonationChainProvider installs the process-wide chain provider used by
+// the GCP Cloud Run compute provider. Called once at startup; defaults to the
+// no-op impl. A nil provider is ignored so the default is preserved.
+func SetImpersonationChainProvider(p ImpersonationChainProvider) {
+	chainProviderMu.Lock()
+	defer chainProviderMu.Unlock()
+	if p != nil {
+		chainProvider = p
+	}
+}
+
+// getImpersonationChainProvider returns the process-wide chain provider.
+func getImpersonationChainProvider() ImpersonationChainProvider {
+	chainProviderMu.RLock()
+	defer chainProviderMu.RUnlock()
+	return chainProvider
+}
+
+func (NoopImpersonationChainProvider) ResolveChain(_ context.Context, input ResolveChainInput) ([]string, error) {
+	delegates := make([]string, 0, len(input.GlobalSACandidates))
+	for _, step := range input.GlobalSACandidates {
+		if len(step) == 0 {
+			continue
+		}
+		picked := step[rand.Intn(len(step))]
+		if picked == "" {
+			return nil, fmt.Errorf("invalid empty intermediary service account email")
+		}
+		delegates = append(delegates, picked)
+	}
+	return delegates, nil
 }

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -1,0 +1,180 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"go.temporal.io/auto-scaled-workers/wci/client"
+)
+
+type captureChainProvider struct {
+	capture   *ResolveChainInput
+	delegates []string
+	err       error
+}
+
+func (c *captureChainProvider) ResolveChain(_ context.Context, input ResolveChainInput) ([]string, error) {
+	if c.capture != nil {
+		*c.capture = input
+	}
+	return c.delegates, c.err
+}
+
+// setChainProviderForTest installs cp as the process-wide chain provider for the
+// duration of the test, restoring the no-op default on cleanup.
+func setChainProviderForTest(t *testing.T, cp ImpersonationChainProvider) {
+	t.Helper()
+	SetImpersonationChainProvider(cp)
+	t.Cleanup(func() { SetImpersonationChainProvider(NoopImpersonationChainProvider{}) })
+}
+
+func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *testing.T) {
+	var captured ResolveChainInput
+	setChainProviderForTest(t, &captureChainProvider{capture: &captured, delegates: []string{"d1"}})
+	p := &gcpCloudRunComputeProvider{
+		intermediaryServiceAccounts: [][]client.GCPIAMServiceAccountRequest{
+			{{ServiceAccountEmail: "sa-a"}, {ServiceAccountEmail: "sa-b"}},
+			{{ServiceAccountEmail: "sa-c"}},
+		},
+	}
+	// Discard the final return — we only care the chain provider was invoked with
+	// the expected input. The downstream Cloud Run client construction may or may
+	// not succeed depending on the test env's GCP auth state.
+	_, _, _ = p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	})
+	if captured.Namespace != "my-ns" {
+		t.Errorf("namespace not threaded: got %q, want %q", captured.Namespace, "my-ns")
+	}
+	want := [][]string{{"sa-a", "sa-b"}, {"sa-c"}}
+	if !reflect.DeepEqual(captured.GlobalSACandidates, want) {
+		t.Errorf("candidates mismatch: got %v, want %v", captured.GlobalSACandidates, want)
+	}
+}
+
+func TestGCPCloudRun_ChainProviderErrorWrapped(t *testing.T) {
+	setChainProviderForTest(t, &captureChainProvider{err: errors.New("boom")})
+	p := &gcpCloudRunComputeProvider{}
+	_, _, err := p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	})
+	if err == nil {
+		t.Fatal("expected wrapped chain-provider error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected wrapped error containing 'boom'; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "impersonation chain") {
+		t.Errorf("expected 'impersonation chain' in error; got: %v", err)
+	}
+}
+
+func TestGCPCloudRun_ChainProviderNotCalledWithoutCustomerSA(t *testing.T) {
+	called := false
+	setChainProviderForTest(t, chainProviderFunc(func(context.Context, ResolveChainInput) ([]string, error) {
+		called = true
+		return nil, nil
+	}))
+	p := &gcpCloudRunComputeProvider{}
+	_, _, _ = p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+		configGCPCloudRunProject:    "p",
+		configGCPCloudRunRegion:     "r",
+		configGCPCloudRunWorkerPool: "wp",
+		// no service_account → no impersonation chain needed
+	})
+	if called {
+		t.Error("chain provider should not be called when customer service account is absent")
+	}
+}
+
+type chainProviderFunc func(context.Context, ResolveChainInput) ([]string, error)
+
+func (f chainProviderFunc) ResolveChain(ctx context.Context, input ResolveChainInput) ([]string, error) {
+	return f(ctx, input)
+}
+
+func TestNoopImpersonationChainProvider_Empty(t *testing.T) {
+	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(delegates) != 0 {
+		t.Errorf("expected empty Delegates, got: %v", delegates)
+	}
+}
+
+func TestNoopImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
+	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		GlobalSACandidates: [][]string{{"sa-a"}},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !reflect.DeepEqual(delegates, []string{"sa-a"}) {
+		t.Errorf("expected [sa-a], got: %v", delegates)
+	}
+}
+
+func TestNoopImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
+	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		GlobalSACandidates: [][]string{{"hop-1"}, {"hop-2"}, {"hop-3"}},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !reflect.DeepEqual(delegates, []string{"hop-1", "hop-2", "hop-3"}) {
+		t.Errorf("expected ordered hops, got: %v", delegates)
+	}
+}
+
+func TestNoopImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
+	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		GlobalSACandidates: [][]string{{"a"}, {}, {"b"}},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !reflect.DeepEqual(delegates, []string{"a", "b"}) {
+		t.Errorf("expected empty step skipped, got: %v", delegates)
+	}
+}
+
+func TestNoopImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
+	_, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		GlobalSACandidates: [][]string{{""}},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty entry")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention 'empty'; got: %v", err)
+	}
+}
+
+func TestNoopImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {
+	candidates := []string{"a", "b", "c"}
+	valid := map[string]bool{"a": true, "b": true, "c": true}
+	for i := 0; i < 10; i++ {
+		delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+			GlobalSACandidates: [][]string{candidates},
+		})
+		if err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+		if len(delegates) != 1 {
+			t.Fatalf("iter %d: expected 1 delegate, got: %v", i, delegates)
+		}
+		if !valid[delegates[0]] {
+			t.Errorf("iter %d: pick %q not in candidate set", i, delegates[0])
+		}
+	}
+}

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -25,10 +25,10 @@ func (c *captureChainProvider) ResolveChain(_ context.Context, input ResolveChai
 
 // setChainProviderForTest installs cp as the process-wide chain provider for the
 // duration of the test, restoring the no-op default on cleanup.
-func setChainProviderForTest(t *testing.T, cp ImpersonationChainProvider) {
+func setChainProviderForTest(t *testing.T, cp GCPImpersonationChainProvider) {
 	t.Helper()
-	SetImpersonationChainProvider(cp)
-	t.Cleanup(func() { SetImpersonationChainProvider(NoopImpersonationChainProvider{}) })
+	SetGCPImpersonationChainProvider(cp)
+	t.Cleanup(func() { SetGCPImpersonationChainProvider(NoopGCPImpersonationChainProvider{}) })
 }
 
 func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *testing.T) {
@@ -43,7 +43,7 @@ func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *tes
 	// Discard the final return — we only care the chain provider was invoked with
 	// the expected input. The downstream Cloud Run client construction may or may
 	// not succeed depending on the test env's GCP auth state.
-	_, _, _ = p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -61,7 +61,7 @@ func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *tes
 func TestGCPCloudRun_ChainProviderErrorWrapped(t *testing.T) {
 	setChainProviderForTest(t, &captureChainProvider{err: errors.New("boom")})
 	p := &gcpCloudRunComputeProvider{}
-	_, _, err := p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+	_, _, err := p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -85,7 +85,7 @@ func TestGCPCloudRun_ChainProviderNotCalledWithoutCustomerSA(t *testing.T) {
 		return nil, nil
 	}))
 	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(context.Background(), InvocationContext{Namespace: "my-ns"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:    "p",
 		configGCPCloudRunRegion:     "r",
 		configGCPCloudRunWorkerPool: "wp",
@@ -102,8 +102,8 @@ func (f chainProviderFunc) ResolveChain(ctx context.Context, input ResolveChainI
 	return f(ctx, input)
 }
 
-func TestNoopImpersonationChainProvider_Empty(t *testing.T) {
-	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{})
+func TestNoopGCPImpersonationChainProvider_Empty(t *testing.T) {
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -112,8 +112,8 @@ func TestNoopImpersonationChainProvider_Empty(t *testing.T) {
 	}
 }
 
-func TestNoopImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
-	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+func TestNoopGCPImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"sa-a"}},
 	})
 	if err != nil {
@@ -124,8 +124,8 @@ func TestNoopImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
 	}
 }
 
-func TestNoopImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
-	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+func TestNoopGCPImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"hop-1"}, {"hop-2"}, {"hop-3"}},
 	})
 	if err != nil {
@@ -136,8 +136,8 @@ func TestNoopImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
 	}
 }
 
-func TestNoopImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
-	delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+func TestNoopGCPImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"a"}, {}, {"b"}},
 	})
 	if err != nil {
@@ -148,8 +148,8 @@ func TestNoopImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
 	}
 }
 
-func TestNoopImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
-	_, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+func TestNoopGCPImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
+	_, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{""}},
 	})
 	if err == nil {
@@ -160,11 +160,11 @@ func TestNoopImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
 	}
 }
 
-func TestNoopImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {
+func TestNoopGCPImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {
 	candidates := []string{"a", "b", "c"}
 	valid := map[string]bool{"a": true, "b": true, "c": true}
 	for i := 0; i < 10; i++ {
-		delegates, err := (NoopImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 			GlobalSACandidates: [][]string{candidates},
 		})
 		if err != nil {

--- a/wci/workflow/compute_provider/k8s.go
+++ b/wci/workflow/compute_provider/k8s.go
@@ -36,7 +36,7 @@ func (p *k8sComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	client, namespace, deployment, err := p.buildClientAndParams(config)
 	if err != nil {
 		return err
@@ -48,11 +48,11 @@ func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, _ InvocationCon
 	return nil
 }
 
-func (p *k8sComputeProvider) InvokeWorker(ctx context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *k8sComputeProvider) InvokeWorker(ctx context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *k8sComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ InvocationContext, config ComputeProviderConfig, count int32) error {
+func (p *k8sComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ RequestContext, config ComputeProviderConfig, count int32) error {
 	client, namespace, deployment, err := p.buildClientAndParams(config)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/k8s.go
+++ b/wci/workflow/compute_provider/k8s.go
@@ -36,7 +36,7 @@ func (p *k8sComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, config ComputeProviderConfig) error {
+func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	client, namespace, deployment, err := p.buildClientAndParams(config)
 	if err != nil {
 		return err
@@ -48,11 +48,11 @@ func (p *k8sComputeProvider) ValidateConfig(ctx context.Context, config ComputeP
 	return nil
 }
 
-func (p *k8sComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+func (p *k8sComputeProvider) InvokeWorker(ctx context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *k8sComputeProvider) UpdateWorkerSetSize(ctx context.Context, config ComputeProviderConfig, count int32) error {
+func (p *k8sComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ InvocationContext, config ComputeProviderConfig, count int32) error {
 	client, namespace, deployment, err := p.buildClientAndParams(config)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -17,14 +17,13 @@ type (
 	ComputeProviderConfig      = map[string]any
 	ComputeProviderConstructor func(context.Context, *dynamicconfig.Collection) (ComputeProvider, error)
 
-	// InvocationContext carries the WCI identity a compute provider may need to
-	// act on behalf of a specific namespace/deployment (e.g. resolving the GCP
-	// impersonation chain). It is populated by the activity layer from the
-	// request's RequestContext.
-	InvocationContext struct {
-		Namespace      string
-		DeploymentName string
-		BuildID        string
+	// RequestContext carries the namespace/deployment identity tags shared by every
+	// activity request type. Compute providers receive it to act on behalf of a
+	// specific namespace/deployment (e.g. resolving the GCP impersonation chain).
+	RequestContext struct {
+		NamespaceName     string `json:"namespace_name"`
+		DeploymentName    string `json:"deployment_name"`
+		DeploymentBuildID string `json:"deployment_build_id"`
 	}
 
 	ComputeProvider interface {
@@ -36,17 +35,17 @@ type (
 		// ValidateConfig checks the provided configuration for correctness. This might involved
 		// invoking cloud provider functions to check permissions as well. If any issues are found
 		// returns an error with a description
-		ValidateConfig(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error
+		ValidateConfig(ctx context.Context, rc RequestContext, config ComputeProviderConfig) error
 
 		// InvokeWorker starts a new worker instance when using the LaunchStrategy 'invoke'. any
 		// error is returned if the invocation failed, but not if the invoked work dies before connecting
 		// to Temporal. Returns an error for other launch strategies.
-		InvokeWorker(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error
+		InvokeWorker(ctx context.Context, rc RequestContext, config ComputeProviderConfig) error
 
 		// UpdateWorkerSetSize updates the size of the managed worker set to the provided 'size' when using
 		// the LaunchStrategy 'worker-set'. An error is returned when the size update fails, but might not
 		// if the triggered instance starts/stops fail. Always returns an error for other launch stratgies.
-		UpdateWorkerSetSize(ctx context.Context, ic InvocationContext, config ComputeProviderConfig, size int32) error
+		UpdateWorkerSetSize(ctx context.Context, rc RequestContext, config ComputeProviderConfig, size int32) error
 	}
 )
 

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -17,6 +17,16 @@ type (
 	ComputeProviderConfig      = map[string]any
 	ComputeProviderConstructor func(context.Context, *dynamicconfig.Collection) (ComputeProvider, error)
 
+	// InvocationContext carries the WCI identity a compute provider may need to
+	// act on behalf of a specific namespace/deployment (e.g. resolving the GCP
+	// impersonation chain). It is populated by the activity layer from the
+	// request's RequestContext.
+	InvocationContext struct {
+		Namespace      string
+		DeploymentName string
+		BuildID        string
+	}
+
 	ComputeProvider interface {
 		// LaunchStrategy returns the LaunchStrategy used by this ComputeProvider, i.e. whether it is
 		// starts instances that end by themselves (invoke) or manages a managed
@@ -26,17 +36,17 @@ type (
 		// ValidateConfig checks the provided configuration for correctness. This might involved
 		// invoking cloud provider functions to check permissions as well. If any issues are found
 		// returns an error with a description
-		ValidateConfig(ctx context.Context, config ComputeProviderConfig) error
+		ValidateConfig(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error
 
 		// InvokeWorker starts a new worker instance when using the LaunchStrategy 'invoke'. any
 		// error is returned if the invocation failed, but not if the invoked work dies before connecting
 		// to Temporal. Returns an error for other launch strategies.
-		InvokeWorker(ctx context.Context, config ComputeProviderConfig) error
+		InvokeWorker(ctx context.Context, ic InvocationContext, config ComputeProviderConfig) error
 
 		// UpdateWorkerSetSize updates the size of the managed worker set to the provided 'size' when using
 		// the LaunchStrategy 'worker-set'. An error is returned when the size update fails, but might not
 		// if the triggered instance starts/stops fail. Always returns an error for other launch stratgies.
-		UpdateWorkerSetSize(ctx context.Context, config ComputeProviderConfig, size int32) error
+		UpdateWorkerSetSize(ctx context.Context, ic InvocationContext, config ComputeProviderConfig, size int32) error
 	}
 )
 

--- a/wci/workflow/compute_provider/subprocess.go
+++ b/wci/workflow/compute_provider/subprocess.go
@@ -35,7 +35,7 @@ func (p *subprocessComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *subprocessComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *subprocessComputeProvider) ValidateConfig(_ context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	command, ok := config[configSubprocessCommand].(string)
 	if !ok || strings.TrimSpace(command) == "" {
 		return fmt.Errorf("command not found in config")
@@ -52,7 +52,7 @@ func (p *subprocessComputeProvider) ValidateConfig(_ context.Context, _ Invocati
 	return nil
 }
 
-func (p *subprocessComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *subprocessComputeProvider) InvokeWorker(_ context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	command, ok := config[configSubprocessCommand].(string)
 	if !ok || strings.TrimSpace(command) == "" {
 		return fmt.Errorf("command not found in config")
@@ -82,7 +82,7 @@ func (p *subprocessComputeProvider) InvokeWorker(_ context.Context, _ Invocation
 	return nil
 }
 
-func (p *subprocessComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
+func (p *subprocessComputeProvider) UpdateWorkerSetSize(_ context.Context, _ RequestContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/subprocess.go
+++ b/wci/workflow/compute_provider/subprocess.go
@@ -35,7 +35,7 @@ func (p *subprocessComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *subprocessComputeProvider) ValidateConfig(ctx context.Context, config ComputeProviderConfig) error {
+func (p *subprocessComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	command, ok := config[configSubprocessCommand].(string)
 	if !ok || strings.TrimSpace(command) == "" {
 		return fmt.Errorf("command not found in config")
@@ -52,7 +52,7 @@ func (p *subprocessComputeProvider) ValidateConfig(ctx context.Context, config C
 	return nil
 }
 
-func (p *subprocessComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+func (p *subprocessComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	command, ok := config[configSubprocessCommand].(string)
 	if !ok || strings.TrimSpace(command) == "" {
 		return fmt.Errorf("command not found in config")
@@ -82,7 +82,7 @@ func (p *subprocessComputeProvider) InvokeWorker(ctx context.Context, config Com
 	return nil
 }
 
-func (p *subprocessComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+func (p *subprocessComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -29,7 +29,7 @@ func (p *testInvokeComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *testInvokeComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *testInvokeComputeProvider) ValidateConfig(_ context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	if _, ok := config[configTestInvokeIllegalField].(string); ok {
 		return fmt.Errorf("illegal_field found in config")
 	}
@@ -37,11 +37,11 @@ func (p *testInvokeComputeProvider) ValidateConfig(_ context.Context, _ Invocati
 	return nil
 }
 
-func (p *testInvokeComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
+func (p *testInvokeComputeProvider) InvokeWorker(_ context.Context, _ RequestContext, _ ComputeProviderConfig) error {
 	return nil
 }
 
-func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
+func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ RequestContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -29,7 +29,7 @@ func (p *testInvokeComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyInvoke
 }
 
-func (p *testInvokeComputeProvider) ValidateConfig(ctx context.Context, config ComputeProviderConfig) error {
+func (p *testInvokeComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	if _, ok := config[configTestInvokeIllegalField].(string); ok {
 		return fmt.Errorf("illegal_field found in config")
 	}
@@ -37,11 +37,11 @@ func (p *testInvokeComputeProvider) ValidateConfig(ctx context.Context, config C
 	return nil
 }
 
-func (p *testInvokeComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+func (p *testInvokeComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
 	return nil
 }
 
-func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+func (p *testInvokeComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
 	return errors.ErrUnsupported
 }
 

--- a/wci/workflow/compute_provider/test_worker_set.go
+++ b/wci/workflow/compute_provider/test_worker_set.go
@@ -27,7 +27,7 @@ func (p *testWorkerSetComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *testWorkerSetComputeProvider) ValidateConfig(ctx context.Context, config ComputeProviderConfig) error {
+func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
 	if _, ok := config[configTestWorkerSetIllegalField].(string); ok {
 		return fmt.Errorf("illegal_field found in config")
 	}
@@ -35,10 +35,10 @@ func (p *testWorkerSetComputeProvider) ValidateConfig(ctx context.Context, confi
 	return nil
 }
 
-func (p *testWorkerSetComputeProvider) InvokeWorker(ctx context.Context, config ComputeProviderConfig) error {
+func (p *testWorkerSetComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ ComputeProviderConfig, _ int32) error {
+func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
 	return nil
 }

--- a/wci/workflow/compute_provider/test_worker_set.go
+++ b/wci/workflow/compute_provider/test_worker_set.go
@@ -27,7 +27,7 @@ func (p *testWorkerSetComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, _ InvocationContext, config ComputeProviderConfig) error {
+func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, _ RequestContext, config ComputeProviderConfig) error {
 	if _, ok := config[configTestWorkerSetIllegalField].(string); ok {
 		return fmt.Errorf("illegal_field found in config")
 	}
@@ -35,10 +35,10 @@ func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, _ Invoc
 	return nil
 }
 
-func (p *testWorkerSetComputeProvider) InvokeWorker(_ context.Context, _ InvocationContext, _ ComputeProviderConfig) error {
+func (p *testWorkerSetComputeProvider) InvokeWorker(_ context.Context, _ RequestContext, _ ComputeProviderConfig) error {
 	return errors.ErrUnsupported
 }
 
-func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ InvocationContext, _ ComputeProviderConfig, _ int32) error {
+func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ RequestContext, _ ComputeProviderConfig, _ int32) error {
 	return nil
 }

--- a/wci/workflow/validate_workflow.go
+++ b/wci/workflow/validate_workflow.go
@@ -33,7 +33,10 @@ func ValidateSpecWorkflow(ctx workflow.Context, args *iface.ValidateWorkerContro
 			RetryPolicy:         &temporal.RetryPolicy{MaximumAttempts: 1},
 		}),
 		activities.ValidateSpec,
-		&ValidateSpecRequest{Spec: &spec},
+		&ValidateSpecRequest{
+			RequestContext: RequestContext{NamespaceName: workflow.GetInfo(ctx).Namespace},
+			Spec:           &spec,
+		},
 	).Get(ctx, nil)
 	if err != nil {
 		var appErr *temporal.ApplicationError


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
The GCP Cloud Run compute provider needs the customer namespace to resolve the per-namespace IAM impersonation chain. This PR threads that identity through the `ComputeProvider` interface and makes the chain resolution pluggable.

### Changes                                                                                                                                                           
                                                                                                                                                                       
  - **`ComputeProvider` interface** now takes an `InvocationContext{Namespace, DeploymentName, BuildID}` instead of a bare config. The struct is owned by the`compute_provider` package and extends without further signature churn. All providers (AWS ECS/Lambda, GCP Cloud Run, k8s, subprocess, test fakes) updated.                                                                                                               
  - **Pluggable impersonation chain.** GCP Cloud Run resolves its impersonation delegates through a process-wide `ImpersonationChainProvider`, defaulting to `NoopImpersonationChainProvider` (which reproduces the prior behavior: random SA pick per hop). The real per-namespace resolver can be installed via `fx.Decorate` + `SetImpersonationChainProvider`, wired in `wci/fx.go`.
  - **Activity layer** builds the `InvocationContext` from each request's embedded `RequestContext` (`req.invocationContext()`).
  - **Validation:** `ValidateSpecWorkflow` (standalone dry-run path) was constructing its `ValidateSpecRequest` without a `RequestContext`, so `ValidateConfig` saw an empty namespace. It now populates it from `workflow.GetInfo(ctx).Namespace` (the workflow runs in the customer namespace). Without this, validation would resolve a different impersonation chain than the runtime `InvokeWorker`/`UpdateWorkerSetSize` path once a real resolver is installed.                                                                                       
                                                                                                                                                                       
  ### Compatibility / risk                                                                                                                                              
                                                                                                                                                                       
  - Default behavior is unchanged: the Noop provider preserves the existing random-per-hop delegate selection.                                                                                                                                 
  - The chain provider is a mutable package singleton set once at startup. Known tradeoff (tests mutate it with `t.Cleanup`, so they can't run `t.Parallel`);
                                                                                                                                                                       
## Why?
<!-- Tell your future self why have you made these changes -->
Support for GCP Cloud Run pre-release

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
