### PR TITLE
COM-186: Migrate dynamic config from cell/global to namespace.

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -18,6 +18,7 @@ type (
 	}
 )
 
+// Namespace-scoped settings.
 var (
 	WorkerControllerEnabled = dynamicconfig.NewNamespaceBoolSetting(
 		"workercontroller.enabled",
@@ -34,6 +35,25 @@ var (
 		2,
 		`WorkerControllerInstanceWorkflowVersion controls what version of the logic should the manager workflows use.`,
 	)
+	WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.hook.min_signal_interval_no_sync_match",
+		500,
+		`WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds controls the batching interval of no-sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal. `,
+	)
+	WorkerControllerMinSignalIntervalSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
+		"workercontroller.hook.min_signal_interval_sync_match",
+		60_000, // 1 minute
+		`WorkerControllerMinSignalIntervalSyncMatchMilliseconds controls the batching interval of sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal.`,
+	)
+	WorkerControllerEnabledComputeProviders = dynamicconfig.NewNamespaceTypedSetting(
+		"workercontroller.compute_providers.enabled",
+		[]string(nil),
+		`WorkerControllerEnabledComputeProviders defines the list of compute providers enabled for use. Namespace-scoped: a namespace-level value overrides the cell-wide (global) value, and namespaces without an entry inherit the cell value.`,
+	)
+)
+
+// Global settings.
+var (
 	WorkerControllerAWSIntermediaryRoles = dynamicconfig.NewGlobalTypedSetting(
 		"workercontroller.compute_providers.aws.intermediary_roles",
 		[][]AWSIAMRoleRequest(nil),
@@ -44,11 +64,6 @@ var (
 		[][]GCPIAMServiceAccountRequest(nil),
 		`WorkerControllerGCPIntermediaryServiceAccounts defines the service account chaining to assume before assuming the per-provider role.`,
 	)
-	WorkerControllerEnabledComputeProviders = dynamicconfig.NewGlobalTypedSetting(
-		"workercontroller.compute_providers.enabled",
-		[]string(nil),
-		`WorkerControllerEnabledComputeProviders defines the list of compute providers enabled for use.`,
-	)
 	WorkerControllerEnabledScalingAlgorithms = dynamicconfig.NewGlobalTypedSetting(
 		"workercontroller.scaling_algorithms.enabled",
 		[]string(nil),
@@ -58,16 +73,6 @@ var (
 		"workercontroller.compute_providers.aws.require_role_and_external_id",
 		true,
 		`WorkerControllerAWSRequireRoleAndExternalID controls whether AWS compute providers require a role ARN and external ID. Defaults to true. Set to false to allow configurations without these fields and accepting the associated security risks.`,
-	)
-	WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
-		"workercontroller.hook.min_signal_interval_no_sync_match",
-		500,
-		`WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds controls the batching interval of no-sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal. `,
-	)
-	WorkerControllerMinSignalIntervalSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(
-		"workercontroller.hook.min_signal_interval_sync_match",
-		60_000, // 1 minute
-		`WorkerControllerMinSignalIntervalSyncMatchMilliseconds controls the batching interval of sync matches grouped by WCI in milliseconds (per namespace). Each batch triggers a signal.`,
 	)
 	WorkerControllerPeriodicValidationIntervalSeconds = dynamicconfig.NewGlobalIntSetting(
 		"workercontroller.periodic_validation_interval_s",

--- a/wci/client/config_test.go
+++ b/wci/client/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 )

--- a/wci/client/config_test.go
+++ b/wci/client/config_test.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+)
+
+// The signal-batching intervals are namespace-scoped so operators can tune the
+// hook's signal cadence per namespace. These tests pin that contract (key,
+// namespace precedence, default, and per-namespace override) so the settings
+// can't silently regress to global scope.
+
+func TestSignalIntervalSettings_KeyAndPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		setting dynamicconfig.NamespaceIntSetting
+		key     string
+		def     int
+	}{
+		{
+			name:    "no_sync_match",
+			setting: WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds,
+			key:     "workercontroller.hook.min_signal_interval_no_sync_match",
+			def:     500,
+		},
+		{
+			name:    "sync_match",
+			setting: WorkerControllerMinSignalIntervalSyncMatchMilliseconds,
+			key:     "workercontroller.hook.min_signal_interval_sync_match",
+			def:     60_000,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.key, tc.setting.Key().String())
+			require.Equal(t, dynamicconfig.PrecedenceNamespace, tc.setting.Precedence(),
+				"signal interval settings must be namespace-scoped")
+
+			// Default resolves from an empty (noop) collection.
+			def := tc.setting.Get(dynamicconfig.NewNoopCollection())("some-namespace")
+			require.Equal(t, tc.def, def)
+		})
+	}
+}
+
+func TestSignalIntervalSettings_PerNamespaceOverride(t *testing.T) {
+	const override = 1234
+	setting := WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds
+
+	client := dynamicconfig.StaticClient{setting.Key(): override}
+	coll := dynamicconfig.NewCollection(client, log.NewNoopLogger())
+
+	get := setting.Get(coll)
+	require.Equal(t, override, get("ns-a"))
+	require.Equal(t, override, get("ns-b"))
+}
+
+// EnabledComputeProviders is namespace-scoped so a namespace (e.g. a Cloud Run
+// namespace) can override the cell-wide default set in the cell's global DCO,
+// while namespaces without an entry (e.g. Lambda namespaces) inherit that cell
+// value. These tests pin that key, precedence, and fallback behavior.
+func TestEnabledComputeProviders_KeyAndPrecedence(t *testing.T) {
+	setting := WorkerControllerEnabledComputeProviders
+	require.Equal(t, "workercontroller.compute_providers.enabled", setting.Key().String())
+	require.Equal(t, dynamicconfig.PrecedenceNamespace, setting.Precedence(),
+		"compute providers must be namespace-scoped so namespaces can override the cell value")
+	require.Nil(t, setting.Get(dynamicconfig.NewNoopCollection())("any-ns"))
+}
+
+func TestEnabledComputeProviders_NamespaceOverridesCellDefault(t *testing.T) {
+	setting := WorkerControllerEnabledComputeProviders
+
+	// Cell-wide (unconstrained/global) value plus a namespace-constrained override,
+	// mirroring the cell DCO + Cloud Run namespace DCO layering.
+	client := dynamicconfig.StaticClient{
+		setting.Key(): []dynamicconfig.ConstrainedValue{
+			{Value: []string{"gcp-cloud-run"}, Constraints: dynamicconfig.Constraints{Namespace: "cloud-run-ns"}},
+			{Value: []string{"aws-lambda"}}, // no constraint => cell-wide default
+		},
+	}
+	coll := dynamicconfig.NewCollection(client, log.NewNoopLogger())
+	get := setting.Get(coll)
+
+	// Cloud Run namespace gets its override.
+	require.Equal(t, []string{"gcp-cloud-run"}, get("cloud-run-ns"))
+	// A Lambda namespace with no entry inherits the cell-wide value.
+	require.Equal(t, []string{"aws-lambda"}, get("lambda-ns"))
+}

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -158,7 +158,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 	defer cancel()
 
 	for key, entry := range req.Spec.ScalingGroupSpecs {
-		provider, err := computeprovider.GetComputeProvider(timeoutCtx, entry.Compute.ProviderType, a.dc)
+		provider, err := computeprovider.GetComputeProvider(timeoutCtx, entry.Compute.ProviderType, a.namespace.Name().String(), a.dc)
 		if err != nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
@@ -220,7 +220,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
 	for k, v := range req.ScalingGroupSpecs {
-		provider, err := computeprovider.GetComputeProvider(ctx, v.Compute.ProviderType, a.dc)
+		provider, err := computeprovider.GetComputeProvider(ctx, v.Compute.ProviderType, a.namespace.Name().String(), a.dc)
 		if err != nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
@@ -257,7 +257,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeInvokeWorker)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
-	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.dc)
+	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.namespace.Name().String(), a.dc)
 	if err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return err
