### PR TITLE
Add NexusEndpoint field to ComputeProviderSpec

### DIFF
--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -14,8 +14,9 @@ type (
 
 	// ComputeProviderSpec is a single provider type and its settings (used per task queue type or as default).
 	ComputeProviderSpec struct {
-		ProviderType ComputeProviderType `json:"provider_type,omitempty"`
-		Config       *commonpb.Payload   `json:"config,omitempty"`
+		ProviderType  ComputeProviderType `json:"provider_type,omitempty"`
+		Config        *commonpb.Payload   `json:"config,omitempty"`
+		NexusEndpoint string              `json:"nexus_endpoint,omitempty"`
 	}
 
 	ScalingAlgorithmType   string
@@ -210,7 +211,8 @@ func (c *ScalingGroupSpec) Clone() *ScalingGroupSpec {
 	cloned := &ScalingGroupSpec{
 		TaskTypes: slices.Clone(c.TaskTypes),
 		Compute: ComputeProviderSpec{
-			ProviderType: c.Compute.ProviderType,
+			ProviderType:  c.Compute.ProviderType,
+			NexusEndpoint: c.Compute.NexusEndpoint,
 		},
 	}
 

--- a/wci/workflow/iface/spec_update.go
+++ b/wci/workflow/iface/spec_update.go
@@ -28,6 +28,8 @@ func applyFieldMask(dst, src *ScalingGroupSpec, paths []string) error {
 			} else {
 				dst.Compute.Config = proto.Clone(src.Compute.Config).(*common.Payload)
 			}
+		case "provider.nexus_endpoint":
+			dst.Compute.NexusEndpoint = src.Compute.NexusEndpoint
 		case "scaler":
 			if src.Scaling == nil {
 				dst.Scaling = nil


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adding the missing nexus endpoint field to the config struct

## Why?
In preparation for adding support for Nexus-based providers, adding the endpoint field on the WCI end. This already exists in the API so this is just backfill.