### PR TITLE
Apply consistent tag emission to metrics with multiple paths

### DIFF
--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -80,6 +80,9 @@ const (
 	ErrorTypeAlgorithmFailed            ErrorType = "algorithm_failed"
 	ErrorTypeComputeProviderUnavailable ErrorType = "compute_provider_unavailable"
 	ErrorTypeComputeProviderFailed      ErrorType = "compute_provider_failed"
+	// ErrorTypeNone is the sentinel used when a metric's fixed tag schema requires the
+	// error_type tag on a non-error path.
+	ErrorTypeNone ErrorType = "none"
 )
 
 const (
@@ -92,6 +95,9 @@ const (
 	SkippedReasonInvalidCount         SkippedReason = "invalid_count"
 	SkippedReasonNoSourceRequest      SkippedReason = "no_source_request"
 	SkippedReasonTaskTypeMismatch     SkippedReason = "task_type_mismatch"
+	// SkippedReasonNone is the sentinel used when a metric's fixed tag schema requires the
+	// skip_reason tag on a non-skip path.
+	SkippedReasonNone SkippedReason = "none"
 )
 
 const (
@@ -101,6 +107,9 @@ const (
 	ActivityErrorTypePanic       ActivityErrorType = "panic"
 	ActivityErrorTypeTerminated  ActivityErrorType = "terminated"
 	ActivityErrorTypeOther       ActivityErrorType = "other"
+	// ActivityErrorTypeNone is the sentinel used when a metric's fixed tag schema requires
+	// the activity_error_type tag on a path that is not an activity error.
+	ActivityErrorTypeNone ActivityErrorType = "none"
 )
 
 const (

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -579,14 +579,22 @@ func newActivityRecorders(h sdkclient.MetricsHandler) (
 	recordSuccess func(),
 ) {
 	name := wcimetrics.Activities.Name()
+	// emit writes the fixed tag schema on every path; non-applicable dimensions
+	// take their sentinel value so the tag set never varies across call sites.
+	emit := func(errorType wcimetrics.ErrorType, reason wcimetrics.SkippedReason) {
+		h.WithTags(map[string]string{
+			wcimetrics.ErrorTypeTagName:  string(errorType),
+			wcimetrics.SkipReasonTagName: string(reason),
+		}).Counter(name).Inc(1)
+	}
 	recordError = func(errorType wcimetrics.ErrorType) {
-		h.WithTags(map[string]string{wcimetrics.ErrorTypeTagName: string(errorType)}).Counter(name).Inc(1)
+		emit(errorType, wcimetrics.SkippedReasonNone)
 	}
 	recordSkipped = func(reason wcimetrics.SkippedReason) {
-		h.WithTags(map[string]string{wcimetrics.SkipReasonTagName: string(reason)}).Counter(name).Inc(1)
+		emit(wcimetrics.ErrorTypeNone, reason)
 	}
 	recordSuccess = func() {
-		h.Counter(name).Inc(1)
+		emit(wcimetrics.ErrorTypeNone, wcimetrics.SkippedReasonNone)
 	}
 	return
 }

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -274,20 +274,14 @@ func (d *WorkflowRunner) handleValidateSpec(ctx workflow.Context, args *iface.Va
 		RemoveScalingGroups: args.RemoveScalingGroups,
 	})
 	if err != nil {
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeValidateSpec,
-			wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeBuildUpdatedSpecFailure),
-		}).Counter(wcimetrics.Updates.Name()).Inc(1)
+		d.recordUpdate(wcimetrics.UpdateTypeValidateSpec, wcimetrics.ErrorTypeBuildUpdatedSpecFailure, wcimetrics.ActivityErrorTypeNone)
 
 		return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 	}
 
 	if updatedSpec != nil {
 		if err := updatedSpec.Validate(); err != nil {
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeValidateSpec,
-				wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeInvalidSpec),
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeValidateSpec, wcimetrics.ErrorTypeInvalidSpec, wcimetrics.ActivityErrorTypeNone)
 
 			return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 		}
