### PR TITLE
COM-231: Skip task-queue registration when the queue already exists

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,16 @@
 [tools]
+go = "1.26.4"
 golangci-lint = "2.12.2"
+
+# Integration tests live in the ./tests module and require the test_dep build tag
+# (compute-observer spy hooks). TEMPORAL_ROOT keeps testcore's .testoutput out of the
+# read-only module cache. Extra args are appended, e.g. `mise run integration -- -run TestWCIWorkerSet`.
+[tasks.integration]
+description = "Run WCI integration tests (in-process Temporal server)"
+dir = "tests"
+env = { TEMPORAL_ROOT = "{{config_root}}" }
+run = "go test -tags=test_dep -timeout 300s ./integration/..."
+
+[tasks.lint-branch]
+description = "Lint changes since the merge-base with main"
+run = "make lint-branch"

--- a/tests/integration/worker_set_test.go
+++ b/tests/integration/worker_set_test.go
@@ -9,8 +9,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
 	computepb "go.temporal.io/api/compute/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	wciworkflow "go.temporal.io/auto-scaled-workers/wci/workflow"
@@ -164,12 +167,18 @@ func TestWCIWorkerSetScaleUpPastOne(t *testing.T) {
 	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
 	events := spy.events
 
+	// Fast poll cadence so the post-registration idle scale-down (poll-driven) fires within
+	// the test's deadline rather than at the 5-minute production default.
+	t.Cleanup(wciworkflow.SetPollIntervalsForTest(2*time.Second, 1*time.Second))
+
 	createWorkerDeployment(t, env, deploymentName)
 	createWorkerSetVersion(t, ctx, cli, namespace, version,
 		rateBasedScaler(map[string]string{"scale_up_cooldown_ms": "0"}))
 
 	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
-	drainEvents(t, events)
+	// Registration reconciles the scaler's model to 1; sync on the idle scale-down back to 0
+	// so the first backlog scale-up below is the expected 0->1 rather than a 1->2 step.
+	awaitWorkerSetSize(t, events, 0, 60*time.Second, "idle scale-down before backlog")
 
 	// First backlog workflow → first scale-up (0 -> 1).
 	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
@@ -295,8 +304,15 @@ func TestWCIWorkerSetMultipleVersionsScaleIndependently(t *testing.T) {
 
 	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID1, taskQueue)
 	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID2, taskQueue)
-	drainEvents(t, events1)
-	drainEvents(t, events2)
+
+	// Registration brings each worker set up to (and reconciles the scaler's model to) a
+	// non-zero size, after which the idle poll scales back to 0. Sync on that 0 so the
+	// backlog scale-up below is observed from a known-idle state — otherwise a version whose
+	// cap equals the registration size (v2, cap 1) already sits at cap and emits no scale-up
+	// event. awaitWorkerSetSize logs-and-skips the intervening registration events, so it also
+	// subsumes the drain.
+	awaitWorkerSetSize(t, events1, 0, 60*time.Second, "v1 idle scale-down before backlog")
+	awaitWorkerSetSize(t, events2, 0, 60*time.Second, "v2 idle scale-down before backlog")
 
 	// Backlog both versions (no pollers). v1 scales up to its cap of 2, v2 to 1 —
 	// each observed on its own observer, confirming independent, differently-sized
