### PR TITLE
Add WCI worker deployment routing and manager integration tests

### DIFF
--- a/tests/integration/env.go
+++ b/tests/integration/env.go
@@ -3,9 +3,19 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/tests/testcore"
+)
+
+// Drain worker deployment versions quickly so tests that clear a current/ramping
+// version can observe the DRAINING -> DRAINED transition without waiting on the
+// multi-minute production defaults.
+const (
+	testVersionDrainageRefreshInterval       = 1 * time.Second
+	testVersionDrainageVisibilityGracePeriod = 1 * time.Second
 )
 
 // createWCITestEnv starts an in-process Temporal server with the WCI worker component registered
@@ -17,5 +27,7 @@ func createWCITestEnv(t *testing.T) *testcore.TestEnv {
 		testcore.WithDedicatedCluster(),
 		testcore.WithWorkerService("WCI"),
 		testcore.WithDynamicConfig(client.WorkerControllerEnabled, true),
+		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusRefreshInterval, testVersionDrainageRefreshInterval),
+		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusVisibilityGracePeriod, testVersionDrainageVisibilityGracePeriod),
 	)
 }

--- a/tests/integration/wci_test.go
+++ b/tests/integration/wci_test.go
@@ -759,27 +759,18 @@ func TestWCISetCurrentVersionHappyPath(t *testing.T) {
 	namespace := env.Namespace().String()
 	deploymentName, buildID, version := setupPolledVersion(t, env)
 
-	// Get the current conflict token from the deployment.
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-
 	// Promote the version to current.
-	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
 		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        buildID,
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
 
 	// The routing config should now name this version as current.
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -814,18 +805,11 @@ func TestWCISetCurrentVersionToUnversioned(t *testing.T) {
 	deploymentName, _, version := setupPolledVersion(t, env)
 
 	// Promote the version to current first.
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-	setResp, err := cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
 		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        version.GetBuildId(),
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
@@ -836,13 +820,12 @@ func TestWCISetCurrentVersionToUnversioned(t *testing.T) {
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        "",
-			ConflictToken:  setResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
 
 	// Routing config should no longer name a current deployment version.
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -925,18 +908,11 @@ func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
 	}, 60*time.Second, 500*time.Millisecond, "task queue never registered against version A")
 
 	// Promote version A to current while it has active pollers.
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
 	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
 		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        buildA,
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
@@ -964,13 +940,6 @@ func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
 	// Version B is created but never polls A's backlogged task queue.
 	versionB := createUnpolledVersion(t, env, deploymentName)
 
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-
 	// Promoting version B must fail: it is missing A's backlogged task queue and
 	// ignore_missing_task_queues is false.
 	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
@@ -978,7 +947,6 @@ func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
 			Namespace:               namespace,
 			DeploymentName:          deploymentName,
 			BuildId:                 versionB.GetBuildId(),
-			ConflictToken:           descResp.GetConflictToken(),
 			Identity:                "test-identity",
 			IgnoreMissingTaskQueues: false,
 		})
@@ -990,25 +958,18 @@ func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
 	// Flip only ignore_missing_task_queues to true on the exact same backlogged
 	// state. The promotion that just failed must now succeed, proving the flag is
 	// what gates the guardrail.
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
 	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
 		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:               namespace,
 			DeploymentName:          deploymentName,
 			BuildId:                 versionB.GetBuildId(),
