### PR TITLE
Queue task-add signals for sequential processing behind a workflow patch

### DIFF
--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -134,6 +134,7 @@ const (
 	SkippedReasonInvalidCount         SkippedReason = "invalid_count"
 	SkippedReasonNoSourceRequest      SkippedReason = "no_source_request"
 	SkippedReasonTaskTypeMismatch     SkippedReason = "task_type_mismatch"
+	SkippedReasonQueueFull            SkippedReason = "queue_full"
 	// SkippedReasonNone is the sentinel used when a metric's fixed tag schema requires the
 	// skip_reason tag on a non-skip path.
 	SkippedReasonNone SkippedReason = "none"

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -30,10 +30,13 @@ const (
 	RegisterTaskQueuesViaWorkersActivityTimeout  = 30 * time.Second
 
 	periodicValidationInterval = 6 * time.Hour
-	maxPendingTaskAddSignals   = 4000
 
-	taskAddSignalQueueProcessingPatch = "taskAddSignalQueueProcessing"
-	taskAddSignalQueueLimitPatch      = "taskAddSignalQueueLimit"
+	// maxPendingTaskAddSignals defines how many past signals are kept around. At the
+	// default batching of 500ms this means we keep a bit more than 30min around, which
+	// seems like a reasonable cutoff while managing workflow state size.
+	maxPendingTaskAddSignals = 4000
+
+	taskAddSignalQueueLimitPatch = "taskAddSignalQueueLimit"
 )
 
 type WorkerControllerInstanceWorkflowVersion int64
@@ -196,9 +199,8 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return err
 	}
 
-	useQueuedTaskAddSignals := workflow.GetVersion(ctx, taskAddSignalQueueProcessingPatch, workflow.DefaultVersion, 1) > workflow.DefaultVersion
 	d.limitPendingTaskAddSignals = workflow.GetVersion(ctx, taskAddSignalQueueLimitPatch, workflow.DefaultVersion, 1) > workflow.DefaultVersion
