### PR TITLE
Gate AWS Lambda ExternalID enforcement behind require_role_and_external_id

### DIFF
--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -73,8 +73,13 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ Request
 		return fmt.Errorf("cannot access the compute resource: %w", err)
 	}
 
-	if err := p.checkExternalID(ctx, cfg, arn); err != nil {
-		return fmt.Errorf("IAM role trust policy does not enforce ExternalID condition: %w", err)
+	// Only enforce the ExternalID trust-policy check when role/external-ID are
+	// required. When require_role_and_external_id is false (e.g. local/dev), the
+	// flag governs the whole role/external-ID behavior, not just presence.
+	if p.requireRoleAndExternalID {
+		if err := p.checkExternalID(ctx, cfg, arn); err != nil {
+			return fmt.Errorf("IAM role trust policy does not enforce ExternalID condition: %w", err)
+		}
 	}
 
 	return nil

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -277,3 +277,29 @@ func TestAWSLambdaValidateConfig_ExternalIDSkipped_WhenRoleMissing(t *testing.T)
 	require.NoError(t, p.ValidateConfig(t.Context(), RequestContext{}, cfg))
 	assert.False(t, called, "verifyExternalIDEnforcedFn should not be called without role and external ID")
 }
+
+func TestAWSLambdaValidateConfig_ExternalIDSkipped_WhenNotRequired(t *testing.T) {
+	stubLambdaClient(t, &mockLambdaClient{
+		getFunctionFn: func(_ context.Context, _ *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+			return &lambda.GetFunctionOutput{}, nil
+		},
+	})
+
+	called := false
+	stubVerifyExternalID(t, func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		called = true
+		return nil
+	})
+
+	// require_role_and_external_id=false governs enforcement, not just presence:
+	// even with role and external ID present, the enforcement probe is skipped.
+	p := &awsLambdaComputeProvider{requireRoleAndExternalID: false}
+	cfg := ComputeProviderConfig{
+		configAWSLambdaARN:            testLambdaARN,
+		configAWSLambdaRole:           testRoleARN,
+		configAWSLambdaRoleExternalID: "my-eid",
+	}
+
+	require.NoError(t, p.ValidateConfig(t.Context(), RequestContext{}, cfg))
+	assert.False(t, called, "verifyExternalIDEnforcedFn should not be called when require_role_and_external_id is false")
+}


### PR DESCRIPTION
## Problem

`require_role_and_external_id` is documented as the escape hatch for relaxing the AWS role/external-ID requirement, but it doesn't actually work as one:

- In the provider (`aws_lambda.go` `ValidateConfig`), the flag only gates the **presence** check. The `aws:ExternalId` **enforcement probe** (`checkExternalID`) still runs whenever a role + external ID are present.
- The probe verifies enforcement by calling `AssumeRole` *without* the external ID and expecting `AccessDenied`. Any backend that doesn't enforce IAM trust conditions (e.g. a local emulator like LocalStack, whose STS is permissive) makes the probe fail, so a config can never validate.

Net: there's no way to stand up a **local dev** setup for serverless workers, because the multi-tenant confused-deputy control is enforced even in single-tenant local scenarios where it protects nothing.

## Change

Gate the `checkExternalID` probe behind `require_role_and_external_id` in the AWS Lambda provider, so the flag governs the whole role/external-ID behavior (presence **and** enforcement), not just presence.

## Semantics shift

This changes the meaning of `require_role_and_external_id=false` from *"don't require the fields to be present"* to *"don't require or enforce them."*

- Default stays `true` → **production behavior is unchanged**.
- Blast radius: `false` is a global flag, so it also disables external-ID enforcement for configs that *do* supply a role. It should remain `true` everywhere except isolated local/dev clusters.

## Testing

- Added `TestAWSLambdaValidateConfig_ExternalIDSkipped_WhenNotRequired` (probe skipped when the flag is false, even with role + external ID present).
- Validated end-to-end locally: with the fix + `require_role_and_external_id=false`, a compute-config version validates against LocalStack, WCI drives a scale-up (`lambda.Invoke`), and a Lambda-packaged worker completes a workflow.