-			ConflictToken:           descResp.GetConflictToken(),
 			Identity:                "test-identity",
 			IgnoreMissingTaskQueues: true,
 		})
 	require.NoError(t, err,
 		"override with ignore_missing_task_queues=true should succeed on the same backlogged state")
 
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -1079,24 +1040,17 @@ func TestWCISetRampingVersionHappyPath(t *testing.T) {
 	namespace := env.Namespace().String()
 	deploymentName, _, versionB := setupCurrentPlusSecondVersion(t, env)
 
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-	_, err = cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
 		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        versionB.GetBuildId(),
 			Percentage:     20.0,
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
 
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -1133,19 +1087,12 @@ func TestWCISetRampingVersionClear(t *testing.T) {
 	deploymentName, _, versionB := setupCurrentPlusSecondVersion(t, env)
 
 	// Set version B as ramping first.
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-	setResp, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
 		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        versionB.GetBuildId(),
 			Percentage:     20.0,
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
@@ -1157,12 +1104,11 @@ func TestWCISetRampingVersionClear(t *testing.T) {
 			DeploymentName: deploymentName,
 			BuildId:        "",
 			Percentage:     0,
-			ConflictToken:  setResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)
 
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -1202,21 +1148,13 @@ func TestWCISetRampingVersionSameAsCurrent(t *testing.T) {
 	namespace := env.Namespace().String()
 	deploymentName, versionA, _ := setupCurrentPlusSecondVersion(t, env)
 
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-
 	// versionA is the current version; ramping to it must be rejected.
-	_, err = cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
 		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        versionA.GetBuildId(),
 			Percentage:     20.0,
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.Error(t, err)
@@ -1284,8 +1222,7 @@ func TestWCISetManagerHappyPath(t *testing.T) {
 			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
 				ManagerIdentity: "wci-controller-xyz",
 			},
-			ConflictToken: descResp.GetConflictToken(),
-			Identity:      "test-identity",
+			Identity: "test-identity",
 		})
 	require.NoError(t, err)
 
@@ -1318,21 +1255,14 @@ func TestWCISetManagerOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set an initial manager identity.
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-	setResp, err := cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+	_, err = cli.WorkflowService().SetWorkerDeploymentManager(ctx,
 		&workflowservice.SetWorkerDeploymentManagerRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
 				ManagerIdentity: "old-controller",
 			},
-			ConflictToken: descResp.GetConflictToken(),
-			Identity:      "test-identity",
+			Identity: "test-identity",
 		})
 	require.NoError(t, err)
 
@@ -1344,12 +1274,11 @@ func TestWCISetManagerOverride(t *testing.T) {
 			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
 				ManagerIdentity: "new-controller",
 			},
-			ConflictToken: setResp.GetConflictToken(),
-			Identity:      "test-identity",
+			Identity: "test-identity",
 		})
 	require.NoError(t, err)
 
-	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
 		&workflowservice.DescribeWorkerDeploymentRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
@@ -1428,21 +1357,14 @@ func TestWCIManagerIdentityEnforcedOnSetCurrent(t *testing.T) {
 	deploymentName, buildID, _ := setupPolledVersion(t, env)
 
 	// Claim ownership as "owner-a".
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
-	setResp, err := cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+	_, err := cli.WorkflowService().SetWorkerDeploymentManager(ctx,
 		&workflowservice.SetWorkerDeploymentManagerRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
 				ManagerIdentity: "owner-a",
 			},
-			ConflictToken: descResp.GetConflictToken(),
-			Identity:      "owner-a",
+			Identity: "owner-a",
 		})
 	require.NoError(t, err)
 
@@ -1452,7 +1374,6 @@ func TestWCIManagerIdentityEnforcedOnSetCurrent(t *testing.T) {
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        buildID,
-			ConflictToken:  setResp.GetConflictToken(),
 			Identity:       "intruder-b",
 		})
 	require.Error(t, err)
@@ -1601,18 +1522,11 @@ func setupCurrentPlusSecondVersion(
 
 	versionA := createUnpolledVersion(t, env, deploymentName)
 
-	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
-		&workflowservice.DescribeWorkerDeploymentRequest{
-			Namespace:      namespace,
-			DeploymentName: deploymentName,
-		})
-	require.NoError(t, err)
 	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
 		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
 			Namespace:      namespace,
 			DeploymentName: deploymentName,
 			BuildId:        versionA.GetBuildId(),
-			ConflictToken:  descResp.GetConflictToken(),
 			Identity:       "test-identity",
 		})
 	require.NoError(t, err)

--- a/tests/integration/wci_test.go
+++ b/tests/integration/wci_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/tests/testcore"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -744,6 +745,880 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 	// Ensure no more events in version 2 channel and also that no events were sent to version 2
 	requireNoEvents(t, events1)
 	requireNoEvents(t, events2)