-	if !useQueuedTaskAddSignals {
+	if !d.limitPendingTaskAddSignals {
 		// Process the signals from the prior run (pre-CaN)
 		d.processPendingTaskAddSignals(ctx)
 	}
@@ -209,7 +211,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		var req *iface.SignalTaskAddRequest
 		c.Receive(ctx, &req)
 
-		if useQueuedTaskAddSignals {
+		if d.limitPendingTaskAddSignals {
 			d.queueTaskAddSignal(req)
 		} else {
 			d.handleNoSyncMatchSignal(ctx, req)
@@ -261,13 +263,13 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// before we start processing, we quickly drain the task add signals into the queue to make sure
 	// they get processed in this workflow task and not further queued for the next one. This makes
 	// it easier to debug the resulting queue.
-	if useQueuedTaskAddSignals {
+	if d.limitPendingTaskAddSignals {
 		d.drainTaskAddSignalChannelToQueue()
 	}
 
 	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
 	for !d.shouldContinueAsNew(ctx) {
-		if useQueuedTaskAddSignals && d.processNextQueuedTaskAddSignal(ctx) {
+		if d.limitPendingTaskAddSignals && d.processNextQueuedTaskAddSignal(ctx) {
 			continue
 		}
 
@@ -291,7 +293,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// we pass the current state as input to the next workflow execution, resulting in a new
 	// workflow history with just two initial events. This minimizes the risk of NDE (Non-Deterministic Execution)
 	// errors during server rollbacks.
-	if !useQueuedTaskAddSignals {
+	if !d.limitPendingTaskAddSignals {
 		d.drainPendingTaskAddSignals()
 	}
 
@@ -792,7 +794,7 @@ func (d *WorkflowRunner) processPendingTaskAddSignals(ctx workflow.Context) {
 func (d *WorkflowRunner) queueTaskAddSignal(req *iface.SignalTaskAddRequest) {
 	if req == nil {
 		d.logger.Warn("Received nil task-add signal request; dropping")
-		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonInvalidRequest)
+		d.signalMetric(wcimetrics.SignalTypeTaskAdd).recordSkipped(wcimetrics.SkippedReasonInvalidRequest)
 		return
 	}
 	if d.State == nil {
@@ -809,7 +811,7 @@ func (d *WorkflowRunner) queueTaskAddSignal(req *iface.SignalTaskAddRequest) {
 			"sync_match_batch", req.SyncMatchSignalsSinceLast,
 			"no_sync_match_batch", req.NoSyncMatchSignalsSinceLast,
 		)
-		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonQueueFull)
+		d.signalMetric(wcimetrics.SignalTypeTaskAdd).recordSkipped(wcimetrics.SkippedReasonQueueFull)
 		return
 	}
 	d.State.PendingTaskAddSignals = append(d.State.PendingTaskAddSignals, req)

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -30,8 +30,10 @@ const (
 	RegisterTaskQueuesViaWorkersActivityTimeout  = 30 * time.Second
 
 	periodicValidationInterval = 6 * time.Hour
+	maxPendingTaskAddSignals   = 4000
 
 	taskAddSignalQueueProcessingPatch = "taskAddSignalQueueProcessing"
+	taskAddSignalQueueLimitPatch      = "taskAddSignalQueueLimit"
 )
 
 type WorkerControllerInstanceWorkflowVersion int64
@@ -83,6 +85,8 @@ type (
 		stateChanged  bool
 		signalHandler *SignalHandler
 		forceCAN      bool
+
+		limitPendingTaskAddSignals bool
 
 		// workflowVersion is set at workflow start based on the dynamic config of the worker
 		// that completes the first task. It remains constant for the lifetime of the run and
@@ -193,6 +197,7 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	}
 
 	useQueuedTaskAddSignals := workflow.GetVersion(ctx, taskAddSignalQueueProcessingPatch, workflow.DefaultVersion, 1) > workflow.DefaultVersion
+	d.limitPendingTaskAddSignals = workflow.GetVersion(ctx, taskAddSignalQueueLimitPatch, workflow.DefaultVersion, 1) > workflow.DefaultVersion
 	if !useQueuedTaskAddSignals {
 		// Process the signals from the prior run (pre-CaN)
 		d.processPendingTaskAddSignals(ctx)
@@ -792,6 +797,20 @@ func (d *WorkflowRunner) queueTaskAddSignal(req *iface.SignalTaskAddRequest) {
 	}
 	if d.State == nil {
 		d.State = &iface.WorkerControllerInstanceLocalState{}
+	}
+	if d.limitPendingTaskAddSignals && len(d.State.PendingTaskAddSignals) >= maxPendingTaskAddSignals {
+		d.logger.Warn(
+			"Dropping task-add signal because pending signal queue is full",
+			"queue_size", len(d.State.PendingTaskAddSignals),
+			"max_queue_size", maxPendingTaskAddSignals,
+			"task_queue", req.TaskQueueName,
+			"task_queue_type", req.TaskQueueType.String(),
+			"sync_match", req.IsSyncMatch,
+			"sync_match_batch", req.SyncMatchSignalsSinceLast,
+			"no_sync_match_batch", req.NoSyncMatchSignalsSinceLast,
+		)
+		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonQueueFull)
+		return
 	}
 	d.State.PendingTaskAddSignals = append(d.State.PendingTaskAddSignals, req)
 }

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -30,6 +30,8 @@ const (
 	RegisterTaskQueuesViaWorkersActivityTimeout  = 30 * time.Second
 
 	periodicValidationInterval = 6 * time.Hour
+
+	taskAddSignalQueueProcessingPatch = "taskAddSignalQueueProcessing"
 )
 
 type WorkerControllerInstanceWorkflowVersion int64
@@ -190,8 +192,11 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		return err
 	}
 
-	// Process the signals from the prior run (pre-CaN)
-	d.processPendingTaskAddSignals(ctx)
+	useQueuedTaskAddSignals := workflow.GetVersion(ctx, taskAddSignalQueueProcessingPatch, workflow.DefaultVersion, 1) > workflow.DefaultVersion
+	if !useQueuedTaskAddSignals {
+		// Process the signals from the prior run (pre-CaN)
+		d.processPendingTaskAddSignals(ctx)
+	}
 
 	// Setup the signal handler for the two signals we are dealing with
 	d.signalHandler.taskAddSignalChannel = workflow.GetSignalChannel(ctx, iface.SignalTaskAdd)
@@ -199,7 +204,11 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		var req *iface.SignalTaskAddRequest
 		c.Receive(ctx, &req)
 
-		d.handleNoSyncMatchSignal(ctx, req)
+		if useQueuedTaskAddSignals {
+			d.queueTaskAddSignal(req)
+		} else {
+			d.handleNoSyncMatchSignal(ctx, req)
+		}
 	})
 
 	var addStatsPullTimer func(nextPoll time.Duration)
@@ -244,8 +253,21 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 		addPeriodicValidationTimer()
 	}
 
+	// before we start processing, we quickly drain the task add signals into the queue to make sure
+	// they get processed in this workflow task and not further queued for the next one. This makes
+	// it easier to debug the resulting queue.
+	if useQueuedTaskAddSignals {
+		d.drainTaskAddSignalChannelToQueue()
+	}
+
 	// Keep waiting for signals, when it's time to CaN the main goroutine will exit.
-	for !d.deleteInstance && !d.forceCAN && !d.stateChanged && !workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+	for !d.shouldContinueAsNew(ctx) {
+		if useQueuedTaskAddSignals && d.processNextQueuedTaskAddSignal(ctx) {
+			continue
+		}
+
+		// process signals after the queue, as any signals that don't go into the queue
+		// are background processes and so should only be done if there is no more urgent work
 		d.signalHandler.signalSelector.Select(ctx)
 	}
 
@@ -264,7 +286,9 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	// we pass the current state as input to the next workflow execution, resulting in a new
 	// workflow history with just two initial events. This minimizes the risk of NDE (Non-Deterministic Execution)
 	// errors during server rollbacks.
-	d.drainPendingTaskAddSignals()
+	if !useQueuedTaskAddSignals {
+		d.drainPendingTaskAddSignals()
+	}
 
 	return workflow.NewContinueAsNewError(ctx, iface.WorkerControllerInstanceWorkflowType, d.WorkerControllerInstanceWorkflowArgs)
 }
@@ -760,6 +784,45 @@ func (d *WorkflowRunner) processPendingTaskAddSignals(ctx workflow.Context) {
 	}
 }
 