@@ -316,6 +332,171 @@ func TestWCIWorkerSetMultipleVersionsScaleIndependently(t *testing.T) {
 
 	awaitWorkerSetSize(t, events1, 0, 90*time.Second, "v1 scale-down to 0")
 	awaitWorkerSetSize(t, events2, 0, 90*time.Second, "v2 scale-down to 0")
+}
+
+// TestWCIWorkerSetUpdateDoesNotShrinkLiveSet is the regression guard for the core fix: a
+// compute-config update on a live worker set must never collapse it to 1. This group is a
+// catch-all (no declared task types), so the existence check does not skip it, but the
+// registration resize is sized to the algorithm's planned count — re-asserting the current
+// size (2) rather than the pre-fix bare 1. The set therefore never shrinks.
+func TestWCIWorkerSetUpdateDoesNotShrinkLiveSet(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := "workerset-noshrink-tq-" + deploymentName
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	createWorkerDeployment(t, env, deploymentName)
+	createWorkerSetVersion(t, ctx, cli, namespace, version, cappedRateBasedScaler(2))
+
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
+	drainEvents(t, events)
+
+	// Backlog with no poller drives the set up to its cap of 2 via the no-sync-match path.
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	submitPinnedWorkflow(t, ctx, cli, taskQueue, deploymentName, buildID)
+	awaitWorkerSetSize(t, events, 2, 60*time.Second, "scale-up to cap 2")
+	drainEvents(t, events)
+
+	// Update the (registered, live) version's scaler. handleUpdateInstance always runs
+	// InvokeWorkersToRegisterTaskQueues; the resize it issues must be sized to the planned
+	// count (2), so the set must never drop below 2 (the pre-fix bug collapsed it to 1).
+	updateWorkerSetScaler(t, ctx, cli, namespace, version, cappedRateBasedScaler(2))
+	assertNoWorkerSetShrink(t, events, 2, 6*time.Second, "updating a registered, live worker set")
+}
+
+// TestWCIWorkerSetUpdateOnRegisteredVersionSkipsResize verifies the existence-check skip on the
+// update path: when the group declares exactly the task type its worker registers (workflow),
+// an update to the already-registered version emits no registration resize at all (only a
+// validate). Under the pre-fix behavior the update would resize the set to 1.
+func TestWCIWorkerSetUpdateOnRegisteredVersionSkipsResize(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	taskQueue := "workerset-skip-tq-" + deploymentName
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	createWorkerDeployment(t, env, deploymentName)
+	// Declare task_queue_types=[workflow] so the group's effective types exactly match what the
+	// workflow-only test worker registers — otherwise a catch-all group also expects activity/nexus
+	// (never registered) and the "all registered" gate can never be satisfied.
+	cc := workerSetConfigWithScaler(cappedRateBasedScaler(2))
+	cc.GetScalingGroups()["default"].TaskQueueTypes = []enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW}
+	_, err := cli.WorkflowService().CreateWorkerDeploymentVersion(ctx,
+		&workflowservice.CreateWorkerDeploymentVersionRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			ComputeConfig:     cc,
+			RequestId:         uuid.NewString(),
+		})
+	require.NoError(t, err)
+
+	registerVersionTaskQueue(t, ctx, cli, namespace, deploymentName, buildID, taskQueue)
+	drainEvents(t, events)
+
+	// scaler.details-only update leaves task_queue_types intact, so the group's [workflow] is still
+	// fully registered → InvokeWorkersToRegisterTaskQueues skips → no resize event.
+	updateWorkerSetScaler(t, ctx, cli, namespace, version, cappedRateBasedScaler(2))
+	assertNoWorkerSetResize(t, events, 6*time.Second, "updating a registered, idle worker set")
+}
+
+// TestWCIWorkerSetRegistrationHonorsInitialCount verifies the registration resize is sized to
+// the scaler's planned count (initial_count), not a bare 1.
+func TestWCIWorkerSetRegistrationHonorsInitialCount(t *testing.T) {
+	env := createWCITestEnv(t)
+	ctx := env.Context()
+	cli := env.SdkClient()
+
+	namespace := env.Namespace().String()
+	deploymentName := uuid.NewString()
+	buildID := uuid.NewString()
+	version := &deploymentpb.WorkerDeploymentVersion{DeploymentName: deploymentName, BuildId: buildID}
+
+	spy := &invokeSpy{events: make(chan string, 16)}
+	t.Cleanup(computeprovider.SetComputeObserver(buildID, spy))
+	events := spy.events
+
+	createWorkerDeployment(t, env, deploymentName)
+	// initial_count=3 with headroom (max_count=5); registration should size the set to 3.
+	createWorkerSetVersion(t, ctx, cli, namespace, version,
+		rateBasedScaler(map[string]string{"initial_count": "3", "max_count": "5"}))
+
+	awaitWorkerSetSize(t, events, 3, 60*time.Second, "registration sizes to initial_count")
+}
+
+// updateWorkerSetScaler updates the "default" scaling group's scaler details on an existing
+// worker-set version, driving the WCI update path.
+func updateWorkerSetScaler(t *testing.T, ctx context.Context, cli sdkclient.Client, namespace string, version *deploymentpb.WorkerDeploymentVersion, scaler *computepb.ComputeScaler) {
+	t.Helper()
+	updated := workerSetConfigWithScaler(scaler)
+	_, err := cli.WorkflowService().UpdateWorkerDeploymentVersionComputeConfig(ctx,
+		&workflowservice.UpdateWorkerDeploymentVersionComputeConfigRequest{
+			Namespace:         namespace,
+			DeploymentVersion: version,
+			Identity:          "test-identity",
+			RequestId:         uuid.NewString(),
+			ComputeConfigScalingGroups: map[string]*computepb.ComputeConfigScalingGroupUpdate{
+				"default": {
+					ScalingGroup: updated.GetScalingGroups()["default"],
+					UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"scaler.details"}},
+				},
+			},
+		})
+	require.NoError(t, err)
+}
+
+// assertNoWorkerSetResize fails if any "update-worker-set-size" action is observed within the
+// window. Other provider actions (e.g. "validate") are logged and ignored.
+func assertNoWorkerSetResize(t *testing.T, events <-chan string, window time.Duration, desc string) {
+	t.Helper()
+	deadline := time.After(window)
+	for {
+		select {
+		case action := <-events:
+			if strings.HasPrefix(action, "update-worker-set-size") {
+				t.Fatalf("unexpected worker-set resize while %s: %s", desc, action)
+			}
+			t.Logf("ignoring provider action while %s: %s", desc, action)
+		case <-deadline:
+			return
+		}
+	}
+}
+
+// assertNoWorkerSetShrink fails if any "update-worker-set-size-N" with N < floor is observed
+// within the window. A resize that re-asserts the current size (N >= floor) is allowed; only a
+// shrink below floor fails. Non-resize actions (e.g. "validate") are ignored.
+func assertNoWorkerSetShrink(t *testing.T, events <-chan string, floor int, window time.Duration, desc string) {
+	t.Helper()
+	deadline := time.After(window)
+	for {
+		select {
+		case action := <-events:
+			if strings.HasPrefix(action, "update-worker-set-size") && parseWorkerSetCount(t, action) < floor {
+				t.Fatalf("unexpected worker-set shrink below %d while %s: %s", floor, desc, action)
+			}
+			t.Logf("provider action while %s: %s", desc, action)
+		case <-deadline:
+			return
+		}
+	}
 }
 
 // workerSetComputeConfig is the worker-set analog of testComputeConfig: the

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -9,7 +10,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/auto-scaled-workers/wci/client"
 	wcimetrics "go.temporal.io/auto-scaled-workers/wci/metrics"
