### PR TITLE
use proto field path for Cloud Run scale update mask

### DIFF
--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -24,6 +24,21 @@ const (
 	configGCPCloudRunServiceAccount = "service_account"
 )
 
+// scalingManualInstanceCountMask restricts a WorkerPool update to just the manual
+// instance count. The path MUST be the proto field path (snake_case), not the
+// camelCase JSON name: Cloud Run silently ignores an unknown mask path and instead
+// applies the sparse WorkerPool wholesale, which resets the pool's runtime
+// serviceAccount to the project default compute SA and fails the deployer's actAs
+// check on it. Building via fieldmaskpb.New verifies the path against the proto, so
+// a bad path panics at package load rather than misbehaving silently at runtime.
+var scalingManualInstanceCountMask = func() *fieldmaskpb.FieldMask {
+	m, err := fieldmaskpb.New(&runpb.WorkerPool{}, "scaling.manual_instance_count")
+	if err != nil {
+		panic(fmt.Sprintf("invalid WorkerPool scaling field mask: %v", err))
+	}
+	return m
+}()
+
 type gcpCloudRunComputeProvider struct {
 	intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
 }
@@ -76,7 +91,7 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc
 			Name:    name,
 			Scaling: &runpb.WorkerPoolScaling{ManualInstanceCount: &count},
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling.manualInstanceCount"}},
+		UpdateMask: scalingManualInstanceCountMask,
 	}); err != nil {
 		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Use the proto field path `scaling.manual_instance_count` and build the mask via `fieldmaskpb.New` so an invalid path panics at load instead of misbehaving silently at runtime.

## Why?
<!-- Tell your future self why have you made these changes -->
`UpdateWorkerSetSize` sent the scale update mask as `scaling.manualInstanceCount` (camelCase JSON name). 

Cloud Run silently ignores an unknown mask path and  applies the sparse WorkerPool wholesale, resetting the pool's runtime  serviceAccount to the project default compute SA — which surfaces as an `iam.serviceAccounts.actAs` PermissionDenied on the deployer.                                                                                                          

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