+func (d *WorkflowRunner) queueTaskAddSignal(req *iface.SignalTaskAddRequest) {
+	if req == nil {
+		d.logger.Warn("Received nil task-add signal request; dropping")
+		d.recordSignal(wcimetrics.SignalTypeTaskAdd, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone, wcimetrics.SkippedReasonInvalidRequest)
+		return
+	}
+	if d.State == nil {
+		d.State = &iface.WorkerControllerInstanceLocalState{}
+	}
+	d.State.PendingTaskAddSignals = append(d.State.PendingTaskAddSignals, req)
+}
+
+func (d *WorkflowRunner) processNextQueuedTaskAddSignal(ctx workflow.Context) bool {
+	if d.State == nil || len(d.State.PendingTaskAddSignals) == 0 {
+		return false
+	}
+
+	req := d.State.PendingTaskAddSignals[0]
+	d.State.PendingTaskAddSignals[0] = nil
+	d.State.PendingTaskAddSignals = d.State.PendingTaskAddSignals[1:]
+
+	d.handleNoSyncMatchSignal(ctx, req)
+	return true
+}
+
+func (d *WorkflowRunner) drainTaskAddSignalChannelToQueue() {
+	if d.signalHandler == nil || d.signalHandler.taskAddSignalChannel == nil {
+		return
+	}
+
+	for {
+		var req *iface.SignalTaskAddRequest
+		if !d.signalHandler.taskAddSignalChannel.ReceiveAsync(&req) {
+			return
+		}
+		d.queueTaskAddSignal(req)
+	}
+}
+
 func (d *WorkflowRunner) drainPendingTaskAddSignals() {
 	if d.State == nil || d.signalHandler == nil || d.signalHandler.taskAddSignalChannel == nil {
 		return
@@ -776,6 +839,10 @@ func (d *WorkflowRunner) drainPendingTaskAddSignals() {
 		d.State.PendingTaskAddSignals = append(d.State.PendingTaskAddSignals, req)
 		d.stateChanged = true
 	}
+}
+
+func (d *WorkflowRunner) shouldContinueAsNew(ctx workflow.Context) bool {
+	return d.deleteInstance || d.forceCAN || d.stateChanged || workflow.GetInfo(ctx).GetContinueAsNewSuggested()
 }
 
 func (d *WorkflowRunner) hasMinVersion(version WorkerControllerInstanceWorkflowVersion) bool {

--- a/wci/workflow/workflow_signal_queue_test.go
+++ b/wci/workflow/workflow_signal_queue_test.go
@@ -1,0 +1,166 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+)
+
+type queueSignalTestResult struct {
+	ProcessedFirst       bool
+	ProcessedSecond      bool
+	ProcessedCount       int
+	RemainingAfterFirst  []string
+	RemainingAfterSecond []string
+	Remaining            []string
+}
+
+func newSignalQueueTestRunner(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs, activities *Activities) *WorkflowRunner {
+	return &WorkflowRunner{
+		WorkerControllerInstanceWorkflowArgs: args,
+		a:                                    activities,
+		logger:                               sdkworkflow.GetLogger(ctx),
+		metrics:                              sdkworkflow.GetMetricsHandler(ctx),
+	}
+}
+
+func newSignalQueueTestArgs(pending ...*iface.SignalTaskAddRequest) *iface.WorkerControllerInstanceWorkflowArgs {
+	return &iface.WorkerControllerInstanceWorkflowArgs{
+		NamespaceName:  "test-namespace",
+		DeploymentName: "test-deployment",
+		BuildId:        "test-build",
+		State: &iface.WorkerControllerInstanceLocalState{
+			PendingTaskAddSignals: pending,
+		},
+	}
+}
+
+func namedTaskAddSignal(name string) *iface.SignalTaskAddRequest {
+	req := newTestSignalTaskAddEvent()
+	req.TaskQueueName = name
+	return &req
+}
+
+func pendingTaskAddSignalNames(requests []*iface.SignalTaskAddRequest) []string {
+	names := make([]string, 0, len(requests))
+	for _, req := range requests {
+		if req == nil {
+			names = append(names, "<nil>")
+			continue
+		}
+		names = append(names, req.TaskQueueName)
+	}
+	return names
+}
+
+func TestQueuedTaskAddSignalsProcessOneAtATimeFromState(t *testing.T) {
+	activities := NewActivities(nil, nil, nil)
+	args := newSignalQueueTestArgs(namedTaskAddSignal("first"), namedTaskAddSignal("second"))
+
+	var processed []string
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) (*queueSignalTestResult, error) {
+		runner := newSignalQueueTestRunner(ctx, args, activities)
+
+		result := &queueSignalTestResult{}
+		result.ProcessedFirst = runner.processNextQueuedTaskAddSignal(ctx)
+		result.RemainingAfterFirst = pendingTaskAddSignalNames(runner.State.PendingTaskAddSignals)
+
+		result.ProcessedSecond = runner.processNextQueuedTaskAddSignal(ctx)
+		result.RemainingAfterSecond = pendingTaskAddSignalNames(runner.State.PendingTaskAddSignals)
+		return result, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+	env.OnActivity(activities.HandleTaskAddSignal, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, req HandleTaskAddSignalActivityRequest) (*HandleTaskAddSignalActivityResponse, error) {
+			processed = append(processed, req.Request.TaskQueueName)
+			return &HandleTaskAddSignalActivityResponse{}, nil
+		}).Twice()
+
+	env.ExecuteWorkflow(testWorkflow, args)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result queueSignalTestResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	assert.True(t, result.ProcessedFirst)
+	assert.Equal(t, []string{"second"}, result.RemainingAfterFirst)
+	assert.True(t, result.ProcessedSecond)
+	assert.Empty(t, result.RemainingAfterSecond)
+	assert.Equal(t, []string{"first", "second"}, processed)
+}
+
+func TestQueuedTaskAddSignalsStopAfterCANCondition(t *testing.T) {
+	activities := NewActivities(nil, nil, nil)
+	args := newSignalQueueTestArgs(namedTaskAddSignal("first"), namedTaskAddSignal("second"))
+
+	var processed []string
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) (*queueSignalTestResult, error) {
+		runner := newSignalQueueTestRunner(ctx, args, activities)
+
+		result := &queueSignalTestResult{}
+		for !runner.shouldContinueAsNew(ctx) {
+			if !runner.processNextQueuedTaskAddSignal(ctx) {
+				break
+			}
+			result.ProcessedCount++
+			if result.ProcessedCount == 1 {
+				runner.stateChanged = true
+			}
+		}
+		result.Remaining = pendingTaskAddSignalNames(runner.State.PendingTaskAddSignals)
+		return result, nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+	env.OnActivity(activities.HandleTaskAddSignal, mock.Anything, mock.Anything).
+		Return(func(_ context.Context, req HandleTaskAddSignalActivityRequest) (*HandleTaskAddSignalActivityResponse, error) {
+			processed = append(processed, req.Request.TaskQueueName)
+			return &HandleTaskAddSignalActivityResponse{}, nil
+		}).Once()
+
+	env.ExecuteWorkflow(testWorkflow, args)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var result queueSignalTestResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	assert.Equal(t, 1, result.ProcessedCount)
+	assert.Equal(t, []string{"second"}, result.Remaining)
+	assert.Equal(t, []string{"first"}, processed)
+}
+
+func TestQueueTaskAddSignalDropsNilRequests(t *testing.T) {
+	activities := NewActivities(nil, nil, nil)
+	args := newSignalQueueTestArgs()
+
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) ([]string, error) {
+		runner := newSignalQueueTestRunner(ctx, args, activities)
+		runner.queueTaskAddSignal(nil)
+		runner.queueTaskAddSignal(namedTaskAddSignal("valid"))
+		return pendingTaskAddSignalNames(runner.State.PendingTaskAddSignals), nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+
+	env.ExecuteWorkflow(testWorkflow, args)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var remaining []string
+	require.NoError(t, env.GetWorkflowResult(&remaining))
+	assert.Equal(t, []string{"valid"}, remaining)
+}