@@ -295,7 +295,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeUpdateWorkerSetSize)
 	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
 
-	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.dc)
+	provider, err := computeprovider.GetComputeProvider(ctx, req.ComputeConfig.ProviderType, a.namespace.Name().String(), a.dc)
 	if err != nil {
 		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
 		return err

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -69,8 +69,8 @@ func RegisterComputeProvider(providerType iface.ComputeProviderType, ctor Comput
 	}
 }
 
-func GetComputeProvider(ctx context.Context, providerType iface.ComputeProviderType, dc *dynamicconfig.Collection) (ComputeProvider, error) {
-	enabledProviders := client.WorkerControllerEnabledComputeProviders.Get(dc)()
+func GetComputeProvider(ctx context.Context, providerType iface.ComputeProviderType, namespace string, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	enabledProviders := client.WorkerControllerEnabledComputeProviders.Get(dc)(namespace)
 	if enabledProviders != nil && !slices.Contains(enabledProviders, string(providerType)) {
 		return nil, nil
 	}

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -69,8 +69,8 @@ func RegisterComputeProvider(providerType iface.ComputeProviderType, ctor Comput
 	}
 }
 
-func GetComputeProvider(ctx context.Context, providerType iface.ComputeProviderType, namespace string, dc *dynamicconfig.Collection) (ComputeProvider, error) {
-	enabledProviders := client.WorkerControllerEnabledComputeProviders.Get(dc)(namespace)
+func GetComputeProvider(ctx context.Context, providerType iface.ComputeProviderType, namespaceName string, dc *dynamicconfig.Collection) (ComputeProvider, error) {
+	enabledProviders := client.WorkerControllerEnabledComputeProviders.Get(dc)(namespaceName)
 	if enabledProviders != nil && !slices.Contains(enabledProviders, string(providerType)) {
 		return nil, nil
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Moved the `workercontroller.compute_providers.enabled` config value from the global/cell priority to namespace priority. 

## Why?
<!-- Tell your future self why have you made these changes -->
This change allows to specify a global value and then override it at the namespace level.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
[COM-186](https://temporalio.atlassian.net/browse/COM-186)
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
* Added unit tests for `wci/client/config`
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
* No


[COM-186]: https://temporalio.atlassian.net/browse/COM-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