### PR TITLE
Gate AWS Lambda ExternalID enforcement behind require_role_and_external_id

### DIFF
--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -73,8 +73,11 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ Request
 		return fmt.Errorf("cannot access the compute resource: %w", err)
 	}
 
-	if err := p.checkExternalID(ctx, cfg, arn); err != nil {
-		return fmt.Errorf("IAM role trust policy does not enforce ExternalID condition: %w", err)
+	// Only enforce the ExternalID trust-policy check when role/external-ID are required.
+	if p.requireRoleAndExternalID {
+		if err := p.checkExternalID(ctx, cfg, arn); err != nil {
+			return fmt.Errorf("IAM role trust policy does not enforce ExternalID condition: %w", err)
+		}
 	}
 
 	return nil

--- a/wci/workflow/compute_provider/aws_lambda_test.go
+++ b/wci/workflow/compute_provider/aws_lambda_test.go
@@ -277,3 +277,29 @@ func TestAWSLambdaValidateConfig_ExternalIDSkipped_WhenRoleMissing(t *testing.T)
 	require.NoError(t, p.ValidateConfig(t.Context(), RequestContext{}, cfg))
 	assert.False(t, called, "verifyExternalIDEnforcedFn should not be called without role and external ID")
 }
+
+func TestAWSLambdaValidateConfig_ExternalIDSkipped_WhenNotRequired(t *testing.T) {
+	stubLambdaClient(t, &mockLambdaClient{
+		getFunctionFn: func(_ context.Context, _ *lambda.GetFunctionInput, _ ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error) {
+			return &lambda.GetFunctionOutput{}, nil
+		},
+	})
+
+	called := false
+	stubVerifyExternalID(t, func(_ context.Context, _, _ string, _ [][]client.AWSIAMRoleRequest) error {
+		called = true
+		return nil
+	})
+
+	// require_role_and_external_id=false governs enforcement, not just presence:
+	// even with role and external ID present, the enforcement probe is skipped.
+	p := &awsLambdaComputeProvider{requireRoleAndExternalID: false}
+	cfg := ComputeProviderConfig{
+		configAWSLambdaARN:            testLambdaARN,
+		configAWSLambdaRole:           testRoleARN,
+		configAWSLambdaRoleExternalID: "my-eid",
+	}
+
+	require.NoError(t, p.ValidateConfig(t.Context(), RequestContext{}, cfg))
+	assert.False(t, called, "verifyExternalIDEnforcedFn should not be called when require_role_and_external_id is false")
+}


### PR DESCRIPTION
Gate the `checkExternalID` enforcement probe behind `require_role_and_external_id` so the flag governs the whole role/external-ID behavior, not just presence. Previously the probe always ran when a role + external ID were present, calling `AssumeRole` without the external ID and expecting `AccessDenied` — which a permissive local STS (e.g. LocalStack) never returns, blocking local dev validation of serverless workers.

Default stays `true`, so production is unchanged. Set `false` only on isolated local/dev clusters.