--- a/wci/workflow/workflow_signal_queue_test.go
+++ b/wci/workflow/workflow_signal_queue_test.go
@@ -164,3 +164,31 @@ func TestQueueTaskAddSignalDropsNilRequests(t *testing.T) {
 	require.NoError(t, env.GetWorkflowResult(&remaining))
 	assert.Equal(t, []string{"valid"}, remaining)
 }
+
+func TestQueueTaskAddSignalDropsWhenQueueFull(t *testing.T) {
+	activities := NewActivities(nil, nil, nil)
+	pending := make([]*iface.SignalTaskAddRequest, maxPendingTaskAddSignals)
+	for i := range pending {
+		pending[i] = namedTaskAddSignal("queued")
+	}
+	args := newSignalQueueTestArgs(pending...)
+
+	testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) (int, error) {
+		runner := newSignalQueueTestRunner(ctx, args, activities)
+		runner.limitPendingTaskAddSignals = true
+		runner.queueTaskAddSignal(namedTaskAddSignal("dropped"))
+		return len(runner.State.PendingTaskAddSignals), nil
+	}
+
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.RegisterWorkflow(testWorkflow)
+
+	env.ExecuteWorkflow(testWorkflow, args)
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+
+	var remainingCount int
+	require.NoError(t, env.GetWorkflowResult(&remainingCount))
+	assert.Equal(t, maxPendingTaskAddSignals, remainingCount)
+}


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add a versioned code path that queues incoming task-add signals into local state and processes them one at a time in the main run loop, rather than handling each signal inline. This aims to avoid the case of processing multiple signals with the bare signal handler (which led to cases of the CAN condition being starved and the workflow getting terminated).
<!-- Describe what has changed in this PR -->

## Why?
During testing we found a case where a constant signal load would starve the CaN condition leading to an eventual termination of the workflow. In this setting the launch of a new lambda was interleaved with the processing of the next signal so that a signal handler was always open (as two ended up happening at the same time). This change aims to fix that by disallowing the signal handler concurrency.
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
