### PR TITLE
Update GCP mask to align with docs

### DIFF
--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -76,7 +76,7 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc
 			Name:    name,
 			Scaling: &runpb.WorkerPoolScaling{ManualInstanceCount: &count},
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling"}},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling.manualInstanceCount"}},
 	}); err != nil {
 		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
 	}


### PR DESCRIPTION
Updating the update mask for GCP cloudrun to align with https://docs.cloud.google.com/run/docs/configuring/workerpools/manual-scaling#rest-api

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Update the update mask for GCP CloudRun to be specific to the instance count, not scaling overvall.
<!-- Describe what has changed in this PR -->

## Why?
To explicitly align with the GCP docs as that was provided as guidance.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