@@ -300,11 +294,7 @@ func (d *WorkflowRunner) handleValidateSpec(ctx workflow.Context, args *iface.Va
 				Spec:           updatedSpec,
 			},
 		).Get(ctx, nil); err != nil {
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName:        wcimetrics.UpdateTypeValidateSpec,
-				wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-				wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeValidateSpec, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err))
 
 			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				if len(args.RemoveScalingGroups) == 0 && len(args.UpsertScalingGroups) == 0 {
@@ -323,9 +313,7 @@ func (d *WorkflowRunner) handleValidateSpec(ctx workflow.Context, args *iface.Va
 		d.signalVersionWorkflow(ctx)
 	}
 
-	d.metrics.WithTags(map[string]string{
-		wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeValidateSpec,
-	}).Counter(wcimetrics.Updates.Name()).Inc(1)
+	d.recordUpdate(wcimetrics.UpdateTypeValidateSpec, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone)
 
 	return &iface.ValidateSpecResponse{}, nil
 }
@@ -351,10 +339,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 	// use lock to enforce only one update at a time
 	if err := d.lock.Lock(ctx); err != nil {
 		d.logger.Error("Could not acquire workflow lock", "error", err)
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeUpdateInstance,
-			wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeLockFailure),
-		}).Counter(wcimetrics.Updates.Name()).Inc(1)
+		d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeLockFailure, wcimetrics.ActivityErrorTypeNone)
 		return nil, serviceerror.NewDeadlineExceeded("Could not acquire workflow lock")
 	}
 	defer func() {
@@ -365,10 +350,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 
 	updatedSpec, err := iface.BuildUpdatedSpec(d.State.Spec, args)
 	if err != nil {
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeUpdateInstance,
-			wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeBuildUpdatedSpecFailure),
-		}).Counter(wcimetrics.Updates.Name()).Inc(1)
+		d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeBuildUpdatedSpecFailure, wcimetrics.ActivityErrorTypeNone)
 		return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 	}
 
@@ -380,9 +362,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 			d.State.ConflictToken = args.ConflictToken
 			d.State.Spec = updatedSpec
 
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeUpdateInstance,
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone)
 
 			return &iface.UpdateWorkerControllerInstanceResponse{Spec: d.State.Spec}, nil
 		}
@@ -390,10 +370,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		validationTime := workflow.Now(ctx)
 
 		if err := updatedSpec.Validate(); err != nil {
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeUpdateInstance,
-				wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeInvalidSpec),
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeInvalidSpec, wcimetrics.ActivityErrorTypeNone)
 			return nil, serviceerror.NewInvalidArgumentf("%s", err.Error())
 		}
 
@@ -405,11 +382,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 				Spec:           updatedSpec,
 			},
 		).Get(ctx, nil); err != nil {
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName:        wcimetrics.UpdateTypeUpdateInstance,
-				wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-				wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err))
 
 			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
@@ -426,11 +399,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 				WorkerControllerInstanceSpec: *updatedSpec,
 			},
 		).Get(ctx, nil); err != nil {
-			d.metrics.WithTags(map[string]string{
-				wcimetrics.UpdateTypeTagName:        wcimetrics.UpdateTypeUpdateInstance,
-				wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-				wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-			}).Counter(wcimetrics.Updates.Name()).Inc(1)
+			d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err))
 
 			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 				if appErr.Type() == "InvalidArgument" {
@@ -447,9 +416,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		d.State.Spec = updatedSpec
 	}
 
-	d.metrics.WithTags(map[string]string{
-		wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeUpdateInstance,
-	}).Counter(wcimetrics.Updates.Name()).Inc(1)
+	d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone)
 
 	return &iface.UpdateWorkerControllerInstanceResponse{Spec: d.State.Spec}, nil
 }
