### PR TITLE
Support worker-set integration tests

### DIFF
--- a/tests/integration/env.go
+++ b/tests/integration/env.go
@@ -29,5 +29,10 @@ func createWCITestEnv(t *testing.T) *testcore.TestEnv {
 		testcore.WithDynamicConfig(client.WorkerControllerEnabled, true),
 		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusRefreshInterval, testVersionDrainageRefreshInterval),
 		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusVisibilityGracePeriod, testVersionDrainageVisibilityGracePeriod),
+		// Effectively disable no-sync-match signal batching so each backlogged
+		// task-add produces its own signal. This makes per-signal scaling
+		// decisions (e.g. rate-based's +1 per backlog signal) deterministic in
+		// tests instead of depending on the 500ms batch window.
+		testcore.WithDynamicConfig(client.WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds, 1),
 	)
 }

--- a/tests/integration/wci_test.go
+++ b/tests/integration/wci_test.go
@@ -278,6 +278,45 @@ func TestWCICreateVersionInvalidComputeConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestWCIInvokeIncompatibleWithRateBased verifies the rate-based algorithm
+// (worker-set launch strategy) cannot be paired with the invoke test provider.
+func TestWCIInvokeIncompatibleWithRateBased(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	version := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        uuid.NewString(),
+	}
+
+	createWorkerDeployment(t, env, deploymentName)
+
+	config := &computepb.ComputeConfig{
+		ScalingGroups: map[string]*computepb.ComputeConfigScalingGroup{
+			"default": {
+				Provider: &computepb.ComputeProvider{Type: "test-invoke"},
+				Scaler:   &computepb.ComputeScaler{Type: "rate-based"},
+			},
+		},
+	}
+	_, err := cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     config,
+			RequestId:         uuid.NewString(),
+		})
+	require.Error(t, err)
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg,
+		"rate-based with an invoke provider should be rejected, got: %v", err)
+	require.ErrorContains(t, err, "not compatible")
+}
+
 func TestWCIUpdateVersionInvalidComputeConfig(t *testing.T) {
 	env := createWCITestEnv(t)
 	ctx := env.Context()
@@ -449,7 +488,7 @@ func TestWCIScaleUp(t *testing.T) {
 
 	// Observe provider invocations for this build before anything can fire one.
 	spy := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildID, spy))
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
 	events := spy.events
 
 	// Create the parent deployment, then a version backed by the no-op
@@ -541,7 +580,7 @@ func TestWCIVersionInactiveAfterInvoke(t *testing.T) {
 
 	// Observe provider invocations for this build before anything can fire one.
 	spy := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildID, spy))
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
 	events := spy.events
 
 	// Create the parent deployment
@@ -633,11 +672,11 @@ func TestWCIMultipleVersionsInvokeWithPinnedWorkflows(t *testing.T) {
 	}
 
 	spy1 := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildID1, spy1))
+	t.Cleanup(computeprovider.SetComputeObserver(buildID1, spy1))
 	events1 := spy1.events
 
 	spy2 := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildID2, spy2))
+	t.Cleanup(computeprovider.SetComputeObserver(buildID2, spy2))
 	events2 := spy2.events
 
 	_, err = cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
@@ -874,7 +913,7 @@ func TestWCISetCurrentVersionMissingTaskQueuesAndOverride(t *testing.T) {
 	}
 
 	spy := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildA, spy))
+	t.Cleanup(computeprovider.SetComputeObserver(buildA, spy))
 	events := spy.events
 
 	// Deployment + version A, with a worker so A registers the task queue.