@@ -36,11 +39,6 @@ const (
 var (
 	minPollInterval = 30 * time.Second
 	maxPollInterval = 5 * time.Minute
-
-	// registerTaskQueueWorkerSetSize is the instance count a worker-set provider is
-	// scaled to so a single worker comes up and registers the task queue. The scaling
-	// algorithm resizes the set from there.
-	registerTaskQueueWorkerSetSize int32 = 1
 )
 
 type (
@@ -121,6 +119,17 @@ type (
 	InvokeWorkersToRegisterTaskQueuesRequest struct {
 		RequestContext
 		iface.WorkerControllerInstanceSpec
+
+		// ScalingStatus is the per-group scaling status, used to size a worker-set
+		// registration resize to the algorithm's planned count.
+		ScalingStatus map[string]iface.ScalingAlgorithmStatus `json:"scaling_status,omitempty"`
+	}
+
+	InvokeWorkersToRegisterTaskQueuesResponse struct {
+		// UpdatedScalingStatus is the complete next-state scaling status for every group in
+		// the spec: resized groups carry their reconciled count, skipped (already-registered)
+		// groups carry their prior status forward. The workflow assigns it wholesale.
+		UpdatedScalingStatus map[string]iface.ScalingAlgorithmStatus `json:"scaling_status,omitempty"`
 	}
 )
 
@@ -244,52 +253,109 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 	return nil
 }
 
-func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req *InvokeWorkersToRegisterTaskQueuesRequest) error {
+func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req *InvokeWorkersToRegisterTaskQueuesRequest) (*InvokeWorkersToRegisterTaskQueuesResponse, error) {
 	if req == nil {
-		return temporal.NewApplicationError("Invalid activity request", "InternalError")
+		return nil, temporal.NewApplicationError("Invalid activity request", "InternalError")
 	}
 
+	logger := activity.GetLogger(ctx)
 	metricsHandler := metricsHandler(ctx, req.RequestContext, wcimetrics.ActivityTypeInvokeWorkersToRegisterTaskQueues, noComputeProvider)
-	_, _, recordSuccess := newActivityRecorders(metricsHandler)
+	recordError, _, recordSuccess := newActivityRecorders(metricsHandler)
+
+	// A task queue type is registered once a worker has polled it under this version;
+	// the association is durable for the version's lifetime, so there's no need for a
+	// worker invocation. Fail open (empty set results in a worker invocation) so a describe hiccup
+	// cannot block an update.
+	registered, err := a.registeredTaskQueueTypes(ctx, req.NamespaceName, req.DeploymentName, req.DeploymentBuildID)
+	if err != nil {
+		// Exception: on rate limiting, don't fail open. Powering through invokes a worker for every
+		// group, resulting in extra load that worsens the throttling. Abort so the
+		// caller backs off and retries once capacity returns.
+		var rateLimited *serviceerror.ResourceExhausted
+		if stderrors.As(err, &rateLimited) {
+			recordError(wcimetrics.ErrorTypeDescribeWorkerDeploymentVersionFailed)
+			return nil, temporal.NewApplicationErrorWithCause(err.Error(), "ResourceExhausted", err)
+		}
+		logger.Warn("Could not determine registered task queues; invoking workers unconditionally", "error", err)
+	}
+
+	updatedScalingStatus := map[string]iface.ScalingAlgorithmStatus{}
 
 	for k, v := range req.ScalingGroupSpecs {
 		// Errors here are attributable to this specific scaling group's provider.
 		recordError, _, _ := newActivityRecorders(computeProviderMetrics(metricsHandler, v.Compute.ProviderType))
 
+		if prior := req.ScalingStatus[k]; prior != nil {
+			updatedScalingStatus[k] = prior
+		}
+
+		// Skip groups whose task types are all already registered: a worker of that type
+		// has polled before, so the queue exists and any live worker set must not be disturbed.
+		if taskTypesAllRegistered(req.EffectiveTaskTypesForGroup(k), registered) {
+			logger.Debug("Task queues already registered; skipping worker invocation", "scaling_group_key", k)
+			continue
+		}
+
 		provider, err := computeprovider.GetComputeProvider(ctx, v.Compute.ProviderType, a.namespace.Name().String(), a.dc)
 		if err != nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
+			return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 		}
 		if provider == nil {
 			recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
-			return temporal.NewApplicationError(fmt.Sprintf("%s: '%s' is an unknown compute provider", k, v.Compute.ProviderType), "InvalidArgument")
+			return nil, temporal.NewApplicationError(fmt.Sprintf("%s: '%s' is an unknown compute provider", k, v.Compute.ProviderType), "InvalidArgument")
 		}
 
 		config := map[string]any{}
 		if err := sdk.PreferProtoDataConverter.FromPayload(v.Compute.Config, &config); err != nil {
 			recordError(wcimetrics.ErrorTypeInvalidRequest)
-			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
+			return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 		}
 
-		switch provider.LaunchStrategy() {
-		case computeprovider.LaunchStrategyInvoke:
-			// Invoke a single worker; it registers the task queue then exits.
-			if err := provider.InvokeWorker(ctx, req.RequestContext, config); err != nil {
-				recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
+		// The algorithm decides both the launch strategy and the resize target: it returns an
+		// InvokeWorker (invoke-only) or an UpdateWorkerSetSize sized to its floor/initial count,
+		// plus the reconciled status to persist. This keeps the count inside the algorithm rather
+		// than the activity reading/writing it out of band.
+		algo, scalingConfig, err := a.getScalingAlgorithmAndConfig(ctx, v)
+		if err != nil {
+			recordError(wcimetrics.ErrorTypeAlgorithmFailed)
+			return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
+		}
+		regResp, err := algo.TaskQueueRegistrationActions(ctx, scalingConfig, req.ScalingStatus[k])
+		if err != nil {
+			recordError(wcimetrics.ErrorTypeAlgorithmFailed)
+			return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "AlgorithmFailed", err)
+		}
+
+		for _, action := range regResp.Actions {
+			switch action.Action {
+			case scalingalgorithm.ActionTypeInvokeWorker:
+				if err := provider.InvokeWorker(ctx, req.RequestContext, config); err != nil {
+					recordError(wcimetrics.ErrorTypeComputeProviderFailed)
+					return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
+				}
+			case scalingalgorithm.ActionTypeUpdateWorkerSetSize:
+				if action.Count == nil {
+					recordError(wcimetrics.ErrorTypeInvalidRequest)
+					return nil, temporal.NewApplicationError(fmt.Sprintf("%s: registration action %q missing count", k, action.Action), "InternalError")
+				}
+				if err := provider.UpdateWorkerSetSize(ctx, req.RequestContext, config, *action.Count); err != nil {
+					recordError(wcimetrics.ErrorTypeComputeProviderFailed)
+					return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
+				}
+			default:
+				recordError(wcimetrics.ErrorTypeInvalidRequest)
+				return nil, temporal.NewApplicationError(fmt.Sprintf("%s: unexpected registration action %q", k, action.Action), "InternalError")
 			}
-		case computeprovider.LaunchStrategyWorkerSet:
-			// Scale the set up so a worker comes up and registers the task queue.
-			if err := provider.UpdateWorkerSetSize(ctx, req.RequestContext, config, registerTaskQueueWorkerSetSize); err != nil {
-				recordError(wcimetrics.ErrorTypeComputeProviderFailed)
-				return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvokeWorkerFailed", err)
-			}
+		}
+
+		if regResp.Status != nil {
+			updatedScalingStatus[k] = regResp.Status
 		}
 	}
 
 	recordSuccess()
-	return nil
+	return &InvokeWorkersToRegisterTaskQueuesResponse{UpdatedScalingStatus: updatedScalingStatus}, nil
 }
 
 func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivityRequest) error {

--- a/wci/workflow/activities_test.go
+++ b/wci/workflow/activities_test.go
@@ -10,18 +10,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	wcimetrics "go.temporal.io/auto-scaled-workers/wci/metrics"
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	scalingalgorithm "go.temporal.io/auto-scaled-workers/wci/workflow/scaling_algorithm"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	sdkworkflow "go.temporal.io/sdk/workflow"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/sdk"
-	"google.golang.org/grpc"
 )
 
 func newTestSignalTaskAddEvent() iface.SignalTaskAddRequest {
@@ -78,6 +84,10 @@ func (a *deferredScalingDecisionTestAlgorithm) CompatibleLaunchStrategies() []co
 
 func (a *deferredScalingDecisionTestAlgorithm) ValidateConfig(context.Context, iface.ScalingAlgorithmConfig) error {
 	return nil
+}
+
+func (a *deferredScalingDecisionTestAlgorithm) TaskQueueRegistrationActions(_ context.Context, _ iface.ScalingAlgorithmConfig, status iface.ScalingAlgorithmStatus) (*scalingalgorithm.TaskQueueRegistrationResponse, error) {
+	return &scalingalgorithm.TaskQueueRegistrationResponse{Status: status}, nil
 }
 
 func (a *deferredScalingDecisionTestAlgorithm) ProcessTaskAdd(
@@ -853,5 +863,196 @@ func TestHandleDeferredScalingDecisionMemoizesMetricsSnapshotErrorSticky(t *test
 		assert.Nil(t, c.snap, "call %d", i)
 		require.Error(t, c.err, "call %d", i)
 		assert.ErrorIs(t, c.err, pullErr, "call %d: cached error must equal the original RPC error", i)
+	}
+}
+
+// stateWorkerCountKey mirrors the unexported rate-based state key (worker_count); the
+// registration path writes the resized worker count here so the algorithm's model matches reality.
+const stateWorkerCountKey = "worker_count"
+
+func describeResponseWithTypes(types ...enumspb.TaskQueueType) *workflowservice.DescribeWorkerDeploymentVersionResponse {
+	resp := &workflowservice.DescribeWorkerDeploymentVersionResponse{}
+	for _, ty := range types {
+		resp.VersionTaskQueues = append(resp.VersionTaskQueues, &workflowservice.DescribeWorkerDeploymentVersionResponse_VersionTaskQueue{
+			Name: "test-queue",
+			Type: ty,
+		})
+	}
+	return resp
+}
+
+// rateBasedWorkerSetGroup builds a worker-set (test provider) scaling group backed by the
+// real rate-based algorithm with the given initial_count for the registration logic to use.
+func rateBasedWorkerSetGroup(t *testing.T, taskType enumspb.TaskQueueType, initialCount int64) iface.ScalingGroupSpec {
+	t.Helper()
+	scalingCfg, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{"initial_count": initialCount})
+	require.NoError(t, err)
+	computeCfg, err := sdk.PreferProtoDataConverter.ToPayload(map[string]any{})
+	require.NoError(t, err)
+	return iface.ScalingGroupSpec{
+		TaskTypes: []enumspb.TaskQueueType{taskType},
+		Compute:   iface.ComputeProviderSpec{ProviderType: iface.ComputeProviderTypeTestWorkerSet, Config: computeCfg},
+		Scaling:   &iface.ScalingAlgorithmSpec{ScalingAlgorithm: iface.ScalingAlgorithmRateBased, Config: scalingCfg},
+	}
+}
+
+func runInvokeWorkersToRegisterTaskQueues(t *testing.T, fake *fakeWorkflowServiceClient, spec iface.WorkerControllerInstanceSpec, scalingStatus map[string]iface.ScalingAlgorithmStatus) *InvokeWorkersToRegisterTaskQueuesResponse {
+	t.Helper()
+	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, "active")
+	activities := NewActivities(ns, dynamicconfig.NewNoopCollection(), fake)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.InvokeWorkersToRegisterTaskQueues)
+	encoded, err := env.ExecuteActivity(activities.InvokeWorkersToRegisterTaskQueues, &InvokeWorkersToRegisterTaskQueuesRequest{
+		RequestContext: RequestContext{
+			NamespaceName:     "test-namespace",
+			DeploymentName:    "test-deployment",
+			DeploymentBuildID: "test-build",
+		},
+		WorkerControllerInstanceSpec: spec,
+		ScalingStatus:                scalingStatus,
+	})
+	require.NoError(t, err)
+	var resp InvokeWorkersToRegisterTaskQueuesResponse
+	require.NoError(t, encoded.Get(&resp))
+	return &resp
+}
+
+// runInvokeWorkersToRegisterTaskQueuesErr runs the activity and returns its error instead of
+// failing the test, for cases that assert the activity aborts.
+func runInvokeWorkersToRegisterTaskQueuesErr(t *testing.T, fake *fakeWorkflowServiceClient, spec iface.WorkerControllerInstanceSpec) (*InvokeWorkersToRegisterTaskQueuesResponse, error) {
+	t.Helper()
+	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, "active")
+	activities := NewActivities(ns, dynamicconfig.NewNoopCollection(), fake)
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestActivityEnvironment()
+	env.RegisterActivity(activities.InvokeWorkersToRegisterTaskQueues)
+	encoded, err := env.ExecuteActivity(activities.InvokeWorkersToRegisterTaskQueues, &InvokeWorkersToRegisterTaskQueuesRequest{
+		RequestContext: RequestContext{
+			NamespaceName:     "test-namespace",
+			DeploymentName:    "test-deployment",
+			DeploymentBuildID: "test-build",
+		},
+		WorkerControllerInstanceSpec: spec,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var resp InvokeWorkersToRegisterTaskQueuesResponse
+	require.NoError(t, encoded.Get(&resp))
+	return &resp, nil
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_SkipsRegistered(t *testing.T) {
+	fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+		return describeResponseWithTypes(enumspb.TASK_QUEUE_TYPE_WORKFLOW), nil
+	}}
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"group": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 5),
+	}}
+
+	resp := runInvokeWorkersToRegisterTaskQueues(t, fake, spec, nil)
+
+	assert.Equal(t, 1, fake.describeCalls)
+	assert.Empty(t, resp.UpdatedScalingStatus, "a registered group must be skipped: no resize, no writeback")
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_ResizesUnregisteredToInitial(t *testing.T) {
+	fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+		// Activity type is registered, workflow (this group) is not.
+		return describeResponseWithTypes(enumspb.TASK_QUEUE_TYPE_ACTIVITY), nil
+	}}
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"group": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 5),
+	}}
+
+	resp := runInvokeWorkersToRegisterTaskQueues(t, fake, spec, nil)
+
+	require.Contains(t, resp.UpdatedScalingStatus, "group")
+	assert.Equal(t, int64(5), resp.UpdatedScalingStatus["group"].GetInt64Field(stateWorkerCountKey, -1),
+		"an unregistered group must be resized to and written back at initial_count, not 1")
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_InitialZeroResizesToOne(t *testing.T) {
+	fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+		return describeResponseWithTypes(), nil // nothing registered
+	}}
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"group": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 0),
+	}}
+
+	resp := runInvokeWorkersToRegisterTaskQueues(t, fake, spec, nil)
+
+	require.Contains(t, resp.UpdatedScalingStatus, "group")
+	assert.Equal(t, int64(1), resp.UpdatedScalingStatus["group"].GetInt64Field(stateWorkerCountKey, -1),
+		"initial_count=0 must still resize to 1 for registration and write back 1 so the next poll can scale to 0")
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_DescribeErrorFailsOpen(t *testing.T) {
+	fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+		return nil, errors.New("describe unavailable")
+	}}
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"group": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 0),
+	}}
+
+	resp := runInvokeWorkersToRegisterTaskQueues(t, fake, spec, nil)
+
+	assert.Equal(t, 1, fake.describeCalls)
+	require.Contains(t, resp.UpdatedScalingStatus, "group",
+		"a describe failure must fail open and still resize the group")
+	assert.Equal(t, int64(1), resp.UpdatedScalingStatus["group"].GetInt64Field(stateWorkerCountKey, -1))
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_CarriesForwardSkippedGroupStatus(t *testing.T) {
+	// "registered" is already registered (skipped); "fresh" is not and gets resized.
+	fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+		return describeResponseWithTypes(enumspb.TASK_QUEUE_TYPE_ACTIVITY), nil
+	}}
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"registered": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_ACTIVITY, 5),
+		"fresh":      rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 3),
+	}}
+	scalingStatus := map[string]iface.ScalingAlgorithmStatus{
+		"registered": {stateWorkerCountKey: int64(7)},
+	}
+
+	resp := runInvokeWorkersToRegisterTaskQueues(t, fake, spec, scalingStatus)
+
+	// The response is the complete next-state: the skipped group's live count is carried
+	// forward untouched, and the fresh group is reconciled to its initial count.
+	require.Contains(t, resp.UpdatedScalingStatus, "registered")
+	assert.Equal(t, int64(7), resp.UpdatedScalingStatus["registered"].GetInt64Field(stateWorkerCountKey, -1),
+		"a skipped group's live count must be carried forward, not dropped or reset")
+	require.Contains(t, resp.UpdatedScalingStatus, "fresh")
+	assert.Equal(t, int64(3), resp.UpdatedScalingStatus["fresh"].GetInt64Field(stateWorkerCountKey, -1))
+}
+
+func TestInvokeWorkersToRegisterTaskQueues_RateLimitFailsClosed(t *testing.T) {
+	spec := iface.WorkerControllerInstanceSpec{ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+		"group": rateBasedWorkerSetGroup(t, enumspb.TASK_QUEUE_TYPE_WORKFLOW, 0),
+	}}
+
+	// The rate-limit error may arrive bare or wrapped; errors.As must unwrap it either way.
+	cases := map[string]error{
+		"bare":    serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "slow down"),
+		"wrapped": errors.Join(errors.New("describe failed"), serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "slow down")),
+	}
+	for name, describeErr := range cases {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+				return nil, describeErr
+			}}
+
+			_, err := runInvokeWorkersToRegisterTaskQueuesErr(t, fake, spec)
+
+			assert.Equal(t, 1, fake.describeCalls, "must not power through to a worker invocation on rate limiting")
+			var appErr *temporal.ApplicationError
+			require.ErrorAs(t, err, &appErr)
+			assert.Equal(t, "ResourceExhausted", appErr.Type(),
+				"rate limiting must abort with a ResourceExhausted error rather than fail open and add load")
+		})
 	}
 }