+}
+
+// SetWorkerDeploymentCurrentVersion promotes a version that has
+// active pollers on at least one task queue to current. Verifies the routing
+// config reflects the new current version and that the version's
+// current_since_time is set.
+func TestWCISetCurrentVersionHappyPath(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, buildID, version := setupPolledVersion(t, env)
+
+	// Get the current conflict token from the deployment.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+
+	// Promote the version to current.
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        buildID,
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// The routing config should now name this version as current.
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	current := descResp.GetWorkerDeploymentInfo().GetRoutingConfig().GetCurrentDeploymentVersion()
+	require.NotNil(t, current, "expected a current deployment version to be set")
+	require.Equal(t, buildID, current.GetBuildId(),
+		"current version build_id should match the promoted version")
+
+	// The version itself should report a current_since_time.
+	verResp, err := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+		&workflowservice.DescribeWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+		})
+	require.NoError(t, err)
+	require.NotNil(t, verResp.GetWorkerDeploymentVersionInfo().GetCurrentSinceTime(),
+		"promoted version should have current_since_time set")
+}
+
+// SetWorkerDeploymentCurrentVersion with an empty build_id routes
+// traffic back to unversioned workers. Verifies the routing config clears the
+// current deployment version and that the previously current version's status
+// transitions away from CURRENT.
+func TestWCISetCurrentVersionToUnversioned(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, _, version := setupPolledVersion(t, env)
+
+	// Promote the version to current first.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	setResp, err := cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        version.GetBuildId(),
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Now clear the current version by passing an empty build_id (unversioned).
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        "",
+			ConflictToken:  setResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Routing config should no longer name a current deployment version.
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	require.Nil(t, descResp.GetWorkerDeploymentInfo().GetRoutingConfig().GetCurrentDeploymentVersion(),
+		"current deployment version should be cleared after setting unversioned")
+
+	// The previously current version drains: once the drainage check finds no
+	// running pinned workflows on it, it reaches DRAINED (which is only reachable
+	// via DRAINING, so this also confirms it left CURRENT).
+	require.Eventually(t, func() bool {
+		verResp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: version,
+			})
+		if derr != nil {
+			return false
+		}
+		info := verResp.GetWorkerDeploymentVersionInfo()
+		return info.GetStatus() == enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED &&
+			info.GetDrainageInfo().GetStatus() == enumspb.VERSION_DRAINAGE_STATUS_DRAINED
+	}, 30*time.Second, 500*time.Millisecond, "previously current version never reached DRAINED")
+}
+
+// Verifies the missing-task-queue guardrail on SetWorkerDeploymentCurrentVersion
+// and its ignore_missing_task_queues override. Version A is current on a
+// backlogged task queue that version B has never polled, then B is promoted:
+//   - with ignore_missing_task_queues=false the promotion is rejected
+//     (FailedPrecondition);
+//   - with ignore_missing_task_queues=true it succeeds.
+func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildA := uuid.NewString()
+	taskQueue := "missingtq-tq-" + deploymentName
+	versionA := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        buildA,
+	}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetInvokeObserver(buildA, spy))
+	events := spy.events
+
+	// Deployment + version A, with a worker so A registers the task queue.
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+	_, err = cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: versionA,
+			Identity:          "test-identity",
+			ComputeConfig:     testComputeConfig(),
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	waitForInvoke(t, events, 60*time.Second, "register-task-queues invoke")
+	w1 := startVersionedWorker(t, cli, taskQueue, deploymentName, buildA)
+	require.Eventually(t, func() bool {
+		resp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: versionA,
+			})
+		return derr == nil &&
+			len(resp.GetWorkerDeploymentVersionInfo().GetTaskQueueInfos()) > 0
+	}, 60*time.Second, 500*time.Millisecond, "task queue never registered against version A")
+
+	// Promote version A to current while it has active pollers.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        buildA,
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Drop A's poller and enqueue a pinned workflow so the task queue keeps a
+	// backlog with no one to drain it.
+	w1.Stop()
+	drainEvents(t, events)
+	_, err = cli.ExecuteWorkflow(ctx,
+		sdkclient.StartWorkflowOptions{
+			TaskQueue: taskQueue,
+			ID:        "missingtq-backlog-" + uuid.NewString(),
+			VersioningOverride: &sdkclient.PinnedVersioningOverride{
+				Version: worker.WorkerDeploymentVersion{
+					DeploymentName: deploymentName,
+					BuildID:        buildA,
+				},
+			},
+		}, scaleUpWorkflow)
+	require.NoError(t, err)
+	// The backlog with no poller drives WCI to fire a scale-up invoke; observing
+	// it confirms the task queue has a backlog before we attempt the promotion.
+	waitForInvoke(t, events, 60*time.Second, "scale-up invoke (backlog present)")
+
+	// Version B is created but never polls A's backlogged task queue.
+	versionB := createUnpolledVersion(t, env, deploymentName)
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+
+	// Promoting version B must fail: it is missing A's backlogged task queue and
+	// ignore_missing_task_queues is false.
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:               namespace,
+			DeploymentName:          deploymentName,
+			BuildId:                 versionB.GetBuildId(),
+			ConflictToken:           descResp.GetConflictToken(),
+			Identity:                "test-identity",
+			IgnoreMissingTaskQueues: false,
+		})
+	require.Error(t, err)
+	var failedPre *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPre,
+		"promoting a version missing backlogged task queues should return FailedPrecondition, got: %v", err)
+
+	// Flip only ignore_missing_task_queues to true on the exact same backlogged
+	// state. The promotion that just failed must now succeed, proving the flag is
+	// what gates the guardrail.
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:               namespace,
+			DeploymentName:          deploymentName,
+			BuildId:                 versionB.GetBuildId(),
+			ConflictToken:           descResp.GetConflictToken(),
+			Identity:                "test-identity",
+			IgnoreMissingTaskQueues: true,
+		})
+	require.NoError(t, err,
+		"override with ignore_missing_task_queues=true should succeed on the same backlogged state")
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	current := descResp.GetWorkerDeploymentInfo().GetRoutingConfig().GetCurrentDeploymentVersion()
+	require.NotNil(t, current, "expected a current deployment version after the override")
+	require.Equal(t, versionB.GetBuildId(), current.GetBuildId(),
+		"version B should have been promoted to current after the override")
+}
+
+// SetWorkerDeploymentCurrentVersion rejects a mutation carrying a stale conflict
+// token: capture a token, advance the routing revision with a successful
+// SetCurrent, then replay the stale token and expect a FailedPrecondition.
+func TestWCISetCurrentVersionStaleConflictToken(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, buildID, _ := setupPolledVersion(t, env)
+
+	// Capture the initial conflict token.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	staleToken := descResp.GetConflictToken()
+
+	// Advance the routing revision by promoting the version to current. This
+	// invalidates staleToken.
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        buildID,
+			ConflictToken:  staleToken,
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Replay the stale token against a different target (unversioned). This is
+	// not a no-op, so it reaches the conflict-token check and must be rejected.
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        "",
+			ConflictToken:  staleToken,
+			Identity:       "test-identity",
+		})
+	require.Error(t, err)
+	var failedPre *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPre,
+		"a stale conflict token should return FailedPrecondition, got: %v", err)
+}
+
+// SetWorkerDeploymentRampingVersion sets a version as the ramping version at a
+// given percentage. Verifies the routing config reflects the ramping version
+// and percentage, and that the version's status becomes RAMPING.
+func TestWCISetRampingVersionHappyPath(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, _, versionB := setupCurrentPlusSecondVersion(t, env)
+
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	_, err = cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        versionB.GetBuildId(),
+			Percentage:     20.0,
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	rc := descResp.GetWorkerDeploymentInfo().GetRoutingConfig()
+	ramping := rc.GetRampingDeploymentVersion()
+	require.NotNil(t, ramping, "expected a ramping deployment version to be set")
+	require.Equal(t, versionB.GetBuildId(), ramping.GetBuildId(),
+		"ramping version build_id should match the requested version")
+	require.Equal(t, float32(20.0), rc.GetRampingVersionPercentage(),
+		"ramping version percentage should be 20")
+
+	require.Eventually(t, func() bool {
+		verResp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: versionB,
+			})
+		return derr == nil &&
+			verResp.GetWorkerDeploymentVersionInfo().GetStatus() == enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING
+	}, 30*time.Second, 500*time.Millisecond, "version never reached RAMPING status")
+}
+
+// SetWorkerDeploymentRampingVersion with an empty build_id clears the ramping
+// version entirely. Verifies the routing config's ramping version is cleared
+// and percentage reset to 0, and that the previously ramping version drains.
+func TestWCISetRampingVersionClear(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, _, versionB := setupCurrentPlusSecondVersion(t, env)
+
+	// Set version B as ramping first.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	setResp, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        versionB.GetBuildId(),
+			Percentage:     20.0,
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Clear the ramping version with an empty build_id and 0 percentage.
+	_, err = cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        "",
+			Percentage:     0,
+			ConflictToken:  setResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	rc := descResp.GetWorkerDeploymentInfo().GetRoutingConfig()
+	require.Nil(t, rc.GetRampingDeploymentVersion(),
+		"ramping deployment version should be cleared")
+	require.Equal(t, float32(0), rc.GetRampingVersionPercentage(),
+		"ramping version percentage should be reset to 0")
+
+	// The previously ramping version drains: once the drainage check finds no
+	// running pinned workflows on it, it reaches DRAINED (only reachable via
+	// DRAINING, so this also confirms the ramp was cleared).
+	require.Eventually(t, func() bool {
+		verResp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: versionB,
+			})
+		if derr != nil {
+			return false
+		}
+		info := verResp.GetWorkerDeploymentVersionInfo()
+		return info.GetStatus() == enumspb.WORKER_DEPLOYMENT_VERSION_STATUS_DRAINED &&
+			info.GetDrainageInfo().GetStatus() == enumspb.VERSION_DRAINAGE_STATUS_DRAINED
+	}, 30*time.Second, 500*time.Millisecond, "version never reached DRAINED")
+}
+
+// SetWorkerDeploymentRampingVersion rejects setting the ramping version to the
+// version that is already current.
+func TestWCISetRampingVersionSameAsCurrent(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, versionA, _ := setupCurrentPlusSecondVersion(t, env)
+
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+
+	// versionA is the current version; ramping to it must be rejected.
+	_, err = cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+		&workflowservice.SetWorkerDeploymentRampingVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        versionA.GetBuildId(),
+			Percentage:     20.0,
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.Error(t, err)
+	var failedPre *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPre,
+		"ramping to the current version should return FailedPrecondition, got: %v", err)
+}
+
+// SetWorkerDeploymentRampingVersion rejects ramp percentages outside [0, 100].
+func TestWCISetRampingVersionInvalidPercentage(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, _, versionB := setupCurrentPlusSecondVersion(t, env)
+
+	for _, pct := range []float32{150.0, -5.0} {
+		_, err := cli.WorkflowService().SetWorkerDeploymentRampingVersion(ctx,
+			&workflowservice.SetWorkerDeploymentRampingVersionRequest{
+				Namespace:      namespace,
+				DeploymentName: deploymentName,
+				BuildId:        versionB.GetBuildId(),
+				Percentage:     pct,
+				Identity:       "test-identity",
+			})
+		require.Error(t, err, "percentage %v should be rejected", pct)
+		var invalidArg *serviceerror.InvalidArgument
+		require.ErrorAs(t, err, &invalidArg,
+			"percentage %v should return InvalidArgument, got: %v", pct, err)
+	}
+}
+
+// SetWorkerDeploymentManager sets the manager identity on a deployment that has
+// none, and the value is persisted.
+func TestWCISetManagerHappyPath(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	require.Empty(t, descResp.GetWorkerDeploymentInfo().GetManagerIdentity(),
+		"deployment should start with no manager identity")
+
+	_, err = cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "wci-controller-xyz",
+			},
+			ConflictToken: descResp.GetConflictToken(),
+			Identity:      "test-identity",
+		})
+	require.NoError(t, err)
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	require.Equal(t, "wci-controller-xyz",
+		descResp.GetWorkerDeploymentInfo().GetManagerIdentity(),
+		"manager identity should be persisted on the deployment")
+}
+
+// SetWorkerDeploymentManager replaces an existing manager identity.
+func TestWCISetManagerOverride(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	// Set an initial manager identity.
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	setResp, err := cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "old-controller",
+			},
+			ConflictToken: descResp.GetConflictToken(),
+			Identity:      "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Replace it with a new value.
+	_, err = cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "new-controller",
+			},
+			ConflictToken: setResp.GetConflictToken(),
+			Identity:      "test-identity",
+		})
+	require.NoError(t, err)
+
+	descResp, err = cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	require.Equal(t, "new-controller",
+		descResp.GetWorkerDeploymentInfo().GetManagerIdentity(),
+		"manager identity should be replaced with the new value")
+}
+
+// SetWorkerDeploymentManager rejects a mutation carrying a stale conflict token:
+// capture a token, advance the revision with a successful SetManager, then
+// replay the stale token and expect a FailedPrecondition.
+func TestWCISetManagerStaleConflictToken(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	staleToken := descResp.GetConflictToken()
+
+	// Advance the revision, invalidating staleToken.
+	_, err = cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "controller-1",
+			},
+			ConflictToken: staleToken,
+			Identity:      "test-identity",
+		})
+	require.NoError(t, err)
+
+	// Replay the stale token against a different manager value.
+	_, err = cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "controller-2",
+			},
+			ConflictToken: staleToken,
+			Identity:      "test-identity",
+		})
+	require.Error(t, err)
+	var failedPre *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPre,
+		"a stale conflict token should return FailedPrecondition, got: %v", err)
+}
+
+// Once a deployment has a manager identity, a routing mutation (SetCurrent) from
+// a different identity is rejected with FailedPrecondition.
+func TestWCIManagerIdentityEnforcedOnSetCurrent(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName, buildID, _ := setupPolledVersion(t, env)
+
+	// Claim ownership as "owner-a".
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	setResp, err := cli.WorkflowService().SetWorkerDeploymentManager(ctx,
+		&workflowservice.SetWorkerDeploymentManagerRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			NewManagerIdentity: &workflowservice.SetWorkerDeploymentManagerRequest_ManagerIdentity{
+				ManagerIdentity: "owner-a",
+			},
+			ConflictToken: descResp.GetConflictToken(),
+			Identity:      "owner-a",
+		})
+	require.NoError(t, err)
+
+	// A different identity attempting to change routing must be rejected.
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        buildID,
+			ConflictToken:  setResp.GetConflictToken(),
+			Identity:       "intruder-b",
+		})
+	require.Error(t, err)
+	var failedPre *serviceerror.FailedPrecondition
+	require.ErrorAs(t, err, &failedPre,
+		"SetCurrent from a non-manager identity should be rejected with FailedPrecondition, got: %v", err)
+}
+
+// setupPolledVersion creates a worker deployment and a single version, brings
+// up a versioned worker for it, and waits until the version has registered at
+// least one task queue (i.e. it has active pollers). It returns the deployment
+// name, build ID, and version. The worker is stopped via t.Cleanup.
+func setupPolledVersion(
+	t *testing.T,
+	env *testcore.TestEnv,
+) (string, string, *deploymentpb.WorkerDeploymentVersion) {
+	t.Helper()
+	ctx := env.Context()
+	cli := env.SdkClient()
+	namespace := env.Namespace().String()
+
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := t.Name() + "-tq-" + deploymentName
+	version := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        buildID,
+	}
+
+	// Observe provider invocations for this build before anything can fire one.
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetInvokeObserver(buildID, spy))
+
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	_, err = cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     testComputeConfig(),
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	// WCI invokes workers to register task queues; bring up a versioned worker so
+	// the task queue registers active pollers against this version.
+	waitForInvoke(t, spy.events, 60*time.Second, "register-task-queues invoke")
+	w := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID)
+	t.Cleanup(w.Stop)
+	require.Eventually(t, func() bool {
+		resp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: version,
+			})
+		return derr == nil &&
+			len(resp.GetWorkerDeploymentVersionInfo().GetTaskQueueInfos()) > 0
+	}, 60*time.Second, 500*time.Millisecond, "task queue never registered against the version")
+
+	return deploymentName, buildID, version
+}
+
+// createUnpolledVersion creates an additional version under an existing
+// deployment without bringing up a worker, so it registers no task queues. It
+// waits until the version is visible in the deployment before returning.
+func createUnpolledVersion(
+	t *testing.T,
+	env *testcore.TestEnv,
+	deploymentName string,
+) *deploymentpb.WorkerDeploymentVersion {
+	t.Helper()
+	ctx := env.Context()
+	cli := env.SdkClient()
+	namespace := env.Namespace().String()
+
+	buildID := uuid.NewString()
+	version := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        buildID,
+	}
+
+	_, err := cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     testComputeConfig(),
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	// The version registers itself with the deployment asynchronously; wait
+	// until it shows up so later SetCurrent/SetRamping calls don't race a
+	// "version not found" error.
+	require.Eventually(t, func() bool {
+		resp, derr := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+			&workflowservice.DescribeWorkerDeploymentRequest{
+				Namespace:      namespace,
+				DeploymentName: deploymentName,
+			})
+		if derr != nil {
+			return false
+		}
+		for _, s := range resp.GetWorkerDeploymentInfo().GetVersionSummaries() {
+			if s.GetDeploymentVersion().GetBuildId() == buildID {
+				return true
+			}
+		}
+		return false
+	}, 60*time.Second, 500*time.Millisecond, "version never registered in the deployment")
+
+	return version
+}
+
+// setupCurrentPlusSecondVersion builds a deployment where version A is current
+// and a second version B exists. Neither version is polled: the ramping tests
+// that use this setup never need active pollers, and promoting the first version
+// from unversioned skips the missing-task-queue check. It returns the deployment
+// name, the current version A, and the second version B.
+func setupCurrentPlusSecondVersion(
+	t *testing.T,
+	env *testcore.TestEnv,
+) (string, *deploymentpb.WorkerDeploymentVersion, *deploymentpb.WorkerDeploymentVersion) {
+	t.Helper()
+	ctx := env.Context()
+	cli := env.SdkClient()
+	namespace := env.Namespace().String()
+
+	deploymentName := uuid.NewString()
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	versionA := createUnpolledVersion(t, env, deploymentName)
+
+	descResp, err := cli.WorkflowService().DescribeWorkerDeployment(ctx,
+		&workflowservice.DescribeWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+		})
+	require.NoError(t, err)
+	_, err = cli.WorkflowService().SetWorkerDeploymentCurrentVersion(ctx,
+		&workflowservice.SetWorkerDeploymentCurrentVersionRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			BuildId:        versionA.GetBuildId(),
+			ConflictToken:  descResp.GetConflictToken(),
+			Identity:       "test-identity",
+		})
+	require.NoError(t, err)
+
+	versionB := createUnpolledVersion(t, env, deploymentName)
+	return deploymentName, versionA, versionB
 }
 
 func startVersionedWorker(


### PR DESCRIPTION
## Summary

Adds integration coverage for the WCI worker-deployment routing and manager APIs, exercised against the in-process WCI test environment.

### SetWorkerDeploymentCurrentVersion
- Happy path: promote a version with active pollers to current; assert routing config and `current_since_time`.
- Set to unversioned (empty `build_id`): current version cleared; the previous version drains to `DRAINED`.
- Missing-task-queue guardrail and its `ignore_missing_task_queues` override, on a single backlogged task queue so flipping only the flag changes the outcome (`FailedPrecondition` vs. success).
- Stale conflict token rejected (`FailedPrecondition`).

### SetWorkerDeploymentRampingVersion
- Happy path: set a version ramping at 20%; assert routing config and `RAMPING` status.
- Clear ramp (empty `build_id`): ramping cleared, percentage reset; the previous version drains to `DRAINED`.
- Ramping-equals-current rejected (`FailedPrecondition`).
- Percentage outside `[0,100]` rejected (`InvalidArgument`).

### SetWorkerDeploymentManager
- Set and override the manager identity.
- Stale conflict token rejected (`FailedPrecondition`).
- Enforcement: a routing mutation (`SetCurrentVersion`) from a non-manager identity is rejected.

### Test infrastructure
- Setup helpers: `setupPolledVersion`, `createUnpolledVersion`, `setupCurrentPlusSecondVersion`.
- `env.go` configures fast version drainage so versions reach `DRAINED` within the test timeouts.

## Testing
- `go test -tags=test_dep ./integration/` — full suite green (21/21).

## Notes
- **Runtime:** these tests add ~60s to the integration suite (each uses a dedicated in-process cluster and waits on real invoke/registration/drainage timing). Flagging that we're aware this increases suite time; parallelizing could be a follow-up if it becomes a concern.
- "Ramping == current" surfaces as `FailedPrecondition` (server validator), not `InvalidArgument`.
- Clearing a current/ramping version drains to `DRAINED` (not `INACTIVE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)