@@ -1406,7 +1445,7 @@ func setupPolledVersion(
 
 	// Observe provider invocations for this build before anything can fire one.
 	spy := &invokeSpy{events: make(chan string, 16)}
-	t.Cleanup(computeprovider.SetInvokeObserver(buildID, spy))
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
 
 	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
 		&workflowservice.CreateWorkerDeploymentRequest{
@@ -1900,7 +1939,6 @@ func TestWCIDescribeVersionReportsTaskQueueStats(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-
 	// Bring up a worker so the task queue registers against (is polled by) the version.
 	_, w1 := createAndRegisterVersion(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
 	require.Eventually(t, func() bool {
@@ -2049,7 +2087,7 @@ func startVersionedWorker(
 
 // invokeSpy forwards the test-invoke provider actions it observes onto a
 // channel the test consumes. It is registered against a single deployment
-// build (see SetInvokeObserver), so every action it receives is relevant.
+// build (see SetComputeObserver), so every action it receives is relevant.
 type invokeSpy struct {
 	events chan string
 }

--- a/tests/integration/worker_deployment_test.go
+++ b/tests/integration/worker_deployment_test.go
@@ -292,18 +292,6 @@ func TestWCIListWorkerDeploymentsEmpty(t *testing.T) {
 	require.Empty(t, got)
 }
 
-func createWorkerDeployment(t *testing.T, env *testcore.TestEnv, deploymentName string) {
-	t.Helper()
-	_, err := env.SdkClient().WorkflowService().CreateWorkerDeployment(env.Context(),
-		&workflowservice.CreateWorkerDeploymentRequest{
-			Namespace:      env.Namespace().String(),
-			DeploymentName: deploymentName,
-			Identity:       "test-identity",
-			RequestId:      uuid.NewString(),
-		})
-	require.NoError(t, err)
-}
-
 func createVersion(t *testing.T, env *testcore.TestEnv, deploymentName, buildID string) *deploymentpb.WorkerDeploymentVersion {
 	t.Helper()
 	version := &deploymentpb.WorkerDeploymentVersion{

--- a/tests/integration/worker_set_test.go
+++ b/tests/integration/worker_set_test.go
@@ -1,0 +1,502 @@
+package integration
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	computepb "go.temporal.io/api/compute/v1"
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	"go.temporal.io/api/serviceerror"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+	wciworkflow "go.temporal.io/auto-scaled-workers/wci/workflow"
+	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/server/common/sdk"
+	"go.temporal.io/server/tests/testcore"
+)
+
+func TestWCIWorkerSetScaleUp(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := "workerset-scaleup-tq-" + deploymentName
+
+	version := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        buildID,
+	}
+
+	// Observe provider actions for this build before anything can fire one.
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	// Version backed by the no-op test-worker-set provider with the rate-based scaler.
+	_, err = cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     workerSetComputeConfig(),
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	// Bring up worker to register TQ
+	w1 := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID)
+	require.Eventually(t, func() bool {
+		resp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: version,
+			})
+		return derr == nil &&
+			len(resp.GetWorkerDeploymentVersionInfo().GetTaskQueueInfos()) > 0
+	}, 60*time.Second, 500*time.Millisecond, "task queue never registered against the version")
+
+	// Drop the poller so a backlog can form on the versioned task queue.
+	w1.Stop()
+	drainEvents(t, events)
+
+	// Submit a workflow pinned to this version with no poller present, creating a backlog.
+	run, err := cli.ExecuteWorkflow(ctx,
+		sdkclient.StartWorkflowOptions{
+			TaskQueue: taskQueue,
+			ID:        "workerset-scaleup-wf-" + uuid.NewString(),
+			VersioningOverride: &sdkclient.PinnedVersioningOverride{
+				Version: worker.WorkerDeploymentVersion{
+					DeploymentName: deploymentName,
+					BuildID:        buildID,
+				},
+			},
+		}, scaleUpWorkflow)
+	require.NoError(t, err)
+
+	// The backlog with no poller should drive the rate-based scaler to resize the worker set.
+	count := waitForWorkerSetUpdate(t, events, 60*time.Second, "scale-up worker-set update")
+	require.Greater(t, count, 0, "Expected non-zero scale-up")
+
+	// Bring up a worker to drain the backlog and complete the workflow.
+	w2 := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID)
+	t.Cleanup(w2.Stop)
+
+	var result string
+	getCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, run.Get(getCtx, &result))
+	require.Equal(t, "foo", result)
+}
+
+func TestWCIWorkerSetCreateVersionInvalidComputeConfig(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	version := &deploymentpb.WorkerDeploymentVersion{
+		DeploymentName: deploymentName,
+		BuildId:        uuid.NewString(),
+	}
+
+	_, err := cli.WorkflowService().CreateWorkerDeployment(ctx,
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      namespace,
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	_, err = cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     invalidWorkerSetComputeConfig(),
+			RequestId:         uuid.NewString(),
+		})
+	require.Error(t, err)
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg,
+		"invalid compute config should return an InvalidArgument error, got: %v", err)
+
+	// The rejected create must not have left a version behind.
+	_, err = cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+		&workflowservice.DescribeWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+		})
+	require.Error(t, err)
+}
+
+func TestWCIWorkerSetScaleUpPastOne(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := "workerset-scaleup2-tq-" + deploymentName
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	createWorkerDeployment(t, env, deploymentName)
+	createWorkerSetVersion(t, ctx, cli, namespace, version,
+		rateBasedScaler(map[string]string{"scale_up_cooldown_ms": "0"}))
+
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
+	drainEvents(t, events)
+
+	// First backlog workflow → first scale-up (0 -> 1).
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	first := waitForWorkerSetUpdate(t, events, 60*time.Second, "first scale-up")
+	require.Equal(t, 1, first, "first scale-up should set worker set size to 1")
+	drainEvents(t, events)
+
+	// Second backlog workflow → the scaler raises the worker set above the first size.
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	second := waitForWorkerSetUpdate(t, events, 60*time.Second, "second scale-up")
+	require.Greater(t, second, first, "second scale-up should set a higher worker set size than the first")
+}
+
+// TestWCIWorkerSetScaleDownToZero verifies the rate-based scaler reduces the
+// worker set once the backlog drains, eventually returning to 0. Scale-down only
+// happens on the metrics-poll path, so the test uses a fast poll cadence (the
+// production floor is 30s) and caps the worker set at 2 for a bounded, quick run.
+func TestWCIWorkerSetScaleDownToZero(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := "workerset-scaledown-tq-" + deploymentName
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	// Poll on a fast cadence so the poll-driven scale-down completes within the
+	// test env's deadline instead of the production 5m/30s intervals.
+	t.Cleanup(wciworkflow.SetPollIntervalsForTest(2*time.Second, 1*time.Second))
+
+	createWorkerDeployment(t, env, deploymentName)
+	createWorkerSetVersion(t, ctx, cli, namespace, version, cappedRateBasedScaler(2))
+
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
+	drainEvents(t, events)
+
+	// Backlog with no poller drives the worker set up to its cap of 2.
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	awaitWorkerSetSize(t, events, 2, 60*time.Second, "scale-up to cap")
+
+	// Bring up a worker to drain the backlog; with no load the scaler reduces the
+	// worker set back down to 0.
+	w := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID)
+	t.Cleanup(w.Stop)
+
+	awaitWorkerSetSize(t, events, 0, 90*time.Second, "scale-down to 0")
+}
+
+func TestWCIWorkerSetIncompatibleWithNoSync(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: uuid.NewString()}
+
+	createWorkerDeployment(t, env, deploymentName)
+
+	config := &computepb.ComputeConfig{
+		ScalingGroups: map[string]*computepb.ComputeConfigScalingGroup{
+			"default": {
+				Provider: &computepb.ComputeProvider{Type: "test-worker-set"},
+				Scaler:   &computepb.ComputeScaler{Type: "no-sync"},
+			},
+		},
+	}
+	_, err := cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     config,
+			RequestId:         uuid.NewString(),
+		})
+	require.Error(t, err)
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg,
+		"no-sync with a worker-set provider should be rejected, got: %v", err)
+	require.ErrorContains(t, err, "not compatible")
+}
+
+// TestWCIWorkerSetMultipleVersionsScaleIndependently verifies two worker-set
+// versions on the same deployment scale up and down independently, each tracking
+// its own worker count. Their caps differ (v1=2, v2=1), so they reach different
+// sizes, and each drains back to 0 on its own observer without cross-talk.
+func TestWCIWorkerSetMultipleVersionsScaleIndependently(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID1 := uuid.NewString()
+	buildID2 := uuid.NewString()
+	taskQueue := "workerset-multi-tq-" + deploymentName
+	version1 := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID1}
+	version2 := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID2}
+
+	spy1 := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID1, spy1))
+	events1 := spy1.events
+
+	spy2 := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID2, spy2))
+	events2 := spy2.events
+
+	// Fast poll cadence so both versions reach the poll-driven scale-down path
+	// within the test env's deadline.
+	t.Cleanup(wciworkflow.SetPollIntervalsForTest(2*time.Second, 1*time.Second))
+
+	createWorkerDeployment(t, env, deploymentName)
+	// Different caps → the two versions settle at different worker-set sizes.
+	createWorkerSetVersion(t, ctx, cli, namespace, version1, cappedRateBasedScaler(2))
+	createWorkerSetVersion(t, ctx, cli, namespace, version2, cappedRateBasedScaler(1))
+
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID1, taskQueue)
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID2, taskQueue)
+	drainEvents(t, events1)
+	drainEvents(t, events2)
+
+	// Backlog both versions (no pollers). v1 scales up to its cap of 2, v2 to 1 —
+	// each observed on its own observer, confirming independent, differently-sized
+	// worker sets.
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID1)
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID1)
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID2)
+	awaitWorkerSetSize(t, events1, 2, 60*time.Second, "v1 scale-up to cap 2")
+	awaitWorkerSetSize(t, events2, 1, 60*time.Second, "v2 scale-up to cap 1")
+
+	// Bring up workers for both versions; each scales its own worker set back to 0
+	// independently.
+	w1 := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID1)
+	t.Cleanup(w1.Stop)
+	w2 := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID2)
+	t.Cleanup(w2.Stop)
+
+	awaitWorkerSetSize(t, events1, 0, 90*time.Second, "v1 scale-down to 0")
+	awaitWorkerSetSize(t, events2, 0, 90*time.Second, "v2 scale-down to 0")
+}
+
+// workerSetComputeConfig is the worker-set analog of testComputeConfig: the
+// no-op test-worker-set provider with the rate-based scaler.
+func workerSetComputeConfig() *computepb.ComputeConfig {
+	return &computepb.ComputeConfig{
+		ScalingGroups: map[string]*computepb.ComputeConfigScalingGroup{
+			"default": {
+				Provider: &computepb.ComputeProvider{
+					Type: "test-worker-set",
+				},
+				Scaler: &computepb.ComputeScaler{
+					Type: "rate-based",
+				},
+			},
+		},
+	}
+}
+
+// invalidWorkerSetComputeConfig hands the test-worker-set provider a config
+// carrying the illegal field, which its ValidateConfig rejects.
+func invalidWorkerSetComputeConfig() *computepb.ComputeConfig {
+	return &computepb.ComputeConfig{
+		ScalingGroups: map[string]*computepb.ComputeConfigScalingGroup{
+			"default": {
+				Provider: computeprovider.TestWorkerSetComputeProviderInvalidComputeProvider(),
+				Scaler: &computepb.ComputeScaler{
+					Type: "rate-based",
+				},
+			},
+		},
+	}
+}
+
+// createWorkerDeployment creates the parent worker deployment.
+func createWorkerDeployment(t *testing.T, env *testcore.TestEnv, deploymentName string) {
+	t.Helper()
+	_, err := env.SdkClient().WorkflowService().CreateWorkerDeployment(env.Context(),
+		&workflowservice.CreateWorkerDeploymentRequest{
+			Namespace:      env.Namespace().String(),
+			DeploymentName: deploymentName,
+			Identity:       "test-identity",
+			RequestId:      uuid.NewString(),
+		})
+	require.NoError(t, err)
+}
+
+// createWorkerSetVersion creates a version backed by the test-worker-set provider
+// with the given rate-based scaler.
+func createWorkerSetVersion(t *testing.T, ctx context.Context, cli sdkclient.Client, namespace string, version *deploymentpb.WorkerDeploymentVersion, scaler *computepb.ComputeScaler) {
+	t.Helper()
+	_, err := cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     workerSetConfigWithScaler(scaler),
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+}
+
+// registerVersionTaskQueue brings up a versioned worker just long enough to
+// register the task queue against the version, then stops it so a backlog can form.
+func registerVersionTaskQueue(t *testing.T, ctx context.Context, cli sdkclient.Client, namespace, deploymentName, buildID, taskQueue string) {
+	t.Helper()
+	w := startVersionedWorker(t, cli, taskQueue, deploymentName, buildID)
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+	require.Eventually(t, func() bool {
+		resp, derr := cli.WorkflowService().DescribeWorkerDeploymentVersion(ctx,
+			&workflowservice.DescribeWorkerDeploymentVersionRequest{
+				Namespace:         namespace,
+				DeploymentVersion: version,
+			})
+		return derr == nil &&
+			len(resp.GetWorkerDeploymentVersionInfo().GetTaskQueueInfos()) > 0
+	}, 60*time.Second, 500*time.Millisecond, "task queue never registered against version "+buildID)
+	w.Stop()
+}
+
+// submitPinnedWorkflow starts a scaleUpWorkflow pinned to the given version.
+func submitPinnedWorkflow(t *testing.T, ctx context.Context, cli sdkclient.Client, taskQueue, deploymentName, buildID string) sdkclient.WorkflowRun {
+	t.Helper()
+	run, err := cli.ExecuteWorkflow(ctx,
+		sdkclient.StartWorkflowOptions{
+			TaskQueue: taskQueue,
+			ID:        "workerset-wf-" + uuid.NewString(),
+			VersioningOverride: &sdkclient.PinnedVersioningOverride{
+				Version: worker.WorkerDeploymentVersion{
+					DeploymentName: deploymentName,
+					BuildID:        buildID,
+				},
+			},
+		}, scaleUpWorkflow)
+	require.NoError(t, err)
+	return run
+}
+
+// awaitWorkerSetSize consumes "update-worker-set-size" actions until the observed
+// size equals target, logging others (e.g. "validate") along the way.
+func awaitWorkerSetSize(t *testing.T, events <-chan string, target int, timeout time.Duration, desc string) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case action := <-events:
+			t.Logf("provider action while awaiting %s: %s", desc, action)
+			if strings.HasPrefix(action, "update-worker-set-size") && parseWorkerSetCount(t, action) == target {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s (worker set size %d)", desc, target)
+		}
+	}
+}
+
+// parseWorkerSetCount extracts the trailing size from an "update-worker-set-size-N" action.
+func parseWorkerSetCount(t *testing.T, action string) int {
+	t.Helper()
+	parts := strings.Split(action, "-")
+	count, err := strconv.Atoi(parts[len(parts)-1])
+	require.NoError(t, err, "worker set update action missing a valid count: %s", action)
+	return count
+}
+
+// cappedRateBasedScaler is a rate-based scaler tuned for tests: cooldowns and the
+// no-sync-quiet gate are 0, and max_count bounds the worker set so scale
+// up/down covers a small, deterministic range.
+func cappedRateBasedScaler(maxCount int) *computepb.ComputeScaler {
+	return rateBasedScaler(map[string]string{
+		"max_count":                strconv.Itoa(maxCount),
+		"metrics_poll_interval_ms": "30000",
+		"scale_up_cooldown_ms":     "0",
+		"scale_down_cooldown_ms":   "0",
+		"no_sync_quiet_ms":         "0",
+	})
+}
+
+// rateBasedScaler builds a rate-based ComputeScaler with the given config details.
+func rateBasedScaler(details map[string]string) *computepb.ComputeScaler {
+	payload, _ := sdk.PreferProtoDataConverter.ToPayload(details)
+	return &computepb.ComputeScaler{
+		Type:    "rate-based",
+		Details: payload,
+	}
+}
+
+// workerSetConfigWithScaler builds a compute config pairing the test-worker-set
+// provider with the given scaler.
+func workerSetConfigWithScaler(scaler *computepb.ComputeScaler) *computepb.ComputeConfig {
+	return &computepb.ComputeConfig{
+		ScalingGroups: map[string]*computepb.ComputeConfigScalingGroup{
+			"default": {
+				Provider: &computepb.ComputeProvider{Type: "test-worker-set"},
+				Scaler:   scaler,
+			},
+		},
+	}
+}
+
+// waitForWorkerSetUpdate blocks until an "update-worker-set-size" provider action
+// arrives, logging any other actions (e.g. "validate") seen along the way. It is
+// the worker-set analog of waitForInvoke.
+func waitForWorkerSetUpdate(t *testing.T, events <-chan string, timeout time.Duration, desc string) int {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case action := <-events:
+			t.Logf("provider action while awaiting %s: %s", desc, action)
+			if strings.HasPrefix(action, "update-worker-set-size") {
+				parts := strings.Split(action, "-")
+				countstr := parts[len(parts)-1]
+				count, err := strconv.Atoi(countstr)
+				if err != nil {
+					t.Fatalf("worker set update doesn't contain valid int: %s", action)
+				}
+				return count
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %s", desc)
+		}
+	}
+}

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -28,7 +28,12 @@ const (
 	validateSpecTimeout           = 15 * time.Second
 	startNewWorkerInstanceTimeout = 60 * time.Second
 	updateWorkerSetSizeTimeout    = 60 * time.Second
+)
 