@@ -469,10 +436,7 @@ func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.
 	// use lock to enforce only one update at a time
 	if err := d.lock.Lock(ctx); err != nil {
 		d.logger.Error("Could not acquire workflow lock", "error", err)
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeDeleteInstance,
-			wcimetrics.ErrorTypeTagName:  string(wcimetrics.ErrorTypeLockFailure),
-		}).Counter(wcimetrics.Updates.Name()).Inc(1)
+		d.recordUpdate(wcimetrics.UpdateTypeDeleteInstance, wcimetrics.ErrorTypeLockFailure, wcimetrics.ActivityErrorTypeNone)
 
 		return &iface.DeleteWorkerControllerInstanceResponse{}, serviceerror.NewDeadlineExceeded("Could not acquire workflow lock")
 	}
@@ -484,9 +448,7 @@ func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.
 
 	d.deleteInstance = true
 
-	d.metrics.WithTags(map[string]string{
-		wcimetrics.UpdateTypeTagName: wcimetrics.UpdateTypeDeleteInstance,
-	}).Counter(wcimetrics.Updates.Name()).Inc(1)
+	d.recordUpdate(wcimetrics.UpdateTypeDeleteInstance, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone)
 
 	return &iface.DeleteWorkerControllerInstanceResponse{}, nil
 }
@@ -507,19 +469,13 @@ func (d *WorkflowRunner) pullStatsAndUpdate(ctx workflow.Context) time.Duration 
 		}).Get(ctx, &resp); err != nil {
 		d.logger.Warn("PullStats activity failed", "error", err)
 
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.OperationTagName:         wcimetrics.OperationTypePullStats,
-			wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-			wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-		}).Counter(wcimetrics.Operations.Name()).Inc(1)
+		d.recordOperation(wcimetrics.OperationTypePullStats, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 
 		return maxPollInterval
 	} else {
 		d.logger.Info("Completed PullStats", "action_count", len(resp.Actions), "next_poll_seconds", resp.NextPollSeconds)
 
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.OperationTagName: wcimetrics.OperationTypePullStats,
-		}).Counter(wcimetrics.Operations.Name()).Inc(1)
+		d.recordOperation(wcimetrics.OperationTypePullStats, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 
 		// Apply the updated status before handleActions for consistency between this
 		// and the no-sync-match path
@@ -549,11 +505,7 @@ func (d *WorkflowRunner) periodicValidateSpec(ctx workflow.Context) {
 			Spec:           d.State.Spec,
 		},
 	).Get(ctx, nil); err != nil {
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.OperationTagName:         wcimetrics.OperationTypeValidateSpec,
-			wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-			wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-		}).Counter(wcimetrics.Operations.Name()).Inc(1)
+		d.recordOperation(wcimetrics.OperationTypeValidateSpec, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 
 		if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
 			d.State.ValidationStatus = iface.NewValidationStatusFailed(now, appErr.Message())
@@ -565,9 +517,7 @@ func (d *WorkflowRunner) periodicValidateSpec(ctx workflow.Context) {
 			d.logger.Warn("Periodic spec validation failed with transient error, leaving validation state unchanged", "error", err)
 		}
 	} else {
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.OperationTagName: wcimetrics.OperationTypeValidateSpec,
-		}).Counter(wcimetrics.Operations.Name()).Inc(1)
+		d.recordOperation(wcimetrics.OperationTypeValidateSpec, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 
 		d.State.ValidationStatus = iface.NewValidationStatusSuccess(now)
 		d.signalVersionWorkflow(ctx)
@@ -579,10 +529,7 @@ func (d *WorkflowRunner) periodicValidateSpec(ctx workflow.Context) {
 func (d *WorkflowRunner) handleNoSyncMatchSignal(ctx workflow.Context, req *iface.SignalTaskAddRequest) {
 	if req == nil {
 		d.logger.Warn("Received nil task-add signal request; dropping")
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.SignalTypeTagName: wcimetrics.SignalTypeTaskAdd,
-			wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonInvalidRequest),
-		}).Counter(wcimetrics.Signals.Name()).Inc(1)
+		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonInvalidRequest)
 		return
 	}
 
