### PR TITLE
Allow validating the current spec via an empty ValidateSpec request

### DIFF
--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -259,13 +259,9 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 }
 
 func (d *WorkflowRunner) validateValidateSpec(args *iface.ValidateSpecRequest) error {
-	if err := d.ensureNotDeleted(); err != nil {
-		return err
-	}
-	if len(args.RemoveScalingGroups) == 0 && len(args.UpsertScalingGroups) == 0 {
-		return temporal.NewApplicationError("no change found", iface.ErrFailedPrecondition)
-	}
-	return nil
+	// Unlike validateUpdateInstance, an empty request is valid here.
+	// It allows validating the current configuration rather than a dry-run of changes.
+	return d.ensureNotDeleted()
 }
 
 // handleValidateSpec is the handler for the validateSpec update request. It implements a dry-run for any submitted changes,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fix guardrail in `validateValidateSpec` to allow validating the current compute config spec on-demand. Sending an update request that has empty `RemoveScalingGroups`/`UpsertScalingGroups` indicates the current spec needs to be re-validated and is not a dry-run operation.

## Why?
<!-- Tell your future self why have you made these changes -->
Allows on-demand validation of existing compute config spec

## Checklist

1. How was this tested:
Built and deployed a custom WCI binary in a test cell

