### PR TITLE
Establish GCP global SA as impersonation base, not delegate.

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -64,6 +64,15 @@ var (
 		[][]GCPIAMServiceAccountRequest(nil),
 		`WorkerControllerGCPIntermediaryServiceAccounts defines the service account chaining to assume before assuming the per-provider role.`,
 	)
+	WorkerControllerGCPFirstDelegateAsBase = dynamicconfig.NewGlobalBoolSetting(
+		"workercontroller.compute_providers.gcp.first_delegate_as_base",
+		false,
+		`WorkerControllerGCPFirstDelegateAsBase controls how the first entry of the resolved GCP impersonation chain is treated. `+
+			`When true, the first delegate is the identity the pod's ambient Workload Identity can *directly* impersonate `+
+			`(roles/iam.workloadIdentityUser -> getAccessToken): it is used as the base credential of the chain, and the remaining `+
+			`delegates are passed as token-creator delegates to the target. When false, the entire chain is passed as token-creator `+
+			`delegates starting from the ambient ADC (default), which requires the ambient identity to hold implicitDelegation on the first delegate.`,
+	)
 	WorkerControllerEnabledScalingAlgorithms = dynamicconfig.NewGlobalTypedSetting(
 		"workercontroller.scaling_algorithms.enabled",
 		[]string(nil),

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -28,6 +28,10 @@ const (
 
 type gcpCloudRunComputeProvider struct {
 	intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+	// firstDelegateAsBase controls whether delegates[0] is consumed as the chain
+	// base (direct impersonation) or passed as an ordinary token-creator delegate.
+	// See client.WorkerControllerGCPFirstDelegateAsBase.
+	firstDelegateAsBase bool
 }
 
 // impersonateTokenSourceFn is the seam over impersonate.CredentialsTokenSource so
@@ -43,12 +47,15 @@ func init() {
 
 func NewGCPCloudRunComputeProvider(_ context.Context, dc *dynamicconfig.Collection) (ComputeProvider, error) {
 	var intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+	firstDelegateAsBase := false
 	if dc != nil {
 		intermediaryServiceAccounts = client.WorkerControllerGCPIntermediaryServiceAccounts.Get(dc)()
+		firstDelegateAsBase = client.WorkerControllerGCPFirstDelegateAsBase.Get(dc)()
 	}
 
 	return &gcpCloudRunComputeProvider{
 		intermediaryServiceAccounts: intermediaryServiceAccounts,
+		firstDelegateAsBase:         firstDelegateAsBase,
 	}, nil
 }
 
@@ -132,14 +139,17 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, r
 
 		scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
 
-		// delegates[0] is the pool's ambient identity can *directly*
-		// impersonate (workloadIdentityUser → getAccessToken).
-		// It must be the base of the chain, not a Delegates entry: the ambient SA
-		// holds no implicitDelegation through it. Remaining entries are genuine
-		// delegates to the customer target SA.
+		// When firstDelegateAsBase is set, delegates[0] is the identity the
+		// pool's ambient Workload Identity can *directly* impersonate
+		// (workloadIdentityUser → getAccessToken). It must be the base of the
+		// chain, not a Delegates entry: the ambient SA holds no implicitDelegation
+		// through it. Remaining entries are genuine token-creator delegates to the
+		// customer target SA. When unset, the whole chain is passed as delegates
+		// from the ambient ADC (requires implicitDelegation on delegates[0]).
+		// Controlled by client.WorkerControllerGCPFirstDelegateAsBase.
 		var baseOpts []option.ClientOption
 		chainDelegates := delegates
-		if len(chainDelegates) > 0 {
+		if p.firstDelegateAsBase && len(chainDelegates) > 0 {
 			baseTS, err := impersonateTokenSourceFn(ctx, impersonate.CredentialsConfig{
 				TargetPrincipal: chainDelegates[0],
 				Scopes:          scopes,

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -9,13 +9,14 @@ import (
 
 	run "cloud.google.com/go/run/apiv2"
 	runpb "cloud.google.com/go/run/apiv2/runpb"
-	"go.temporal.io/auto-scaled-workers/wci/client"
-	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
-	"go.temporal.io/server/common/dynamicconfig"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
 )
 
 const (

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -80,16 +80,28 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc
 	}
 	defer client.Close()
 
-	if _, err = client.UpdateWorkerPool(ctx, &runpb.UpdateWorkerPoolRequest{
+	if _, err = client.UpdateWorkerPool(ctx, buildUpdateWorkerPoolRequest(name, count)); err != nil {
+		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
+	}
+	return nil
+}
+
+// scalingInstanceCountMaskPath is the update-mask path for WorkerPoolScaling.manual_instance_count.
+// It MUST be the proto field name (snake_case): the Cloud Run client speaks gRPC, which transmits
+// FieldMask paths verbatim (no camelCase→snake_case conversion — that only happens on the JSON/REST
+// transport). A camelCase path fails to resolve server-side, yielding a silent no-op update.
+const scalingInstanceCountMaskPath = "scaling.manual_instance_count"
+
+// buildUpdateWorkerPoolRequest constructs the request that sets the worker pool's manual instance
+// count. Extracted so tests can assert the update mask resolves against the WorkerPool descriptor.
+func buildUpdateWorkerPoolRequest(name string, count int32) *runpb.UpdateWorkerPoolRequest {
+	return &runpb.UpdateWorkerPoolRequest{
 		WorkerPool: &runpb.WorkerPool{
 			Name:    name,
 			Scaling: &runpb.WorkerPoolScaling{ManualInstanceCount: &count},
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"scaling.manualInstanceCount"}},
-	}); err != nil {
-		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{scalingInstanceCountMaskPath}},
 	}
-	return nil
 }
 
 // buildClientAndParams creates a Cloud Run WorkerPoolsClient and constructs the fully-qualified worker pool name.

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -26,6 +27,13 @@ const (
 
 type gcpCloudRunComputeProvider struct {
 	intermediaryServiceAccounts [][]client.GCPIAMServiceAccountRequest
+}
+
+// impersonateTokenSourceFn is the seam over impersonate.CredentialsTokenSource so
+// tests can assert how the impersonation chain is constructed (base vs. delegates)
+// without real GCP auth.
+var impersonateTokenSourceFn = func(ctx context.Context, cfg impersonate.CredentialsConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+	return impersonate.CredentialsTokenSource(ctx, cfg, opts...)
 }
 
 func init() {
@@ -109,11 +117,32 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, r
 			return nil, "", fmt.Errorf("failed to resolve impersonation chain: %w", err)
 		}
 
-		ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
+
+		// delegates[0] is the pool's ambient identity can *directly*
+		// impersonate (workloadIdentityUser → getAccessToken).
+		// It must be the base of the chain, not a Delegates entry: the ambient SA
+		// holds no implicitDelegation through it. Remaining entries are genuine
+		// delegates to the customer target SA.
+		var baseOpts []option.ClientOption
+		chainDelegates := delegates
+		if len(chainDelegates) > 0 {
+			baseTS, err := impersonateTokenSourceFn(ctx, impersonate.CredentialsConfig{
+				TargetPrincipal: chainDelegates[0],
+				Scopes:          scopes,
+			})
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to impersonate global service account %q: %w", chainDelegates[0], err)
+			}
+			baseOpts = []option.ClientOption{option.WithTokenSource(baseTS)}
+			chainDelegates = chainDelegates[1:]
+		}
+
+		ts, err := impersonateTokenSourceFn(ctx, impersonate.CredentialsConfig{
 			TargetPrincipal: serviceAccount,
-			Scopes:          []string{"https://www.googleapis.com/auth/cloud-platform"},
-			Delegates:       delegates,
-		})
+			Scopes:          scopes,
+			Delegates:       chainDelegates,
+		}, baseOpts...)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to create impersonated credentials for %q: %w", serviceAccount, err)
 		}

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -10,6 +10,9 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	runpb "cloud.google.com/go/run/apiv2/runpb"
 
 	"go.temporal.io/auto-scaled-workers/wci/client"
 )
@@ -230,6 +233,30 @@ func TestNoopGCPImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
 	})
 	require.Error(t, err, "expected error for empty entry")
 	assert.ErrorContains(t, err, "empty")