--- a/wci/workflow/register_task_queues.go
+++ b/wci/workflow/register_task_queues.go
@@ -1,0 +1,53 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	deploymentpb "go.temporal.io/api/deployment/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+)
+
+// registeredTaskQueueTypes returns the set of task queue types already registered for the
+// given worker deployment version. A type is present once a worker has polled it under this
+// version, and the association is durable for the version's lifetime. Stats are not requested;
+// only the queue identities are needed.
+func (a *Activities) registeredTaskQueueTypes(ctx context.Context, namespaceName, deploymentName, deploymentBuildID string) (map[enumspb.TaskQueueType]struct{}, error) {
+	resp, err := a.workflowserviceClient.DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
+		Namespace: namespaceName,
+		DeploymentVersion: &deploymentpb.WorkerDeploymentVersion{
+			DeploymentName: deploymentName,
+			BuildId:        deploymentBuildID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("did not receive details in the describe response")
+	}
+
+	registered := map[enumspb.TaskQueueType]struct{}{}
+	for _, taskQueue := range resp.VersionTaskQueues {
+		if taskQueue == nil {
+			continue
+		}
+		registered[taskQueue.Type] = struct{}{}
+	}
+	return registered, nil
+}
+
+// taskTypesAllRegistered reports whether every task type in want is present in registered.
+// An empty want means no queue is yet known to exist, so it returns false to force a bootstrap invocation.
+func taskTypesAllRegistered(want []enumspb.TaskQueueType, registered map[enumspb.TaskQueueType]struct{}) bool {
+	if len(want) == 0 {
+		return false
+	}
+	for _, taskQueue := range want {
+		if _, ok := registered[taskQueue]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/wci/workflow/register_task_queues_test.go
+++ b/wci/workflow/register_task_queues_test.go
@@ -1,0 +1,48 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	workflowservice "go.temporal.io/api/workflowservice/v1"
+)
+
+func TestTaskTypesAllRegistered(t *testing.T) {
+	registered := map[enumspb.TaskQueueType]struct{}{
+		enumspb.TASK_QUEUE_TYPE_WORKFLOW: {},
+		enumspb.TASK_QUEUE_TYPE_ACTIVITY: {},
+	}
+
+	assert.True(t, taskTypesAllRegistered([]enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW}, registered))
+	assert.True(t, taskTypesAllRegistered([]enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW, enumspb.TASK_QUEUE_TYPE_ACTIVITY}, registered))
+	assert.False(t, taskTypesAllRegistered([]enumspb.TaskQueueType{enumspb.TASK_QUEUE_TYPE_WORKFLOW, enumspb.TASK_QUEUE_TYPE_NEXUS}, registered),
+		"a single unregistered type must force a worker invocation")
+	assert.False(t, taskTypesAllRegistered(nil, registered),
+		"empty want means nothing is known to exist yet, so it must not be treated as satisfied")
+}
+
+func TestRegisteredTaskQueueTypes(t *testing.T) {
+	t.Run("parses registered types", func(t *testing.T) {
+		fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+			return describeResponseWithTypes(enumspb.TASK_QUEUE_TYPE_WORKFLOW, enumspb.TASK_QUEUE_TYPE_ACTIVITY), nil
+		}}
+		got, err := NewActivities(nil, nil, fake).registeredTaskQueueTypes(t.Context(), "ns", "dep", "build")
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Contains(t, got, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+		assert.Contains(t, got, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	})
+
+	t.Run("propagates describe error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		fake := &fakeWorkflowServiceClient{describeFn: func(*workflowservice.DescribeWorkerDeploymentVersionRequest) (*workflowservice.DescribeWorkerDeploymentVersionResponse, error) {
+			return nil, wantErr
+		}}
+		_, err := NewActivities(nil, nil, fake).registeredTaskQueueTypes(t.Context(), "ns", "dep", "build")
+		assert.ErrorIs(t, err, wantErr)
+	})
+}

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -85,6 +85,15 @@ func (a *scalingAlgorithmNoSync) CompatibleLaunchStrategies() []computeprovider.
 	return []computeprovider.LaunchStrategy{computeprovider.LaunchStrategyInvoke}
 }
 
