### PR TITLE
Update comments, fix race condition in tests

### DIFF
--- a/tests/integration/wci_test.go
+++ b/tests/integration/wci_test.go
@@ -563,7 +563,7 @@ func TestWCIVersionInactiveAfterInvoke(t *testing.T) {
 	require.NoError(t, err)
 
 	// Before any worker has registered a task queue against the version, its
-	// status should be created.
+	// status should have status CREATED.
 	descResp, err := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
 		&workflowservice.DescribeWorkerDeploymentVersionRequest{
 			Namespace:         namespace,
@@ -572,7 +572,7 @@ func TestWCIVersionInactiveAfterInvoke(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_CREATED,
 		descResp.GetWorkerDeploymentVersionInfo().GetStatus(),
-		"version should be CREATED before any task queue is registered")
+		"version should have status CREATED before any task queue is registered")
 
 	// WCI validates the spec then invokes workers to register task queues.
 	waitForInvoke(t, events, 60*time.Second, "register-task-queues invoke")
@@ -617,10 +617,9 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-
 	buildID1 := uuid.NewString()
 	buildID2 := uuid.NewString()
-	taskQueue := "inactive-tq" + deploymentName
+	taskQueue := "pinned-wflws-tq-" + deploymentName
 
 	version1 := &deploymentpb.WorkerDeploymentVersion{
 		DeploymentName: deploymentName,
@@ -691,8 +690,7 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 	drainEvents(t, events2)
 	w2.Stop()
 
-
-	// Submit a workflow pinned to both versions with no pollers present, creating a backlog.
+	// Submit a workflow pinned to version 1 and assert only version 1 receives events
 	wflow1, err := cli.ExecuteWorkflow(ctx,
 		sdkclient.StartWorkflowOptions{
 			TaskQueue: taskQueue,
@@ -706,6 +704,21 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 		}, scaleUpWorkflow)
 	require.NoError(t, err)
 
+	waitForInvoke(t, events1, 60*time.Second, "wflow1 scale-up version1 invoke")
+	w1 = startVersionedWorker(t, cli, taskQueue, deploymentName, buildID1)
+	t.Cleanup(w1.Stop)
+
+	var result string
+	getCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, wflow1.Get(getCtx, &result))
+	require.Equal(t, "foo", result)
+
+	// Ensure no more events in version 1 channel and also that no events were sent to version 2
+	requireNoEvents(t, events1)
+	requireNoEvents(t, events2)
+
+	// Run wflow 2 against version 2, ensuring invoke and no events to channel 1
 	wflow2, err := cli.ExecuteWorkflow(ctx,
 		sdkclient.StartWorkflowOptions{
 			TaskQueue: taskQueue,
@@ -719,20 +732,7 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 		}, scaleUpWorkflow)
 	require.NoError(t, err)
 
-	w1 = startVersionedWorker(t, cli, taskQueue, deploymentName, buildID1)
-	t.Cleanup(w1.Stop)
-
-	var result string
-	getCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	require.NoError(t, wflow1.Get(getCtx, &result))
-	require.Equal(t, "foo", result)
-
-	waitForInvoke(t, events1, 60*time.Second, "wflow1 scale-up v2 invoke")
-	requireNoEvents(t, events2)
-	drainEvents(t, events1)
-
-	// Run wflow 2
+	waitForInvoke(t, events2, 60*time.Second, "wflow2 scale-up version2 invoke")
 	w2 = startVersionedWorker(t, cli, taskQueue, deploymentName, buildID2)
 	t.Cleanup(w2.Stop)
 
@@ -740,8 +740,10 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 	defer cancel()
 	require.NoError(t, wflow2.Get(getCtx, &result))
 	require.Equal(t, "foo", result)
-	waitForInvoke(t, events2, 60*time.Second, "wflow1 scale-up v2 invoke")
+
+	// Ensure no more events in version 2 channel and also that no events were sent to version 2
 	requireNoEvents(t, events1)
+	requireNoEvents(t, events2)
 }
 
 func startVersionedWorker(
@@ -807,12 +809,12 @@ func waitForInvoke(
 
 func requireNoEvents(t *testing.T, events <-chan string) {
 	t.Helper()
-    select {
-    case action := <-events:
+	select {
+	case action := <-events:
 		t.Fatalf("expected no provider actions, but observed: %q", action)
-    default:
+	default:
 		// empty, as expected
-    }
+	}
 }
 
 func drainEvents(t *testing.T, events <-chan string) {

--- a/tests/notes
+++ b/tests/notes
@@ -1,0 +1,13 @@
+        	Error Trace:	/Users/justinschoeff/workplace/serverless/temporal-auto-scaled-workers/tests/integration/wci_test.go:469
+        	Error:      	Received unexpected error:
+        	            	update version compute config failed: update worker controller instance: activity error (type: UpdateWorkerControllerInstance, scheduledEventID: 18, startedEventID: 19, identity: temporal-system@Justins-MacBook-Pro.local@TestWCIUpdateNoChangesToComputeConfig-e4da0807-84c5-4693-949d-a88bdf0ebe92): no change found (type: FailedPrecondition, retryable: true)
+        	Test:       	TestWCIUpdateNoChangesToComputeConfig
+
+	_, err = cli.WorkflowService().UpdateWorkerDeploymentVersionComputeConfig(ctx,
+		&workflowservice.UpdateWorkerDeploymentVersionComputeConfigRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			RequestId:         uuid.NewString(),
+		})
+


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This updates the multiple worker deployment version integration test to
fix a race condition hit in github actions. Previously, the test would
create both workflows and then create a worker before waiting for the
invoke. However, WCI will only trigger the scale-up/invoke if there are
no pollers. So when running locally, WCI matching happens prior to
worker spin up, but in action fleet with slower hosts, it may run
slower.

This also cleans up some of the comments around CREATE status and some
descriptive strings being used in the tests.


## Why?
<!-- Tell your future self why have you made these changes -->
Race condition in test caused github action to faill sometimes. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