+}
+
+// TestUpdateWorkerPoolMaskResolvesAgainstDescriptor is the regression guard for the
+// silent no-op scaling bug: the update mask must use the proto field name (snake_case)
+// so it resolves server-side over gRPC, which transmits FieldMask paths verbatim.
+//
+// FieldMask.IsValid performs the same lookup the Cloud Run server does — it walks each
+// path segment via the message descriptor's proto field names. A camelCase path
+// ("manualInstanceCount") does not resolve, so the field is dropped and instances never
+// scale.
+func TestUpdateWorkerPoolMaskResolvesAgainstDescriptor(t *testing.T) {
+	req := buildUpdateWorkerPoolRequest("projects/p/locations/r/workerPools/wp", 3)
+
+	// The production mask resolves against the real WorkerPool descriptor.
+	require.True(t, req.GetUpdateMask().IsValid(req.GetWorkerPool()),
+		"production update mask %v must resolve against the WorkerPool proto", req.GetUpdateMask().GetPaths())
+	assert.Equal(t, []string{"scaling.manual_instance_count"}, req.GetUpdateMask().GetPaths(),
+		"mask path must be the snake_case proto field name")
+
+	// Demonstrate the bug: the JSON/camelCase form does NOT resolve over the proto
+	// transport, which is why the previous mask produced a granted-but-no-op update.
+	buggy := &fieldmaskpb.FieldMask{Paths: []string{"scaling.manualInstanceCount"}}
+	assert.False(t, buggy.IsValid(&runpb.WorkerPool{}),
+		"camelCase mask path must NOT resolve — this is the no-op scaling bug")
 }
 
 func TestNoopGCPImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -3,12 +3,116 @@ package computeprovider
 import (
 	"context"
 	"errors"
-	"reflect"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/auto-scaled-workers/wci/client"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
 )