+// TaskQueueRegistrationActions registers by invoking a single worker (no-sync is invoke-only); there is
+// no worker set to size, so the status is returned unchanged.
+func (a *scalingAlgorithmNoSync) TaskQueueRegistrationActions(_ context.Context, _ iface.ScalingAlgorithmConfig, status iface.ScalingAlgorithmStatus) (*TaskQueueRegistrationResponse, error) {
+	return &TaskQueueRegistrationResponse{
+		Actions: []ScalingAction{{Action: ActionTypeInvokeWorker}},
+		Status:  status,
+	}, nil
+}
+
 func (a *scalingAlgorithmNoSync) ValidateConfig(ctx context.Context, config iface.ScalingAlgorithmConfig) error {
 	if config == nil {
 		return nil

--- a/wci/workflow/scaling_algorithm/rate_based.go
+++ b/wci/workflow/scaling_algorithm/rate_based.go
@@ -785,6 +785,24 @@ func currentRateBasedPlannedCount(config iface.ScalingAlgorithmConfig, state ifa
 	return int32(config.GetInt64Field(configRateBasedInitialCountKey, configRateBasedInitialCountDefault))
 }
 
+func (a *scalingAlgorithmRateBased) TaskQueueRegistrationActions(ctx context.Context, config iface.ScalingAlgorithmConfig, status iface.ScalingAlgorithmStatus) (*TaskQueueRegistrationResponse, error) {
+	updatedState := cleanRateBasedState(ctx, status)
+	planned := currentRateBasedPlannedCount(config, updatedState)
+	// Clamp to the configured bounds: a stored count can outlive a config change that
+	// lowered max_count, and the algorithm would never actually run outside [min, max].
+	minCount := int32(config.GetInt64Field(configRateBasedMinCountKey, configRateBasedMinCountDefault))
+	maxCount := int32(config.GetInt64Field(configRateBasedMaxCountKey, configRateBasedMaxCountDefault))
+	// At least 1 so a worker comes up to register the queue; fold the size back into the
+	// state so the next decision reconciles with the resize (closes the initial_count==0
+	// orphan where the registration worker would otherwise never scale to 0).
+	size := max(int32(1), min(max(planned, minCount), maxCount))
+	updatedState[stateRateBasedWorkerCount] = int64(size)
+	return &TaskQueueRegistrationResponse{
+		Actions: []ScalingAction{{Action: ActionTypeUpdateWorkerSetSize, Count: &size}},
+		Status:  updatedState,
+	}, nil
+}
+
 func estimatedRateBasedPerConsumerCapacity(config iface.ScalingAlgorithmConfig, state iface.ScalingAlgorithmStatus) float64 {
 	fallback := config.GetFloat64Field(configRateBasedInitialPerConsumerCapacityKey, configRateBasedInitialPerConsumerCapacityDefault)
 	if estimate, ok := state[stateRateBasedEWMAPerConsumerCapacity].(float64); ok && isPositiveFinite(estimate) {

--- a/wci/workflow/scaling_algorithm/rate_based_test.go
+++ b/wci/workflow/scaling_algorithm/rate_based_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
@@ -23,6 +24,63 @@ func newRateBased() *scalingAlgorithmRateBased {
 
 func oldMs() int64 {
 	return time.Now().Add(-time.Hour).UnixMilli()
+}
+
+func TestRateBasedTaskQueueRegistrationActions(t *testing.T) {
+	a := newRateBased()
+
+	// regSize runs TaskQueueRegistrationActions and asserts it emits exactly one UpdateWorkerSetSize
+	// whose count is folded back into the returned status; it returns that count.
+	regSize := func(t *testing.T, config iface.ScalingAlgorithmConfig, status iface.ScalingAlgorithmStatus) int32 {
+		t.Helper()
+		resp, err := a.TaskQueueRegistrationActions(t.Context(), config, status)
+		require.NoError(t, err)
+		require.Len(t, resp.Actions, 1)
+		require.Equal(t, ActionTypeUpdateWorkerSetSize, resp.Actions[0].Action)
+		require.NotNil(t, resp.Actions[0].Count)
+		assert.Equal(t, int64(*resp.Actions[0].Count), resp.Status.GetInt64Field(stateRateBasedWorkerCount, -1),
+			"the resize target must be folded back into the status")
+		return *resp.Actions[0].Count
+	}
+
+	t.Run("unset status resizes to initial_count", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(5)}
+		assert.Equal(t, int32(5), regSize(t, config, nil))
+	})
+
+	t.Run("no status and no initial_count floors to 1 (default initial_count is 0)", func(t *testing.T) {
+		require.Equal(t, int64(0), configRateBasedInitialCountDefault)
+		assert.Equal(t, int32(1), regSize(t, iface.ScalingAlgorithmConfig{}, iface.ScalingAlgorithmStatus{}))
+	})
+
+	t.Run("stored worker_count wins over initial_count", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(5)}
+		status := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: int64(3)}
+		assert.Equal(t, int32(3), regSize(t, config, status))
+	})
+
+	t.Run("garbage stored worker_count is dropped, falls back to initial_count", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(5)}
+		status := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: "not-a-number"}
+		assert.Equal(t, int32(5), regSize(t, config, status))
+	})
+
+	t.Run("stored count above max_count is clamped to max_count", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedMaxCountKey: int64(5)}
+		status := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: int64(10)}
+		assert.Equal(t, int32(5), regSize(t, config, status))
+	})
+
+	t.Run("stored count below min_count is clamped to min_count", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedMinCountKey: int64(3)}
+		status := iface.ScalingAlgorithmStatus{stateRateBasedWorkerCount: int64(1)}
+		assert.Equal(t, int32(3), regSize(t, config, status))
+	})
+
+	t.Run("initial_count 0 still resizes to at least 1", func(t *testing.T) {
+		config := iface.ScalingAlgorithmConfig{configRateBasedInitialCountKey: int64(0)}
+		assert.Equal(t, int32(1), regSize(t, config, nil))
+	})
 }
 
 func staticMetricsSnapshotGetter(snapshot ScalingMetricsSnapshot, callCount *int) ScalingMetricsSnapshotGetter {

--- a/wci/workflow/scaling_algorithm/registry.go
+++ b/wci/workflow/scaling_algorithm/registry.go
@@ -53,6 +53,16 @@ type (
 		NextPoll *time.Duration
 	}
 
+	TaskQueueRegistrationResponse struct {
+		// Actions contains the scaling actions that bring a group's worker set up enough to
+		// register its task queues (an UpdateWorkerSetSize for worker-set algorithms, an
+		// InvokeWorker for invoke-only ones).
+		Actions []ScalingAction
+		// Status is the reconciled status to persist, so a later decision does not see a
+		// phantom count for a resize made on the registration path.
+		Status iface.ScalingAlgorithmStatus
+	}
+
 	ScalingAlgorithm interface {
 		// CompatibleLaunchStrategies returns the list of launch strategies the scaling algorithm can work with
 		CompatibleLaunchStrategies() []computeprovider.LaunchStrategy
@@ -90,6 +100,14 @@ type (
 		//
 		// The returned Actions MUST NOT contain ActionTypeDeferredScalingDecision as it is not supported.
 		ProcessMetricsPoll(ctx context.Context, config iface.ScalingAlgorithmConfig, priorStatus iface.ScalingAlgorithmStatus, metricsSnapshot ScalingMetricsSnapshot) (*MetricsPollResponse, error)
+
+		// TaskQueueRegistrationActions returns the actions that bring a group's worker set up enough to
+		// register its task queues, plus the reconciled status. The algorithm owns both the size
+		// and the launch strategy: worker-set algorithms emit an UpdateWorkerSetSize sized to
+		// their floor/initial count (at least 1) and fold that count into the returned Status;
+		// invoke-only algorithms emit an InvokeWorker and leave Status untouched. The caller
+		// applies the actions and persists the Status.
+		TaskQueueRegistrationActions(ctx context.Context, config iface.ScalingAlgorithmConfig, status iface.ScalingAlgorithmStatus) (*TaskQueueRegistrationResponse, error)
 	}
 )
 

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	wcimetrics "go.temporal.io/auto-scaled-workers/wci/metrics"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
@@ -15,7 +18,6 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 	worker_versioning "go.temporal.io/server/common/worker_versioning"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -394,24 +396,32 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		}
 
 		// we need to scale up each of the groups for a moment to get them to register the task queues
