### PR TITLE
Re-remove the 'server main' integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,8 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-test
     permissions:
-      contents:      read
-      actions:       read
+      contents: read
+      actions: read
       pull-requests: write
     steps:
       - uses: fgrosse/go-coverage-report@v1.3.0
@@ -141,35 +141,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-test
     permissions:
-      contents:      read
-      actions:       read
+      contents: read
+      actions: read
       pull-requests: write # write permission needed to comment on PR
     steps:
       - uses: fgrosse/go-coverage-report@v1.3.0
         with:
           coverage-artifact-name: "integ-code-coverage"
           coverage-file-name: "integration-coverage.out"
-
-  integration-test-server-main:
-    continue-on-error: true
-    runs-on: ubuntu-24.04-arm
-    env:
-      TEST_OUTPUT_ROOT: ${{ github.workspace }}/reports
-      TEMPORAL_ROOT: ${{ github.workspace }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: "tests/go.mod"
-
-      - name: Update server to main
-        working-directory: tests
-        run: |
-          go get go.temporal.io/server@main
-          go mod tidy
-
-      - name: Run Integration Tests
-        run: make integration-test

--- a/.github/workflows/nightly-integration.yaml
+++ b/.github/workflows/nightly-integration.yaml
@@ -6,16 +6,22 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   integration-test-server-main:
     runs-on: ubuntu-24.04-arm
+    env:
+      TEST_OUTPUT_ROOT: ${{ github.workspace }}/reports
+      # Server testcore writes to $TEMPORAL_ROOT/.testoutput; default resolves into
+      # the read-only module cache when server is a dependency.
+      TEMPORAL_ROOT: ${{ github.workspace }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: "tests/go.mod"
 
@@ -26,4 +32,14 @@ jobs:
           go mod tidy
 
       - name: Run Integration Tests
+        env:
+          REPORT: "true"
         run: make integration-test
+
+      - name: Integration Test Report
+        uses: dorny/test-reporter@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: Integration Tests (server@main)
+          path: ${{ env.TEST_OUTPUT_ROOT }}/integration-report.json
+          reporter: golang-json


### PR DESCRIPTION
Removes the on-PR integration test with server-main. Integrates the latest changes made to produce reporting.

This was intended to be done by #92 but was inadvertently put back during main branch merge.