+
+type impersonateCall struct {
+	cfg     impersonate.CredentialsConfig
+	optsLen int
+}
+
+// stubImpersonate swaps the package impersonation seam with a recorder that
+// returns a dummy token source, so tests can assert how the chain is built
+// (base credential vs. Delegates) without real GCP auth. Restores on cleanup.
+func stubImpersonate(t *testing.T) *[]impersonateCall {
+	t.Helper()
+	var calls []impersonateCall
+	orig := impersonateTokenSourceFn
+	impersonateTokenSourceFn = func(_ context.Context, cfg impersonate.CredentialsConfig, opts ...option.ClientOption) (oauth2.TokenSource, error) {
+		calls = append(calls, impersonateCall{cfg: cfg, optsLen: len(opts)})
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake"}), nil
+	}
+	t.Cleanup(func() { impersonateTokenSourceFn = orig })
+	return &calls
+}
+
+// TestGCPCloudRun_GlobalSAConsumedAsBaseNotDelegate asserts the delegates[0]
+// (pool serverless-global-sa) is established as the chain BASE via direct
+// impersonation — no base opts, empty Delegates — and only delegates[1:] reach
+// the target impersonation as Delegates, with the base token source threaded in.
+func TestGCPCloudRun_GlobalSAConsumedAsBaseNotDelegate(t *testing.T) {
+	setChainProviderForTest(t, &captureChainProvider{delegates: []string{"global@pool.iam.gserviceaccount.com", "acct@pool.iam.gserviceaccount.com"}})
+	calls := stubImpersonate(t)
+
+	p := &gcpCloudRunComputeProvider{}
+	// Return values discarded: the downstream Cloud Run client construction is
+	// irrelevant here — we assert only on the captured impersonation calls.
+	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	})
+
+	require.Len(t, *calls, 2, "expected base + target impersonation calls")
+	base, target := (*calls)[0], (*calls)[1]
+
+	assert.Equal(t, "global@pool.iam.gserviceaccount.com", base.cfg.TargetPrincipal, "base hop should target the global SA")
+	assert.Empty(t, base.cfg.Delegates, "base hop must be a direct impersonation (no Delegates)")
+	assert.Zero(t, base.optsLen, "base hop must use the ambient ADC (no base token source)")
+
+	assert.Equal(t, "cust@example.com", target.cfg.TargetPrincipal, "target hop should target the customer SA")
+	assert.Equal(t, []string{"acct@pool.iam.gserviceaccount.com"}, target.cfg.Delegates, "target hop Delegates should be delegates[1:]")
+	assert.Equal(t, 1, target.optsLen, "target hop must receive the base token source")
+}
+
+// TestGCPCloudRun_SingleElementChainBaseThenDirectTarget asserts the boundary
+// where the chain has exactly one entry (the global SA): it is consumed as the
+// base, leaving delegates[1:] as an empty slice, so the target hop impersonates
+// the customer directly *from the global SA base* — base opts present, empty
+// Delegates. Guards the chainDelegates[1:] slicing on a length-1 input.
+func TestGCPCloudRun_SingleElementChainBaseThenDirectTarget(t *testing.T) {
+	setChainProviderForTest(t, &captureChainProvider{delegates: []string{"global@pool.iam.gserviceaccount.com"}})
+	calls := stubImpersonate(t)
+
+	p := &gcpCloudRunComputeProvider{}
+	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	})
+
+	require.Len(t, *calls, 2, "expected base + target impersonation calls")
+	base, target := (*calls)[0], (*calls)[1]
+
+	assert.Equal(t, "global@pool.iam.gserviceaccount.com", base.cfg.TargetPrincipal, "base hop should directly impersonate the global SA")
+	assert.Empty(t, base.cfg.Delegates, "base hop must be a direct impersonation (no Delegates)")
+	assert.Zero(t, base.optsLen, "base hop must use the ambient ADC (no base token source)")
+
+	assert.Equal(t, "cust@example.com", target.cfg.TargetPrincipal, "target hop should target the customer SA")
+	assert.Empty(t, target.cfg.Delegates, "target hop must have empty Delegates when the chain has one entry")
+	assert.Equal(t, 1, target.optsLen, "target hop must still receive the global SA base token source")
+}
+
+// TestGCPCloudRun_EmptyChainDirectlyImpersonatesTarget asserts that when the
+// chain provider returns no delegates (e.g. namespace didn't parse), the target
+// is impersonated directly from the ambient ADC — a single call, no base opts.
+func TestGCPCloudRun_EmptyChainDirectlyImpersonatesTarget(t *testing.T) {
+	setChainProviderForTest(t, &captureChainProvider{delegates: nil})
+	calls := stubImpersonate(t)
+
+	p := &gcpCloudRunComputeProvider{}
+	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "no-dot-here"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	})
+
+	require.Len(t, *calls, 1, "expected a single direct impersonation call")
+	only := (*calls)[0]
+	assert.Equal(t, "cust@example.com", only.cfg.TargetPrincipal, "should impersonate the customer SA directly")
+	assert.Empty(t, only.cfg.Delegates, "expected no Delegates on empty chain")
+	assert.Zero(t, only.optsLen, "expected direct impersonation from ambient ADC (no base opts)")
+}
 
 type captureChainProvider struct {
 	capture   *ResolveChainInput
@@ -49,13 +153,8 @@ func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *tes
 		configGCPCloudRunWorkerPool:     "wp",
 		configGCPCloudRunServiceAccount: "cust@example.com",
 	})