+		var regResp InvokeWorkersToRegisterTaskQueuesResponse
 		if err := workflow.ExecuteActivity(
 			workflow.WithActivityOptions(ctx, workflow.ActivityOptions{StartToCloseTimeout: RegisterTaskQueuesViaWorkersActivityTimeout, RetryPolicy: &temporal.RetryPolicy{MaximumAttempts: 1}}),
 			d.a.InvokeWorkersToRegisterTaskQueues,
 			&InvokeWorkersToRegisterTaskQueuesRequest{
 				RequestContext:               d.requestContext(),
 				WorkerControllerInstanceSpec: *updatedSpec,
+				ScalingStatus:                d.State.ScalingStatus,
 			},
-		).Get(ctx, nil); err != nil {
+		).Get(ctx, &regResp); err != nil {
 			d.recordUpdate(wcimetrics.UpdateTypeUpdateInstance, wcimetrics.ErrorTypeActivityError, classifyActivityErrorType(err))
 
 			if appErr, ok := errors.AsType[*temporal.ApplicationError](err); ok {
-				if appErr.Type() == "InvalidArgument" {
+				switch appErr.Type() {
+				case "InvalidArgument":
 					return nil, serviceerror.NewInvalidArgumentf("%s", appErr.Message())
+				case "ResourceExhausted":
+					// no need to pass through the cause as the client will strip that before returning
+					return nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_UNSPECIFIED, appErr.Message())
 				}
 				return nil, serviceerror.NewFailedPreconditionf("%s", appErr.Message())
 			}
 			return nil, err
 		}