+// Min/max polling interval for PullStats. Constant in production, but a
+// test hook enables modifying these values during integration tests for
+// better coverage avoiding the 30s wait.
+var (
 	minPollInterval = 30 * time.Second
 	maxPollInterval = 5 * time.Minute
 )

--- a/wci/workflow/compute_provider/test_compute.go
+++ b/wci/workflow/compute_provider/test_compute.go
@@ -1,0 +1,30 @@
+package computeprovider
+
+import (
+	"sync"
+)
+
+// ComputeObserver observes actions taken by the test-invoke provider. It is an
+// extension point for integration tests; observers can only be installed under
+// the test_dep build tag (see SetComputeObserver), so it is inert otherwise.
+type ComputeObserver interface {
+	ObserveProviderInvoke(rc RequestContext, action string)
+}
+
+var (
+	computeObserverMu sync.RWMutex
+	// computeObservers maps a deployment build ID to the observer watching it,
+	// so concurrent tests each observe only their own build's actions.
+	computeObservers = map[string]ComputeObserver{}
+)
+
+// emitProviderEvent reports an action to the observer registered for the
+// request's deployment build, if any.
+func emitProviderEvent(rc RequestContext, action string) {
+	computeObserverMu.RLock()
+	o := computeObservers[rc.DeploymentBuildID]
+	computeObserverMu.RUnlock()
+	if o != nil {
+		o.ObserveProviderInvoke(rc, action)
+	}
+}