-	if captured.Namespace != "my-ns" {
-		t.Errorf("namespace not threaded: got %q, want %q", captured.Namespace, "my-ns")
-	}
-	want := [][]string{{"sa-a", "sa-b"}, {"sa-c"}}
-	if !reflect.DeepEqual(captured.GlobalSACandidates, want) {
-		t.Errorf("candidates mismatch: got %v, want %v", captured.GlobalSACandidates, want)
-	}
+	assert.Equal(t, "my-ns", captured.Namespace, "namespace not threaded")
+	assert.Equal(t, [][]string{{"sa-a", "sa-b"}, {"sa-c"}}, captured.GlobalSACandidates, "candidates mismatch")
 }
 
 func TestGCPCloudRun_ChainProviderErrorWrapped(t *testing.T) {
@@ -67,15 +166,9 @@ func TestGCPCloudRun_ChainProviderErrorWrapped(t *testing.T) {
 		configGCPCloudRunWorkerPool:     "wp",
 		configGCPCloudRunServiceAccount: "cust@example.com",
 	})
-	if err == nil {
-		t.Fatal("expected wrapped chain-provider error")
-	}
-	if !strings.Contains(err.Error(), "boom") {
-		t.Errorf("expected wrapped error containing 'boom'; got: %v", err)
-	}
-	if !strings.Contains(err.Error(), "impersonation chain") {
-		t.Errorf("expected 'impersonation chain' in error; got: %v", err)
-	}
+	require.Error(t, err, "expected wrapped chain-provider error")
+	assert.ErrorContains(t, err, "boom")
+	assert.ErrorContains(t, err, "impersonation chain")
 }
 
 func TestGCPCloudRun_ChainProviderNotCalledWithoutCustomerSA(t *testing.T) {
@@ -91,9 +184,7 @@ func TestGCPCloudRun_ChainProviderNotCalledWithoutCustomerSA(t *testing.T) {
 		configGCPCloudRunWorkerPool: "wp",
 		// no service_account → no impersonation chain needed
 	})