+
+		d.State.ScalingStatus = regResp.UpdatedScalingStatus
 
 		d.State.ValidationStatus = iface.NewValidationStatusSuccess(validationTime)
 		d.signalVersionWorkflow(ctx)


### PR DESCRIPTION
Only update worker size set when task queues don't exists. When updating the worker size set take into account min, initial and current number of instances (and write-back to the scaling algorithm the value.)

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This change gates registration on actual queue existence and sizes it off the algorithm's planned count:
- Query `DescribeWorkerDeploymentVersion.VersionTaskQueues` and skip any group whose task types are all already registered. The association is durable for the version's lifetime, so registered groups need no invocation and their live worker sets are left untouched. Fail open (invoke on describe error) so a transient failure can't block an update.
- For groups that **do need** registration (at least one queue type missing), sets the worker-set resize to `max(1, PlannedCount)` so it honors min/initial (instead of clobbering to 1). Then write the size back into the algorithm's status so the next metrics poll sees the real count.

## Why?
<!-- Tell your future self why have you made these changes -->
The call to`InvokeWorkersToRegisterTaskQueues` unconditionally resized every worker-set group to `1` on each spec update, which desynced the rate-based algorithm's model (`stateRateBasedWorkerCount`, whose unset fallback is `initial_count`) from provider reality: it could shrink a live set, under-provision below the configured floor, or strand/orphan a registration worker at `1` when the algorithm believed instance count to be `0`.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
- [COM-231](https://temporalio.atlassian.net/browse/COM-231)
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Unit tests
- Integration tests
- Manual testing, details in [COM-231](https://temporalio.atlassian.net/browse/COM-231)
3. Any docs updates needed?
- None

[COM-231]: https://temporalio.atlassian.net/browse/COM-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