--- a/wci/workflow/compute_provider/test_compute_observer.go
+++ b/wci/workflow/compute_provider/test_compute_observer.go
@@ -4,21 +4,21 @@ package computeprovider
 
 import "fmt"
 
-// SetInvokeObserver installs an observer for test-invoke provider actions on
+// SetComputeObserver installs an observer for test-invoke provider actions on
 // the given deployment build ID and returns a function that removes it. It
 // panics if an observer is already registered for the build ID, since that
 // would silently clobber the existing one. It exists only under the test_dep
 // build tag, so non-test builds cannot install an observer.
-func SetInvokeObserver(buildID string, o InvokeObserver) func() {
-	invokeObserverMu.Lock()
-	defer invokeObserverMu.Unlock()
-	if _, ok := invokeObservers[buildID]; ok {
+func SetComputeObserver(buildID string, o ComputeObserver) func() {
+	computeObserverMu.Lock()
+	defer computeObserverMu.Unlock()
+	if _, ok := computeObservers[buildID]; ok {
 		panic(fmt.Sprintf("invoke observer already registered for build ID %q", buildID))
 	}
-	invokeObservers[buildID] = o
+	computeObservers[buildID] = o
 	return func() {
-		invokeObserverMu.Lock()
-		delete(invokeObservers, buildID)
-		invokeObserverMu.Unlock()
+		computeObserverMu.Lock()
+		delete(computeObservers, buildID)
+		computeObserverMu.Unlock()
 	}
 }

--- a/wci/workflow/compute_provider/test_invoke.go
+++ b/wci/workflow/compute_provider/test_invoke.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	computepb "go.temporal.io/api/compute/v1"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
@@ -65,31 +64,6 @@ func (p *testInvokeComputeProvider) UpdateWorkerSetSize(
 	_ int32,
 ) error {
 	return errors.ErrUnsupported
-}
-
-// InvokeObserver observes actions taken by the test-invoke provider. It is an
-// extension point for integration tests; observers can only be installed under
-// the test_dep build tag (see SetInvokeObserver), so it is inert otherwise.
-type InvokeObserver interface {
-	ObserveProviderInvoke(rc RequestContext, action string)
-}
-
-var (
-	invokeObserverMu sync.RWMutex
-	// invokeObservers maps a deployment build ID to the observer watching it,
-	// so concurrent tests each observe only their own build's actions.
-	invokeObservers = map[string]InvokeObserver{}
-)
-
-// emitProviderEvent reports an action to the observer registered for the
-// request's deployment build, if any.
-func emitProviderEvent(rc RequestContext, action string) {
-	invokeObserverMu.RLock()
-	o := invokeObservers[rc.DeploymentBuildID]
-	invokeObserverMu.RUnlock()
-	if o != nil {
-		o.ObserveProviderInvoke(rc, action)
-	}
 }
 
 // TestInvokeComputeProviderValidComputeProvider provides an example valid config for testing code to use

--- a/wci/workflow/compute_provider/test_worker_set.go
+++ b/wci/workflow/compute_provider/test_worker_set.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 
+	computepb "go.temporal.io/api/compute/v1"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/sdk"
 )
 
 const (
@@ -27,11 +29,12 @@ func (p *testWorkerSetComputeProvider) LaunchStrategy() LaunchStrategy {
 	return LaunchStrategyWorkerSet
 }
 
-func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, _ RequestContext, config ComputeProviderConfig) error {
+func (p *testWorkerSetComputeProvider) ValidateConfig(_ context.Context, rc RequestContext, config ComputeProviderConfig) error {
 	if _, ok := config[configTestWorkerSetIllegalField].(string); ok {
 		return fmt.Errorf("illegal_field found in config")
 	}
 
+	emitProviderEvent(rc, "validate")
 	return nil
 }
 
@@ -39,6 +42,31 @@ func (p *testWorkerSetComputeProvider) InvokeWorker(_ context.Context, _ Request
 	return errors.ErrUnsupported
 }
 
-func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, _ RequestContext, _ ComputeProviderConfig, _ int32) error {
+func (p *testWorkerSetComputeProvider) UpdateWorkerSetSize(_ context.Context, rc RequestContext, _ ComputeProviderConfig, count int32) error {
+	emitProviderEvent(rc, fmt.Sprintf("update-worker-set-size-%d", count))
 	return nil
+}
+
+// TestWorkerSetComputeProviderValidComputeProvider provides an example valid config for testing code to use
+func TestWorkerSetComputeProviderValidComputeProvider() *computepb.ComputeProvider {
+	providerDetails := map[string]string{}
+	payload, _ := sdk.PreferProtoDataConverter.ToPayload(providerDetails)
+
+	return &computepb.ComputeProvider{
+		Type:    string(iface.ComputeProviderTypeTestWorkerSet),
+		Details: payload,
+	}
+}
+
+// TestWorkerSetComputeProviderInvalidComputeProvider provides an example invalid config for testing code to use
+func TestWorkerSetComputeProviderInvalidComputeProvider() *computepb.ComputeProvider {
+	providerDetails := map[string]string{
+		configTestWorkerSetIllegalField: "something",
+	}
+	payload, _ := sdk.PreferProtoDataConverter.ToPayload(providerDetails)
+
+	return &computepb.ComputeProvider{
+		Type:    string(iface.ComputeProviderTypeTestWorkerSet),
+		Details: payload,
+	}
 }

--- a/wci/workflow/test_poll_hook.go
+++ b/wci/workflow/test_poll_hook.go
@@ -1,0 +1,23 @@
+//go:build test_dep
+
+package workflow
+
+import "time"
+
+// SetPollIntervalsForTest overrides the metrics-poll timing so integration tests
+// can exercise the poll-driven path — e.g. rate-based scale-down — without the
+// production 5-minute initial delay and 30-second cadence floor. initial sets the
+// first-poll delay and the cadence cap (maxPollInterval); floor sets the cadence
+// floor (minPollInterval). It returns a function that restores the previous
+// values. It exists only under the test_dep build tag, so production builds
+// cannot shorten the intervals.
+func SetPollIntervalsForTest(initial, floor time.Duration) func() {
+	prevMax := maxPollInterval
+	prevMin := minPollInterval
+	maxPollInterval = initial
+	minPollInterval = floor
+	return func() {
+		maxPollInterval = prevMax
+		minPollInterval = prevMin
+	}
+}


### PR DESCRIPTION
This adds support for integration coverage of the worker-set launch
strategy. This refactors the existing test_invoke and
test_invoke_observer to suport other compute providers instead of
simply invoke strategy.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This adds support for integration coverage of the worker-set launch
strategy. This refactors the existing test_invoke and
test_invoke_observer to suport other compute providers instead of
simply invoke strategy.


## Why?
<!-- Tell your future self why have you made these changes -->
Coverage of upcoming worker set compute provider.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