-	if called {
-		t.Error("chain provider should not be called when customer service account is absent")
-	}
+	assert.False(t, called, "chain provider should not be called when customer service account is absent")
 }
 
 type chainProviderFunc func(context.Context, ResolveChainInput) ([]string, error)
@@ -104,77 +195,50 @@ func (f chainProviderFunc) ResolveChain(ctx context.Context, input ResolveChainI
 
 func TestNoopGCPImpersonationChainProvider_Empty(t *testing.T) {
 	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{})
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if len(delegates) != 0 {
-		t.Errorf("expected empty Delegates, got: %v", delegates)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, delegates, "expected empty Delegates")
 }
 
 func TestNoopGCPImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
 	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"sa-a"}},
 	})
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if !reflect.DeepEqual(delegates, []string{"sa-a"}) {
-		t.Errorf("expected [sa-a], got: %v", delegates)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sa-a"}, delegates)
 }
 
 func TestNoopGCPImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
 	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"hop-1"}, {"hop-2"}, {"hop-3"}},
 	})
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if !reflect.DeepEqual(delegates, []string{"hop-1", "hop-2", "hop-3"}) {
-		t.Errorf("expected ordered hops, got: %v", delegates)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []string{"hop-1", "hop-2", "hop-3"}, delegates, "expected ordered hops")
 }
 
 func TestNoopGCPImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
 	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"a"}, {}, {"b"}},
 	})
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-	if !reflect.DeepEqual(delegates, []string{"a", "b"}) {
-		t.Errorf("expected empty step skipped, got: %v", delegates)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, delegates, "expected empty step skipped")
 }
 
 func TestNoopGCPImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
 	_, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{""}},
 	})
-	if err == nil {
-		t.Fatal("expected error for empty entry")
-	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Errorf("error should mention 'empty'; got: %v", err)
-	}
+	require.Error(t, err, "expected error for empty entry")
+	assert.ErrorContains(t, err, "empty")
 }
 
 func TestNoopGCPImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {
 	candidates := []string{"a", "b", "c"}
-	valid := map[string]bool{"a": true, "b": true, "c": true}
 	for i := 0; i < 10; i++ {
 		delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
 			GlobalSACandidates: [][]string{candidates},
 		})
-		if err != nil {
-			t.Fatalf("iter %d: unexpected error: %v", i, err)
-		}
-		if len(delegates) != 1 {
-			t.Fatalf("iter %d: expected 1 delegate, got: %v", i, delegates)
-		}
-		if !valid[delegates[0]] {
-			t.Errorf("iter %d: pick %q not in candidate set", i, delegates[0])
-		}
+		require.NoErrorf(t, err, "iter %d", i)
+		require.Lenf(t, delegates, 1, "iter %d: expected 1 delegate", i)
+		assert.Containsf(t, candidates, delegates[0], "iter %d: pick not in candidate set", i)
 	}
 }

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.temporal.io/auto-scaled-workers/wci/client"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
+
+	"go.temporal.io/auto-scaled-workers/wci/client"
 )
 
 type impersonateCall struct {
@@ -44,7 +45,7 @@ func TestGCPCloudRun_GlobalSAConsumedAsBaseNotDelegate(t *testing.T) {
 	p := &gcpCloudRunComputeProvider{}
 	// Return values discarded: the downstream Cloud Run client construction is
 	// irrelevant here — we assert only on the captured impersonation calls.
-	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -73,7 +74,7 @@ func TestGCPCloudRun_SingleElementChainBaseThenDirectTarget(t *testing.T) {
 	calls := stubImpersonate(t)
 
 	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -100,7 +101,7 @@ func TestGCPCloudRun_EmptyChainDirectlyImpersonatesTarget(t *testing.T) {
 	calls := stubImpersonate(t)
 
 	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "no-dot-here"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "no-dot-here"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -147,7 +148,7 @@ func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *tes
 	// Discard the final return — we only care the chain provider was invoked with
 	// the expected input. The downstream Cloud Run client construction may or may
 	// not succeed depending on the test env's GCP auth state.
-	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -160,7 +161,7 @@ func TestGCPCloudRun_ChainProviderReceivesNamespaceAndFlattenedCandidates(t *tes
 func TestGCPCloudRun_ChainProviderErrorWrapped(t *testing.T) {
 	setChainProviderForTest(t, &captureChainProvider{err: errors.New("boom")})
 	p := &gcpCloudRunComputeProvider{}
-	_, _, err := p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
+	_, _, err := p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:        "p",
 		configGCPCloudRunRegion:         "r",
 		configGCPCloudRunWorkerPool:     "wp",
@@ -178,7 +179,7 @@ func TestGCPCloudRun_ChainProviderNotCalledWithoutCustomerSA(t *testing.T) {
 		return nil, nil
 	}))
 	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(context.Background(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
+	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
 		configGCPCloudRunProject:    "p",
 		configGCPCloudRunRegion:     "r",
 		configGCPCloudRunWorkerPool: "wp",
@@ -194,13 +195,13 @@ func (f chainProviderFunc) ResolveChain(ctx context.Context, input ResolveChainI
 }
 
 func TestNoopGCPImpersonationChainProvider_Empty(t *testing.T) {
-	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{})
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{})
 	require.NoError(t, err)
 	assert.Empty(t, delegates, "expected empty Delegates")
 }
 
 func TestNoopGCPImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T) {
-	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"sa-a"}},
 	})
 	require.NoError(t, err)