@@ -600,15 +547,9 @@ func (d *WorkflowRunner) handleNoSyncMatchSignal(ctx workflow.Context, req *ifac
 		},
 	).Get(ctx, &resp); err != nil {
 		d.logger.Warn("Failed to process task match signal", "error", err)
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.SignalTypeTagName:        wcimetrics.SignalTypeTaskAdd,
-			wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-			wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-		}).Counter(wcimetrics.Signals.Name()).Inc(1)
+		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 	} else {
-		d.metrics.WithTags(map[string]string{
-			wcimetrics.SignalTypeTagName: wcimetrics.SignalTypeTaskAdd,
-		}).Counter(wcimetrics.Signals.Name()).Inc(1)
+		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 
 		d.logger.Debug("Completed match-signal processing", "action_count", len(resp.Actions), "sync_match", req.IsSyncMatch, "no_sync_match_batch", req.NoSyncMatchSignalsSinceLast)
 
@@ -651,18 +592,12 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 		case scalingalgorithm.ActionTypeDeferredScalingDecision:
 			if action.Count != nil {
 				d.logger.Warn("Deferred scaling decision must not carry a count; dropping action", "scaling_group_key", action.ScalingGroupKey, "count", *action.Count)
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName:  wcimetrics.OperationTypeDeferredScalingDecision,
-					wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonInvalidCount),
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeDeferredScalingDecision, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonInvalidCount)
 				continue
 			}
 			if taskAddRequest == nil {
 				d.logger.Error("Deferred scaling decision cannot be handled without source task-add request; dropping (only ProcessTaskAdd may return ActionTypeDeferredScalingDecision)", "scaling_group_key", action.ScalingGroupKey)
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName:  wcimetrics.OperationTypeDeferredScalingDecision,
-					wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonNoSourceRequest),
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeDeferredScalingDecision, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNoSourceRequest)
 				continue
 			}
 
@@ -684,11 +619,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				},
 			).Get(ctx, &resp); err != nil {
 				d.logger.Error("Failed to process deferred scaling decision", "namespace", d.NamespaceName, "deployment_name", d.DeploymentName, "scaling_group_key", action.ScalingGroupKey, "error", err)
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName:         wcimetrics.OperationTypeDeferredScalingDecision,
-					wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-					wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeDeferredScalingDecision, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 			} else {
 
 				if resp.UpdatedScalingStatus != nil {
@@ -696,9 +627,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 				}
 				d.handleActions(ctx, resp.Actions, nil)
 
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName: wcimetrics.OperationTypeDeferredScalingDecision,
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeDeferredScalingDecision, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 			}
 
 		case scalingalgorithm.ActionTypeInvokeWorker:
@@ -725,15 +654,9 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 					d.State.ValidationStatus = iface.NewValidationStatusFailed(now, appErr.Message())
 					d.signalVersionWorkflow(ctx)
 				}
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName:         wcimetrics.OperationTypeInvokeWorker,
-					wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-					wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeInvokeWorker, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 			} else {
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName: wcimetrics.OperationTypeInvokeWorker,
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeInvokeWorker, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 
 				// We are not setting stateChanged to true to avoid unneccessary CaNs here.
 			}
@@ -742,10 +665,7 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 			if action.Count != nil {
 				if *action.Count < 0 {
 					d.logger.Warn("Scaling action has invalid count value", "count", *action.Count)
-					d.metrics.WithTags(map[string]string{
-						wcimetrics.OperationTagName:  wcimetrics.OperationTypeUpdateWorkerSetSize,
-						wcimetrics.SkipReasonTagName: string(wcimetrics.SkippedReasonInvalidRequest),
-					}).Counter(wcimetrics.Operations.Name()).Inc(1)
+					d.recordOperation(wcimetrics.OperationTypeUpdateWorkerSetSize, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonInvalidRequest)
 					continue
 				}
 				count = *action.Count
@@ -770,15 +690,9 @@ func (d *WorkflowRunner) handleActions(ctx workflow.Context, actions []scalingal
 					d.signalVersionWorkflow(ctx)
 				}
 
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName:         wcimetrics.OperationTypeUpdateWorkerSetSize,
-					wcimetrics.ErrorTypeTagName:         string(wcimetrics.ErrorTypeActivityError),
-					wcimetrics.ActivityErrorTypeTagName: string(classifyActivityErrorType(err)),
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeUpdateWorkerSetSize, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err), wcimetrics.SkippedReasonNone)
 			} else {
-				d.metrics.WithTags(map[string]string{
-					wcimetrics.OperationTagName: wcimetrics.OperationTypeUpdateWorkerSetSize,
-				}).Counter(wcimetrics.Operations.Name()).Inc(1)
+				d.recordOperation(wcimetrics.OperationTypeUpdateWorkerSetSize, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonNone)
 
 				// We are not setting stateChanged to true to avoid unneccessary CaNs here.
 			}
