### PR TITLE
Move persistence store providers to worker DI

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	_ "time/tzdata" // embed tzdata as a fallback
 
-	"go.temporal.io/auto-scaled-workers/wci"
 	"github.com/urfave/cli/v2"
+	"go.temporal.io/auto-scaled-workers/wci"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"
@@ -16,6 +16,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership/ringpop"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"      // needed to load mysql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // needed to load postgresql plugin
@@ -118,6 +119,9 @@ func buildCLI() *cli.App {
 					config.Module,
 					temporal.FxLogAdapter,
 					ringpop.MembershipModule,
+					fx.Provide(persistenceClient.DataStoreFactoryProvider),
+					fx.Invoke(persistenceClient.DataStoreFactoryLifetimeHooks),
+					fx.Provide(newMetadataStore, newClusterMetadataStore),
 					fx.Provide(
 						func() primitives.ServiceName {
 							return wci.ServiceName
@@ -168,4 +172,12 @@ func buildCLI() *cli.App {
 		},
 	}
 	return app
+}
+
+func newMetadataStore(dataStoreFactory persistence.DataStoreFactory) (persistence.MetadataStore, error) {
+	return dataStoreFactory.NewMetadataStore()
+}
+
+func newClusterMetadataStore(dataStoreFactory persistence.DataStoreFactory) (persistence.ClusterMetadataStore, error) {
+	return dataStoreFactory.NewClusterMetadataStore()
 }

--- a/wci/fx.go
+++ b/wci/fx.go
@@ -38,14 +38,13 @@ var Module = fx.Options(
 
 	fx.Provide(persistenceClient.ClusterNameProvider),
 	fx.Provide(persistenceClient.HealthSignalAggregatorProvider),
-	fx.Provide(persistenceClient.DataStoreFactoryProvider),
 	fx.Provide(persistenceClient.EnableDataLossMetricsProvider),
-	fx.Invoke(persistenceClient.DataStoreFactoryLifetimeHooks),
 	fx.Provide(newMetadataManager, newClusterMetadataManager),
 
 	fx.Provide(resource.ClientFactoryProvider),
 	fx.Provide(namespace.NewDefaultReplicationResolverFactory),
 	fx.Provide(resource.NamespaceRegistryProvider),
+	fx.Provide(func() namespace.NamespaceStateChangedFn { return nsregistry.DefaultNamespaceStateChanged }),
 	nsregistry.RegistryLifetimeHooksModule,
 	cluster.MetadataLifetimeHooksModule,
 
@@ -87,7 +86,7 @@ func WorkerConfigProvider(config *Config) *worker.Config {
 }
 
 func newMetadataManager(
-	dataStoreFactory persistence.DataStoreFactory,
+	store persistence.MetadataStore,
 	serializer serialization.Serializer,
 	logger log.Logger,
 	clusterName persistenceClient.ClusterName,
@@ -95,11 +94,6 @@ func newMetadataManager(
 	healthSignals persistence.HealthSignalAggregator,
 	enableDataLossMetrics persistenceClient.EnableDataLossMetrics,
 ) (persistence.MetadataManager, error) {
-	store, err := dataStoreFactory.NewMetadataStore()
-	if err != nil {
-		return nil, err
-	}
-
 	result := persistence.NewMetadataManagerImpl(store, serializer, logger, string(clusterName))
 	// if f.systemRateLimiter != nil && f.namespaceRateLimiter != nil {
 	// 	result = persistence.NewMetadataPersistenceRateLimitedClient(result, f.systemRateLimiter, f.namespaceRateLimiter, f.shardRateLimiter, f.logger)
@@ -112,7 +106,7 @@ func newMetadataManager(
 }
 
 func newClusterMetadataManager(
-	dataStoreFactory persistence.DataStoreFactory,
+	store persistence.ClusterMetadataStore,
 	serializer serialization.Serializer,
 	logger log.Logger,
 	clusterName persistenceClient.ClusterName,
@@ -120,11 +114,6 @@ func newClusterMetadataManager(
 	healthSignals persistence.HealthSignalAggregator,
 	enableDataLossMetrics persistenceClient.EnableDataLossMetrics,
 ) (persistence.ClusterMetadataManager, error) {
-	store, err := dataStoreFactory.NewClusterMetadataStore()
-	if err != nil {
-		return nil, err
-	}
-
 	result := persistence.NewClusterMetadataManagerImpl(store, serializer, string(clusterName), logger)
 	// if f.systemRateLimiter != nil && f.namespaceRateLimiter != nil {
 	// 	result = persistence.NewClusterMetadataPersistenceRateLimitedClient(result, f.systemRateLimiter, f.namespaceRateLimiter, f.shardRateLimiter, f.logger)


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Move DataStoreFactoryProvider and the metadata/cluster-metadata store providers out of the wci Module and into the worker's fx graph, so newMetadataManager and newClusterMetadataManager now receive the stores directly instead of constructing them from the DataStoreFactory.

## Why?
To allow more configurability around the data store implementation, the WCI module now only depends on the specific data store parts it actually uses instead of the whole factory interface.