@@ -208,7 +209,7 @@ func TestNoopGCPImpersonationChainProvider_SingleHopSingleCandidate(t *testing.T
 }
 
 func TestNoopGCPImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) {
-	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"hop-1"}, {"hop-2"}, {"hop-3"}},
 	})
 	require.NoError(t, err)
@@ -216,7 +217,7 @@ func TestNoopGCPImpersonationChainProvider_MultiHopOrderPreserved(t *testing.T) 
 }
 
 func TestNoopGCPImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
-	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+	delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{"a"}, {}, {"b"}},
 	})
 	require.NoError(t, err)
@@ -224,7 +225,7 @@ func TestNoopGCPImpersonationChainProvider_EmptyStepSkipped(t *testing.T) {
 }
 
 func TestNoopGCPImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
-	_, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+	_, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{
 		GlobalSACandidates: [][]string{{""}},
 	})
 	require.Error(t, err, "expected error for empty entry")
@@ -234,7 +235,7 @@ func TestNoopGCPImpersonationChainProvider_EmptyEntryErrors(t *testing.T) {
 func TestNoopGCPImpersonationChainProvider_MultiCandidatePickFromSet(t *testing.T) {
 	candidates := []string{"a", "b", "c"}
 	for i := 0; i < 10; i++ {
-		delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(context.Background(), ResolveChainInput{
+		delegates, err := (NoopGCPImpersonationChainProvider{}).ResolveChain(t.Context(), ResolveChainInput{
 			GlobalSACandidates: [][]string{candidates},
 		})
 		require.NoErrorf(t, err, "iter %d", i)

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -36,85 +36,82 @@ func stubImpersonate(t *testing.T) *[]impersonateCall {
 	return &calls
 }
 
-// TestGCPCloudRun_GlobalSAConsumedAsBaseNotDelegate asserts the delegates[0]
-// (pool serverless-global-sa) is established as the chain BASE via direct
-// impersonation — no base opts, empty Delegates — and only delegates[1:] reach
-// the target impersonation as Delegates, with the base token source threaded in.
-func TestGCPCloudRun_GlobalSAConsumedAsBaseNotDelegate(t *testing.T) {
-	setChainProviderForTest(t, &captureChainProvider{delegates: []string{"global@pool.iam.gserviceaccount.com", "acct@pool.iam.gserviceaccount.com"}})
-	calls := stubImpersonate(t)
+// TestGCPCloudRun_ImpersonationMatrix exercises how buildClientAndParams
+// constructs the impersonation calls across the first-delegate-as-base flag and
+// the size of the resolved delegate chain (nil / zero / one / more-than-one).
+//
+// With the flag ON, delegates[0] is the chain base: it is directly impersonated
+// (its own call, ambient ADC, no Delegates) and delegates[1:] become the target
+// hop's token-creator Delegates, with the base token source threaded in as one
+// client option. With the flag OFF, the whole chain is passed as Delegates from
+// the ambient ADC in a single call. nil and zero-length chains are equivalent
+// (both len 0), so no base hop runs regardless of the flag.
+func TestGCPCloudRun_ImpersonationMatrix(t *testing.T) {
+	const target = "cust@example.com"
+	const g = "global@pool.iam.gserviceaccount.com"
+	const a = "acct@pool.iam.gserviceaccount.com"
 
-	p := &gcpCloudRunComputeProvider{}
-	// Return values discarded: the downstream Cloud Run client construction is
-	// irrelevant here — we assert only on the captured impersonation calls.
-	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
-		configGCPCloudRunProject:        "p",
-		configGCPCloudRunRegion:         "r",
-		configGCPCloudRunWorkerPool:     "wp",
-		configGCPCloudRunServiceAccount: "cust@example.com",
-	})
+	cases := []struct {
+		name        string
+		asBase      bool
+		delegates   []string
+		wantCalls   int
+		wantBase    string   // base hop target principal; "" when there is no base hop
+		wantDelegs  []string // Delegates on the final (target) impersonation call
+		wantBaseOpt bool     // whether the base token source is threaded into the target call
+	}{
+		// Flag ON: delegates[0] consumed as the chain base, delegates[1:] as delegates.
+		{"base/nil", true, nil, 1, "", nil, false},
+		{"base/zero", true, []string{}, 1, "", nil, false},
+		{"base/one", true, []string{g}, 2, g, nil, true},
+		{"base/many", true, []string{g, a}, 2, g, []string{a}, true},
+		// Flag OFF: whole chain passed as delegates from ambient ADC, no base hop.
+		{"nobase/nil", false, nil, 1, "", nil, false},
+		{"nobase/zero", false, []string{}, 1, "", nil, false},
+		{"nobase/one", false, []string{g}, 1, "", []string{g}, false},
+		{"nobase/many", false, []string{g, a}, 1, "", []string{g, a}, false},
+	}
 
-	require.Len(t, *calls, 2, "expected base + target impersonation calls")
-	base, target := (*calls)[0], (*calls)[1]
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setChainProviderForTest(t, &captureChainProvider{delegates: tc.delegates})
+			calls := stubImpersonate(t)
 
-	assert.Equal(t, "global@pool.iam.gserviceaccount.com", base.cfg.TargetPrincipal, "base hop should target the global SA")
-	assert.Empty(t, base.cfg.Delegates, "base hop must be a direct impersonation (no Delegates)")
-	assert.Zero(t, base.optsLen, "base hop must use the ambient ADC (no base token source)")
+			p := &gcpCloudRunComputeProvider{firstDelegateAsBase: tc.asBase}
+			// Return values discarded: we assert only on the captured impersonation calls.
+			_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
+				configGCPCloudRunProject:        "p",
+				configGCPCloudRunRegion:         "r",
+				configGCPCloudRunWorkerPool:     "wp",
+				configGCPCloudRunServiceAccount: target,
+			})
 
-	assert.Equal(t, "cust@example.com", target.cfg.TargetPrincipal, "target hop should target the customer SA")
-	assert.Equal(t, []string{"acct@pool.iam.gserviceaccount.com"}, target.cfg.Delegates, "target hop Delegates should be delegates[1:]")
-	assert.Equal(t, 1, target.optsLen, "target hop must receive the base token source")
-}
+			require.Len(t, *calls, tc.wantCalls, "impersonation call count")
 
-// TestGCPCloudRun_SingleElementChainBaseThenDirectTarget asserts the boundary
-// where the chain has exactly one entry (the global SA): it is consumed as the
-// base, leaving delegates[1:] as an empty slice, so the target hop impersonates
-// the customer directly *from the global SA base* — base opts present, empty
-// Delegates. Guards the chainDelegates[1:] slicing on a length-1 input.
-func TestGCPCloudRun_SingleElementChainBaseThenDirectTarget(t *testing.T) {
-	setChainProviderForTest(t, &captureChainProvider{delegates: []string{"global@pool.iam.gserviceaccount.com"}})
-	calls := stubImpersonate(t)
+			// The target (customer) impersonation is always the last call.
+			targetCall := (*calls)[len(*calls)-1]
+			assert.Equal(t, target, targetCall.cfg.TargetPrincipal, "final hop must target the customer SA")
+			if len(tc.wantDelegs) == 0 {
+				assert.Empty(t, targetCall.cfg.Delegates, "final hop Delegates should be empty")
+			} else {
+				assert.Equal(t, tc.wantDelegs, targetCall.cfg.Delegates, "final hop Delegates")
+			}
+			wantOpts := 0
+			if tc.wantBaseOpt {
+				wantOpts = 1
+			}
+			assert.Equal(t, wantOpts, targetCall.optsLen, "final hop opts (1 => base token source threaded in)")
 
-	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "myns.acct"}, ComputeProviderConfig{
-		configGCPCloudRunProject:        "p",
-		configGCPCloudRunRegion:         "r",
-		configGCPCloudRunWorkerPool:     "wp",
-		configGCPCloudRunServiceAccount: "cust@example.com",
-	})
-
-	require.Len(t, *calls, 2, "expected base + target impersonation calls")
-	base, target := (*calls)[0], (*calls)[1]
-
-	assert.Equal(t, "global@pool.iam.gserviceaccount.com", base.cfg.TargetPrincipal, "base hop should directly impersonate the global SA")
-	assert.Empty(t, base.cfg.Delegates, "base hop must be a direct impersonation (no Delegates)")
-	assert.Zero(t, base.optsLen, "base hop must use the ambient ADC (no base token source)")
-
-	assert.Equal(t, "cust@example.com", target.cfg.TargetPrincipal, "target hop should target the customer SA")
-	assert.Empty(t, target.cfg.Delegates, "target hop must have empty Delegates when the chain has one entry")
-	assert.Equal(t, 1, target.optsLen, "target hop must still receive the global SA base token source")
-}
-
-// TestGCPCloudRun_EmptyChainDirectlyImpersonatesTarget asserts that when the
-// chain provider returns no delegates (e.g. namespace didn't parse), the target
-// is impersonated directly from the ambient ADC — a single call, no base opts.
-func TestGCPCloudRun_EmptyChainDirectlyImpersonatesTarget(t *testing.T) {
-	setChainProviderForTest(t, &captureChainProvider{delegates: nil})
-	calls := stubImpersonate(t)
-
-	p := &gcpCloudRunComputeProvider{}
-	_, _, _ = p.buildClientAndParams(t.Context(), RequestContext{NamespaceName: "no-dot-here"}, ComputeProviderConfig{
-		configGCPCloudRunProject:        "p",
-		configGCPCloudRunRegion:         "r",
-		configGCPCloudRunWorkerPool:     "wp",
-		configGCPCloudRunServiceAccount: "cust@example.com",
-	})
-
-	require.Len(t, *calls, 1, "expected a single direct impersonation call")
-	only := (*calls)[0]
-	assert.Equal(t, "cust@example.com", only.cfg.TargetPrincipal, "should impersonate the customer SA directly")
-	assert.Empty(t, only.cfg.Delegates, "expected no Delegates on empty chain")
-	assert.Zero(t, only.optsLen, "expected direct impersonation from ambient ADC (no base opts)")
+			// A base hop only exists when the first-delegate-as-base flag consumed delegates[0].
+			if tc.wantBase != "" {
+				require.Len(t, *calls, 2, "expected a base hop before the target hop")
+				base := (*calls)[0]
+				assert.Equal(t, tc.wantBase, base.cfg.TargetPrincipal, "base hop must directly impersonate delegates[0]")
+				assert.Empty(t, base.cfg.Delegates, "base hop must be a direct impersonation (no Delegates)")
+				assert.Zero(t, base.optsLen, "base hop must use ambient ADC (no base token source)")
+			}
+		})
+	}
 }
 
 type captureChainProvider struct {

--- a/wci/workflow/compute_provider/gcp_cloudrun_test.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun_test.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 	"testing"
 
+	runpb "cloud.google.com/go/run/apiv2/runpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
-
-	runpb "cloud.google.com/go/run/apiv2/runpb"
 
 	"go.temporal.io/auto-scaled-workers/wci/client"
 )


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Impersonates `delegates[0]` directly as the chain base, then delegate to the customer target service account. 
* Adds tests via an impersonation seam.
* Refactors unit tests to use `assert`/`require`
* Fixed field mask used to update the instance count for Cloud Run worker pools.


## Why?
The Cloud Run provider flattened the whole chain into Delegates off the ambient ADC, which diverges from the established design. 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
* Unit tests
* Manual end-to-end testing.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