@@ -899,6 +813,41 @@ func (d *WorkflowRunner) signalVersionWorkflow(ctx workflow.Context) {
 			d.logger.Warn("failed to signal version workflow with validation status", "error", err, "version_wf_id", versionWfID)
 		}
 	}
+}
+
+// recordUpdate emits the Updates counter with its fixed tag schema:
+// update_type + error_type + activity_error_type (plus the handler's identity tags).
+// Non-applicable dimensions take their sentinel value so the tag set never varies.
+func (d *WorkflowRunner) recordUpdate(updateType string, errorType wcimetrics.ErrorType, activityErrorType wcimetrics.ActivityErrorType) {
+	d.metrics.WithTags(map[string]string{
+		wcimetrics.UpdateTypeTagName:        updateType,
+		wcimetrics.ErrorTypeTagName:         string(errorType),
+		wcimetrics.ActivityErrorTypeTagName: string(activityErrorType),
+	}).Counter(wcimetrics.Updates.Name()).Inc(1)
+}
+
+// recordOperation emits the Operations counter with its fixed tag schema:
+// operation + error_type + activity_error_type + skip_reason.
+// Non-applicable dimensions take their sentinel value so the tag set never varies.
+func (d *WorkflowRunner) recordOperation(operation string, errorType wcimetrics.ErrorType, activityErrorType wcimetrics.ActivityErrorType, skipReason wcimetrics.SkippedReason) {
+	d.metrics.WithTags(map[string]string{
+		wcimetrics.OperationTagName:         operation,
+		wcimetrics.ErrorTypeTagName:         string(errorType),
+		wcimetrics.ActivityErrorTypeTagName: string(activityErrorType),
+		wcimetrics.SkipReasonTagName:        string(skipReason),
+	}).Counter(wcimetrics.Operations.Name()).Inc(1)
+}
+
+// recordSignal emits the Signals counter with its fixed tag schema:
+// signal_type + error_type + activity_error_type + skip_reason.
+// Non-applicable dimensions take their sentinel value so the tag set never varies.
+func (d *WorkflowRunner) recordSignal(signalType string, errorType wcimetrics.ErrorType, activityErrorType wcimetrics.ActivityErrorType, skipReason wcimetrics.SkippedReason) {
+	d.metrics.WithTags(map[string]string{
+		wcimetrics.SignalTypeTagName:        signalType,
+		wcimetrics.ErrorTypeTagName:         string(errorType),
+		wcimetrics.ActivityErrorTypeTagName: string(activityErrorType),
+		wcimetrics.SkipReasonTagName:        string(skipReason),
+	}).Counter(wcimetrics.Signals.Name()).Inc(1)
 }
 
 // classifyActivityErrorType buckets an activity error returned by workflow.ExecuteActivity


### PR DESCRIPTION
## What was changed

Applied consistent tags on all emission sites for `updates`, `operations`, `signals`, and `activities` metrics. The tags now carry a sentinel value of "none" when they are not relevant to the actual path the metric is being emitted on.

## Why?

Metrics bug where applied tags were inconsistent across the different paths -> https://temporalio.atlassian.net/browse/COM-224?atlOrigin=eyJpIjoiMGY5ZGJiYTE5OTAzNDQxZGJkYTFjMTRiNzExN2Q2MDkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ&focusedCommentId=208348&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-208348

Fix is required to get full transparency of all activity requests. Enables the alarming system as well.

## Checklist

1. How was this tested:
Testing on a cell in staging. Verifying all metric emissions are working properly and showing up in Grafana.
