### PR TITLE
Split error type on compute provider failures

### DIFF
--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -90,28 +90,35 @@ const (
 	ErrorTypeInvalidSpec                           ErrorType = "invalid_spec"
 	// ErrorTypeActivityError is the coarse bucket used at workflow-side activity-execution failure sites, paired with
 	// the activity_error_type tag for sub-classification.
-	ErrorTypeActivityError              ErrorType = "activity_error"
-	ErrorTypeInvalidRequest             ErrorType = "invalid_request"
-	ErrorTypeAlgorithmUnavailable       ErrorType = "algorithm_unavailable"
-	ErrorTypeAlgorithmFailed            ErrorType = "algorithm_failed"
-	ErrorTypeComputeProviderUnavailable ErrorType = "compute_provider_unavailable"
+	ErrorTypeActivityError        ErrorType = "activity_error"
+	ErrorTypeInvalidRequest       ErrorType = "invalid_request"
+	ErrorTypeAlgorithmUnavailable ErrorType = "algorithm_unavailable"
+	ErrorTypeAlgorithmFailed      ErrorType = "algorithm_failed"
+	// ErrorTypeComputeProviderNotEnabled means no compute provider is enabled for the
+	// namespace, or the one the spec names is not registered. Nothing was attempted.
+	ErrorTypeComputeProviderNotEnabled ErrorType = "compute_provider_not_enabled"
 	// ErrorTypeComputeProviderFailed is the fallback for a compute provider failure
 	// the provider did not classify. The values below are the classified subsets.
 	ErrorTypeComputeProviderFailed ErrorType = "compute_provider_failed"
-	// ErrorTypeComputeProviderMisconfigured means the provider rejected the
-	// customer's config: a resource that does not exist, or no permission to it.
-	ErrorTypeComputeProviderMisconfigured ErrorType = "compute_provider_misconfigured"
+	// ErrorTypeComputeProviderRejected means the provider rejected a request made
+	// against the customer's config for a reason we could not narrow further.
+	ErrorTypeComputeProviderRejected ErrorType = "compute_provider_rejected"
+	// ErrorTypeComputeProviderRejectedNotFound means the compute resource named by
+	// the customer's config does not exist.
+	ErrorTypeComputeProviderRejectedNotFound ErrorType = "compute_provider_rejected_not_found"
+	// ErrorTypeComputeProviderRejectedAccessDenied means the resource exists but the
+	// role we assumed lacks permission to act on it.
+	ErrorTypeComputeProviderRejectedAccessDenied ErrorType = "compute_provider_rejected_access_denied"
 	// ErrorTypeComputeProviderServiceUnavailable means the provider's API was
-	// unreachable or returned a server-side error. Distinct from
-	// ErrorTypeComputeProviderUnavailable, which means the provider is not enabled
-	// for the namespace or not registered.
+	// unreachable or returned a server-side error.
 	ErrorTypeComputeProviderServiceUnavailable ErrorType = "compute_provider_service_unavailable"
 	// ErrorTypeComputeProviderThrottled means the provider rate- or
 	// concurrency-limited the request.
 	ErrorTypeComputeProviderThrottled ErrorType = "compute_provider_throttled"
-	// ErrorTypeInternal means the failure is attributable to worker-controller-instances's own
-	// configuration or credentials rather than the customer's.
-	ErrorTypeInternal ErrorType = "internal"
+	// ErrorTypeComputeProviderInternal means the compute provider call failed on
+	// worker-controller-instances's own configuration or credentials rather than the
+	// customer's.
+	ErrorTypeComputeProviderInternal ErrorType = "compute_provider_internal"
 	// ErrorTypeNone is the sentinel used when a metric's fixed tag schema requires the
 	// error_type tag on a non-error path.
 	ErrorTypeNone ErrorType = "none"

--- a/wci/metrics/metric_defs.go
+++ b/wci/metrics/metric_defs.go
@@ -95,7 +95,23 @@ const (
 	ErrorTypeAlgorithmUnavailable       ErrorType = "algorithm_unavailable"
 	ErrorTypeAlgorithmFailed            ErrorType = "algorithm_failed"
 	ErrorTypeComputeProviderUnavailable ErrorType = "compute_provider_unavailable"
-	ErrorTypeComputeProviderFailed      ErrorType = "compute_provider_failed"
+	// ErrorTypeComputeProviderFailed is the fallback for a compute provider failure
+	// the provider did not classify. The values below are the classified subsets.
+	ErrorTypeComputeProviderFailed ErrorType = "compute_provider_failed"
+	// ErrorTypeComputeProviderMisconfigured means the provider rejected the
+	// customer's config: a resource that does not exist, or no permission to it.
+	ErrorTypeComputeProviderMisconfigured ErrorType = "compute_provider_misconfigured"
+	// ErrorTypeComputeProviderServiceUnavailable means the provider's API was
+	// unreachable or returned a server-side error. Distinct from
+	// ErrorTypeComputeProviderUnavailable, which means the provider is not enabled
+	// for the namespace or not registered.
+	ErrorTypeComputeProviderServiceUnavailable ErrorType = "compute_provider_service_unavailable"
+	// ErrorTypeComputeProviderThrottled means the provider rate- or
+	// concurrency-limited the request.
+	ErrorTypeComputeProviderThrottled ErrorType = "compute_provider_throttled"
+	// ErrorTypeInternal means the failure is attributable to worker-controller-instances's own
+	// configuration or credentials rather than the customer's.
+	ErrorTypeInternal ErrorType = "internal"
 	// ErrorTypeNone is the sentinel used when a metric's fixed tag schema requires the
 	// error_type tag on a non-error path.
 	ErrorTypeNone ErrorType = "none"

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -388,7 +388,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 	timeoutCtx, cancel := context.WithTimeout(ctx, startNewWorkerInstanceTimeout)
 	defer cancel()
 	if err := provider.InvokeWorker(timeoutCtx, req.RequestContext, config); err != nil {
-		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
+		recordError(computeProviderErrorType(err))
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
 
@@ -426,7 +426,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 	timeoutCtx, cancel := context.WithTimeout(ctx, updateWorkerSetSizeTimeout)
 	defer cancel()
 	if err := provider.UpdateWorkerSetSize(timeoutCtx, req.RequestContext, config, req.UpdatedSize); err != nil {
-		recordError(wcimetrics.ErrorTypeComputeProviderFailed)
+		recordError(computeProviderErrorType(err))
 		return temporal.NewApplicationErrorWithCause(err.Error(), "InvokeWorkerFailed", err)
 	}
 
@@ -690,6 +690,28 @@ func (a *Activities) getScalingAlgorithmAndConfig(ctx context.Context, entry ifa
 		}
 	}
 	return scalingAlgo, scalingConfig, nil
+}
+
+// computeProviderErrorType maps a compute provider's failure classification onto an
+// error_type tag value. Providers classify their own SDK's errors; the metrics
+// vocabulary stays out of the compute provider package.
+func computeProviderErrorType(err error) wcimetrics.ErrorType {
+	var pErr *computeprovider.ProviderError
+	if !stderrors.As(err, &pErr) {
+		return wcimetrics.ErrorTypeComputeProviderFailed
+	}
+	switch pErr.Class {
+	case computeprovider.FailureMisconfigured:
+		return wcimetrics.ErrorTypeComputeProviderMisconfigured
+	case computeprovider.FailureUnavailable:
+		return wcimetrics.ErrorTypeComputeProviderServiceUnavailable
+	case computeprovider.FailureThrottled:
+		return wcimetrics.ErrorTypeComputeProviderThrottled
+	case computeprovider.FailureInternal:
+		return wcimetrics.ErrorTypeInternal
+	default:
+		return wcimetrics.ErrorTypeComputeProviderFailed
+	}
 }
 
 // newActivityRecorders returns three closures that increment the Activities counter

--- a/wci/workflow/activities.go
+++ b/wci/workflow/activities.go
@@ -206,7 +206,7 @@ func (a *Activities) ValidateSpec(ctx context.Context, req *ValidateSpecRequest)
 			return temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", key, err.Error()), "InvalidArgument", err)
 		}
 		if provider == nil {
-			recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
+			recordError(wcimetrics.ErrorTypeComputeProviderNotEnabled)
 			return temporal.NewApplicationError(fmt.Sprintf("%s: Could not instantiate compute provider with type '%s'", key, entry.Compute.ProviderType), "InvalidArgument")
 		}
 		logger.Debug("Validating compute provider", "scaling_group_name", key, "compute_provider_type", entry.Compute.ProviderType)
@@ -302,7 +302,7 @@ func (a *Activities) InvokeWorkersToRegisterTaskQueues(ctx context.Context, req 
 			return nil, temporal.NewApplicationErrorWithCause(fmt.Sprintf("%s: %s", k, err.Error()), "InvalidArgument", err)
 		}
 		if provider == nil {
-			recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
+			recordError(wcimetrics.ErrorTypeComputeProviderNotEnabled)
 			return nil, temporal.NewApplicationError(fmt.Sprintf("%s: '%s' is an unknown compute provider", k, v.Compute.ProviderType), "InvalidArgument")
 		}
 
@@ -373,7 +373,7 @@ func (a *Activities) InvokeWorker(ctx context.Context, req *InvokeWorkerActivity
 		return err
 	}
 	if provider == nil {
-		recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
+		recordError(wcimetrics.ErrorTypeComputeProviderNotEnabled)
 		return temporal.NewApplicationError(fmt.Sprintf("Could not instantiate compute provider with type '%s'", req.ComputeConfig.ProviderType), "InvalidArgument")
 	}
 
@@ -411,7 +411,7 @@ func (a *Activities) UpdateWorkerSetSize(ctx context.Context, req *UpdateWorkerS
 		return err
 	}
 	if provider == nil {
-		recordError(wcimetrics.ErrorTypeComputeProviderUnavailable)
+		recordError(wcimetrics.ErrorTypeComputeProviderNotEnabled)
 		return errors.Errorf("Could not instantiate compute provider with type '%s'", req.ComputeConfig.ProviderType)
 	}
 
@@ -701,14 +701,18 @@ func computeProviderErrorType(err error) wcimetrics.ErrorType {
 		return wcimetrics.ErrorTypeComputeProviderFailed
 	}
 	switch pErr.Class {
-	case computeprovider.FailureMisconfigured:
-		return wcimetrics.ErrorTypeComputeProviderMisconfigured
+	case computeprovider.FailureRejected:
+		return wcimetrics.ErrorTypeComputeProviderRejected
+	case computeprovider.FailureNotFound:
+		return wcimetrics.ErrorTypeComputeProviderRejectedNotFound
+	case computeprovider.FailureAccessDenied:
+		return wcimetrics.ErrorTypeComputeProviderRejectedAccessDenied
 	case computeprovider.FailureUnavailable:
 		return wcimetrics.ErrorTypeComputeProviderServiceUnavailable
 	case computeprovider.FailureThrottled:
 		return wcimetrics.ErrorTypeComputeProviderThrottled
 	case computeprovider.FailureInternal:
-		return wcimetrics.ErrorTypeInternal
+		return wcimetrics.ErrorTypeComputeProviderInternal
 	default:
 		return wcimetrics.ErrorTypeComputeProviderFailed
 	}

--- a/wci/workflow/activities_test.go
+++ b/wci/workflow/activities_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"testing"
 	"time"
@@ -1053,6 +1054,31 @@ func TestInvokeWorkersToRegisterTaskQueues_RateLimitFailsClosed(t *testing.T) {
 			require.ErrorAs(t, err, &appErr)
 			assert.Equal(t, "ResourceExhausted", appErr.Type(),
 				"rate limiting must abort with a ResourceExhausted error rather than fail open and add load")
+		})
+	}
+}
+
+func TestComputeProviderErrorType(t *testing.T) {
+	cause := errors.New("boom")
+	cases := []struct {
+		name string
+		err  error
+		want wcimetrics.ErrorType
+	}{
+		{"misconfigured", computeprovider.NewProviderError(computeprovider.FailureMisconfigured, cause), wcimetrics.ErrorTypeComputeProviderMisconfigured},
+		{"unavailable", computeprovider.NewProviderError(computeprovider.FailureUnavailable, cause), wcimetrics.ErrorTypeComputeProviderServiceUnavailable},
+		{"throttled", computeprovider.NewProviderError(computeprovider.FailureThrottled, cause), wcimetrics.ErrorTypeComputeProviderThrottled},
+		{"internal", computeprovider.NewProviderError(computeprovider.FailureInternal, cause), wcimetrics.ErrorTypeInternal},
+		{"unclassified", computeprovider.NewProviderError(computeprovider.FailureUnclassified, cause), wcimetrics.ErrorTypeComputeProviderFailed},
+		// A provider that doesn't classify falls back rather than being misattributed.
+		{"unwrapped", cause, wcimetrics.ErrorTypeComputeProviderFailed},
+		{"wrapped in temporal error", fmt.Errorf("activity failed: %w",
+			computeprovider.NewProviderError(computeprovider.FailureThrottled, cause)), wcimetrics.ErrorTypeComputeProviderThrottled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, computeProviderErrorType(tc.err))
 		})
 	}
 }

--- a/wci/workflow/activities_test.go
+++ b/wci/workflow/activities_test.go
@@ -1065,10 +1065,12 @@ func TestComputeProviderErrorType(t *testing.T) {
 		err  error
 		want wcimetrics.ErrorType
 	}{
-		{"misconfigured", computeprovider.NewProviderError(computeprovider.FailureMisconfigured, cause), wcimetrics.ErrorTypeComputeProviderMisconfigured},
+		{"rejected", computeprovider.NewProviderError(computeprovider.FailureRejected, cause), wcimetrics.ErrorTypeComputeProviderRejected},
+		{"not found", computeprovider.NewProviderError(computeprovider.FailureNotFound, cause), wcimetrics.ErrorTypeComputeProviderRejectedNotFound},
+		{"access denied", computeprovider.NewProviderError(computeprovider.FailureAccessDenied, cause), wcimetrics.ErrorTypeComputeProviderRejectedAccessDenied},
 		{"unavailable", computeprovider.NewProviderError(computeprovider.FailureUnavailable, cause), wcimetrics.ErrorTypeComputeProviderServiceUnavailable},
 		{"throttled", computeprovider.NewProviderError(computeprovider.FailureThrottled, cause), wcimetrics.ErrorTypeComputeProviderThrottled},
-		{"internal", computeprovider.NewProviderError(computeprovider.FailureInternal, cause), wcimetrics.ErrorTypeInternal},
+		{"internal", computeprovider.NewProviderError(computeprovider.FailureInternal, cause), wcimetrics.ErrorTypeComputeProviderInternal},
 		{"unclassified", computeprovider.NewProviderError(computeprovider.FailureUnclassified, cause), wcimetrics.ErrorTypeComputeProviderFailed},
 		// A provider that doesn't classify falls back rather than being misattributed.
 		{"unwrapped", cause, wcimetrics.ErrorTypeComputeProviderFailed},

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -126,7 +126,7 @@ func buildBaseAWSConfig(ctx context.Context, region string, intermediaryRoles []
 
 		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &req)
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("%w: %w", errWCIOwned, err)
+			return aws.Config{}, fmt.Errorf("%w: error assuming intermediary role: %w", errWCIOwned, err)
 		}
 	}
 	return awsConfig, nil

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -20,11 +21,67 @@ type stsAPI interface {
 	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
 }
 
+// errWCIOwned marks a failure as attributable to worker-controller's own AWS setup
+// (base credentials, intermediary role chain) rather than the customer's config.
+// This has to be marked where it happens: intermediary and customer role
+// assumptions go through the same helper and fail indistinguishably.
+var errWCIOwned = errors.New("worker-controller AWS configuration error")
+
+var (
+	awsThrottleCheck   = retry.ThrottleErrorCode{Codes: retry.DefaultThrottleErrorCodes}
+	awsConnectionCheck = retry.RetryableConnectionError{}
+)
+
+// classifyAWSFailure maps an AWS SDK error onto a FailureClass along two axes:
+// what kind of failure it was, read from the smithy error model, and whose config
+// caused it, read from errWCIOwned.
+func classifyAWSFailure(err error) FailureClass {
+	if err == nil {
+		return FailureUnclassified
+	}
+
+	// A cancelled request tells us nothing about either axis; don't blame it on
+	// whoever's config happened to be in play.
+	if errors.Is(err, context.Canceled) {
+		return FailureUnclassified
+	}
+
+	// Ownership only separates the two client-fault buckets. A throttled or
+	// server-side failure is the provider's regardless of whose config we used.
+	ownerFault := FailureMisconfigured
+	if errors.Is(err, errWCIOwned) {
+		ownerFault = FailureInternal
+	}
+
+	// Throttles are modelled as client faults, so they must be checked before the
+	// fault split or every one of them lands in the misconfiguration bucket.
+	if awsThrottleCheck.IsErrorThrottle(err) == aws.TrueTernary {
+		return FailureThrottled
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.ErrorFault() == smithy.FaultServer {
+			return FailureUnavailable
+		}
+		return ownerFault
+	}
+
+	// No modelled API error: the request either failed in transport or never left
+	// the process. Local validation failures fall through to ownerFault.
+	if awsConnectionCheck.IsErrorRetryable(err) == aws.TrueTernary || errors.Is(err, context.DeadlineExceeded) {
+		return FailureUnavailable
+	}
+	return ownerFault
+}
+
 // buildBaseAWSConfig loads default AWS config and applies any intermediary roles.
+// Every input here comes from worker-controller's own configuration, so all of its
+// failures are marked errWCIOwned.
 func buildBaseAWSConfig(ctx context.Context, region string, intermediaryRoles [][]client.AWSIAMRoleRequest) (aws.Config, error) {
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
-		return aws.Config{}, fmt.Errorf("failed to load AWS config: %w", err)
+		return aws.Config{}, fmt.Errorf("%w: failed to load AWS config: %w", errWCIOwned, err)
 	}
 
 	// the AWS compute providers support role chaining to enable abstracting the role the temporal server has
@@ -39,15 +96,15 @@ func buildBaseAWSConfig(ctx context.Context, region string, intermediaryRoles []
 		// requests across roles/accounts and reduces the impact of any of these accounts failing (until it is removed from the config).
 		req := step[rand.Intn(len(step))]
 		if err = validateRoleARN(req.RoleARN); err != nil {
-			return aws.Config{}, err
+			return aws.Config{}, fmt.Errorf("%w: invalid intermediary role: %w", errWCIOwned, err)
 		}
 		if req.RoleSessionName == "" {
-			return aws.Config{}, fmt.Errorf("empty role session name for intermediary role")
+			return aws.Config{}, fmt.Errorf("%w: empty role session name for intermediary role", errWCIOwned)
 		}
 
 		awsConfig, err = assumeRoleWithRequest(ctx, awsConfig, &req)
 		if err != nil {
-			return aws.Config{}, err
+			return aws.Config{}, fmt.Errorf("%w: %w", errWCIOwned, err)
 		}
 	}
 	return awsConfig, nil

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -46,15 +46,16 @@ func classifyAWSFailure(err error) FailureClass {
 		return FailureUnclassified
 	}
 
-	// Ownership only separates the two client-fault buckets. A throttled or
+	// Ownership separates client-fault from WCI-fault errors. A throttled or
 	// server-side failure is the provider's regardless of whose config we used.
-	ownerFault := FailureMisconfigured
-	if errors.Is(err, errWCIOwned) {
+	wciOwned := errors.Is(err, errWCIOwned)
+	ownerFault := FailureRejected
+	if wciOwned {
 		ownerFault = FailureInternal
 	}
 
 	// Throttles are modelled as client faults, so they must be checked before the
-	// fault split or every one of them lands in the misconfiguration bucket.
+	// fault split or every one of them lands in the rejected bucket.
 	if awsThrottleCheck.IsErrorThrottle(err) == aws.TrueTernary {
 		return FailureThrottled
 	}
@@ -64,7 +65,12 @@ func classifyAWSFailure(err error) FailureClass {
 		if apiErr.ErrorFault() == smithy.FaultServer {
 			return FailureUnavailable
 		}
-		return ownerFault
+		// Our own missing resources and denied permissions page the same on-call in
+		// the same way, so there is nothing to gain from narrowing them.
+		if wciOwned {
+			return FailureInternal
+		}
+		return classifyAWSRejection(apiErr.ErrorCode())
 	}
 
 	// No modelled API error: the request either failed in transport or never left
@@ -73,6 +79,22 @@ func classifyAWSFailure(err error) FailureClass {
 		return FailureUnavailable
 	}
 	return ownerFault
+}
+
+// classifyAWSRejection narrows a customer-caused client fault by error code. AWS
+// names these consistently across services -- a missing resource carries NotFound,
+// a permissions failure carries AccessDenied -- so matching the convention covers
+// services we have not integrated yet, where an explicit code list would not.
+// Anything unrecognized stays in the unnarrowed bucket rather than being guessed.
+func classifyAWSRejection(code string) FailureClass {
+	switch {
+	case strings.Contains(code, "NotFound"):
+		return FailureNotFound
+	case strings.Contains(code, "AccessDenied"):
+		return FailureAccessDenied
+	default:
+		return FailureRejected
+	}
 }
 
 // buildBaseAWSConfig loads default AWS config and applies any intermediary roles.

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -93,6 +93,11 @@ func (p *awsECSComputeProvider) InvokeWorker(_ context.Context, _ RequestContext
 }
 
 func (p *awsECSComputeProvider) UpdateWorkerSetSize(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig, size int32) error {
+	err := p.updateWorkerSetSize(ctx, cfg, size)
+	return NewProviderError(classifyAWSFailure(err), err)
+}
+
+func (p *awsECSComputeProvider) updateWorkerSetSize(ctx context.Context, cfg ComputeProviderConfig, size int32) error {
 	ecsClient, cluster, service, err := p.getECSClientAndParams(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/aws_errors_test.go
+++ b/wci/workflow/compute_provider/aws_errors_test.go
@@ -39,10 +39,16 @@ func TestClassifyAWSFailure(t *testing.T) {
 		{"nil", nil, FailureUnclassified},
 		{"canceled", context.Canceled, FailureUnclassified},
 
-		// Customer-owned client faults.
-		{"resource not found", &types.ResourceNotFoundException{}, FailureMisconfigured},
-		{"access denied", &mockFaultError{code: "AccessDeniedException", fault: smithy.FaultClient}, FailureMisconfigured},
-		{"local validation", errors.New("AWS Lambda Function ARN not found or invalid"), FailureMisconfigured},
+		// Customer-owned client faults, narrowed by error code.
+		{"resource not found", &types.ResourceNotFoundException{}, FailureNotFound},
+		{"access denied", &mockFaultError{code: "AccessDeniedException", fault: smithy.FaultClient}, FailureAccessDenied},
+		// The code convention holds across services we have not integrated yet.
+		{"ecs cluster not found", &mockFaultError{code: "ClusterNotFoundException", fault: smithy.FaultClient}, FailureNotFound},
+		{"kms access denied", &mockFaultError{code: "KMSAccessDeniedException", fault: smithy.FaultClient}, FailureAccessDenied},
+		// Client faults that match neither convention stay unnarrowed rather than
+		// being guessed into one of the two buckets.
+		{"invalid parameter", &mockFaultError{code: "InvalidParameterValueException", fault: smithy.FaultClient}, FailureRejected},
+		{"local validation", errors.New("AWS Lambda Function ARN not found or invalid"), FailureRejected},
 
 		// Server faults and transport failures, regardless of ownership.
 		{"service exception", &types.ServiceException{}, FailureUnavailable},
@@ -57,12 +63,14 @@ func TestClassifyAWSFailure(t *testing.T) {
 		{"ec2 throttled", &types.EC2ThrottledException{}, FailureThrottled},
 		{"wci-owned throttle", wciOwned(&types.TooManyRequestsException{}), FailureThrottled},
 
-		// WCI-owned client faults.
+		// WCI-owned client faults are not narrowed: our own missing resource and our
+		// own denied permission are the same page for the same on-call.
 		{"wci-owned access denied", wciOwned(&mockFaultError{code: "AccessDenied", fault: smithy.FaultClient}), FailureInternal},
+		{"wci-owned not found", wciOwned(&types.ResourceNotFoundException{}), FailureInternal},
 		{"wci-owned local validation", wciOwned(errors.New("empty role session name")), FailureInternal},
 
 		// Classification must survive the wrapping the providers apply.
-		{"wrapped", fmt.Errorf("failed to invoke lambda: %w", &types.ResourceNotFoundException{}), FailureMisconfigured},
+		{"wrapped", fmt.Errorf("failed to invoke lambda: %w", &types.ResourceNotFoundException{}), FailureNotFound},
 	}
 
 	for _, tc := range cases {
@@ -78,7 +86,7 @@ func TestClassifyAWSFailure_SeparatesIntermediaryFromCustomerRole(t *testing.T) 
 	accessDenied := &mockFaultError{code: "AccessDenied", fault: smithy.FaultClient}
 	customer := fmt.Errorf("failed to assume role %s: %w", "arn:aws:iam::1:role/Customer", accessDenied)
 
-	assert.Equal(t, FailureMisconfigured, classifyAWSFailure(customer))
+	assert.Equal(t, FailureAccessDenied, classifyAWSFailure(customer))
 	assert.Equal(t, FailureInternal, classifyAWSFailure(fmt.Errorf("%w: %w", errWCIOwned, customer)))
 }
 
@@ -108,7 +116,7 @@ func TestAWSLambdaInvokeWorker_ClassifiesFailure(t *testing.T) {
 		invokeErr error
 		want      FailureClass
 	}{
-		{"not found", &types.ResourceNotFoundException{}, FailureMisconfigured},
+		{"not found", &types.ResourceNotFoundException{}, FailureNotFound},
 		{"service down", &types.ServiceException{}, FailureUnavailable},
 		{"throttled", &types.TooManyRequestsException{}, FailureThrottled},
 	}
@@ -149,11 +157,12 @@ func TestAWSLambdaInvokeWorker_SuccessIsUnwrapped(t *testing.T) {
 func TestAWSECSUpdateWorkerSetSize_ClassifiesConfigFailure(t *testing.T) {
 	p := &awsECSComputeProvider{intermediaryRoles: [][]client.AWSIAMRoleRequest{}}
 
-	// Missing cluster fails before any AWS call; that's the customer's config.
+	// Missing cluster fails before any AWS call; that's the customer's config, but
+	// there's no error code to narrow it with.
 	err := p.UpdateWorkerSetSize(t.Context(), RequestContext{}, map[string]any{}, 2)
 	require.Error(t, err)
 
 	var pErr *ProviderError
 	require.ErrorAs(t, err, &pErr)
-	assert.Equal(t, FailureMisconfigured, pErr.Class)
+	assert.Equal(t, FailureRejected, pErr.Class)
 }

--- a/wci/workflow/compute_provider/aws_errors_test.go
+++ b/wci/workflow/compute_provider/aws_errors_test.go
@@ -1,0 +1,159 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.temporal.io/auto-scaled-workers/wci/client"
+)
+
+// mockFaultError is a smithy.APIError with a caller-chosen code and fault, for
+// exercising combinations the modelled Lambda types don't cover.
+type mockFaultError struct {
+	code  string
+	fault smithy.ErrorFault
+}
+
+func (e *mockFaultError) ErrorCode() string             { return e.code }
+func (e *mockFaultError) ErrorMessage() string          { return e.code }
+func (e *mockFaultError) ErrorFault() smithy.ErrorFault { return e.fault }
+func (e *mockFaultError) Error() string                 { return e.code }
+
+func TestClassifyAWSFailure(t *testing.T) {
+	wciOwned := func(err error) error { return fmt.Errorf("%w: %w", errWCIOwned, err) }
+
+	cases := []struct {
+		name string
+		err  error
+		want FailureClass
+	}{
+		{"nil", nil, FailureUnclassified},
+		{"canceled", context.Canceled, FailureUnclassified},
+
+		// Customer-owned client faults.
+		{"resource not found", &types.ResourceNotFoundException{}, FailureMisconfigured},
+		{"access denied", &mockFaultError{code: "AccessDeniedException", fault: smithy.FaultClient}, FailureMisconfigured},
+		{"local validation", errors.New("AWS Lambda Function ARN not found or invalid"), FailureMisconfigured},
+
+		// Server faults and transport failures, regardless of ownership.
+		{"service exception", &types.ServiceException{}, FailureUnavailable},
+		{"deadline exceeded", context.DeadlineExceeded, FailureUnavailable},
+		{"connection refused", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, FailureUnavailable},
+		{"wci-owned server fault", wciOwned(&types.ServiceException{}), FailureUnavailable},
+
+		// Throttles, modelled as client faults but neither a misconfiguration nor an
+		// outage. Checked before the fault split, so a server-fault throttle still
+		// classifies as throttled.
+		{"too many requests", &types.TooManyRequestsException{}, FailureThrottled},
+		{"ec2 throttled", &types.EC2ThrottledException{}, FailureThrottled},
+		{"wci-owned throttle", wciOwned(&types.TooManyRequestsException{}), FailureThrottled},
+
+		// WCI-owned client faults.
+		{"wci-owned access denied", wciOwned(&mockFaultError{code: "AccessDenied", fault: smithy.FaultClient}), FailureInternal},
+		{"wci-owned local validation", wciOwned(errors.New("empty role session name")), FailureInternal},
+
+		// Classification must survive the wrapping the providers apply.
+		{"wrapped", fmt.Errorf("failed to invoke lambda: %w", &types.ResourceNotFoundException{}), FailureMisconfigured},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyAWSFailure(tc.err))
+		})
+	}
+}
+
+// The intermediary chain and the customer role both fail through
+// assumeRoleWithRequest with identical wrapping; only errWCIOwned separates them.
+func TestClassifyAWSFailure_SeparatesIntermediaryFromCustomerRole(t *testing.T) {
+	accessDenied := &mockFaultError{code: "AccessDenied", fault: smithy.FaultClient}
+	customer := fmt.Errorf("failed to assume role %s: %w", "arn:aws:iam::1:role/Customer", accessDenied)
+
+	assert.Equal(t, FailureMisconfigured, classifyAWSFailure(customer))
+	assert.Equal(t, FailureInternal, classifyAWSFailure(fmt.Errorf("%w: %w", errWCIOwned, customer)))
+}
+
+// A malformed intermediary role ARN comes from worker-controller's own dynamic
+// config, so it must not be attributed to the customer.
+func TestBuildBaseAWSConfig_MarksIntermediaryFailuresWCIOwned(t *testing.T) {
+	_, err := buildBaseAWSConfig(t.Context(), "us-east-1", [][]client.AWSIAMRoleRequest{
+		{{RoleARN: "not-an-arn", RoleSessionName: "session"}},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, errWCIOwned)
+	assert.Equal(t, FailureInternal, classifyAWSFailure(err))
+}
+
+func TestBuildBaseAWSConfig_MarksEmptySessionNameWCIOwned(t *testing.T) {
+	_, err := buildBaseAWSConfig(t.Context(), "us-east-1", [][]client.AWSIAMRoleRequest{
+		{{RoleARN: testRoleARN, RoleSessionName: ""}},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, errWCIOwned)
+	assert.Equal(t, FailureInternal, classifyAWSFailure(err))
+}
+
+func TestAWSLambdaInvokeWorker_ClassifiesFailure(t *testing.T) {
+	cases := []struct {
+		name      string
+		invokeErr error
+		want      FailureClass
+	}{
+		{"not found", &types.ResourceNotFoundException{}, FailureMisconfigured},
+		{"service down", &types.ServiceException{}, FailureUnavailable},
+		{"throttled", &types.TooManyRequestsException{}, FailureThrottled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stubLambdaClient(t, &mockLambdaClient{
+				invokeFn: func(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
+					return nil, tc.invokeErr
+				},
+			})
+
+			err := newLambdaProvider().InvokeWorker(
+				t.Context(), RequestContext{}, map[string]any{configAWSLambdaARN: testLambdaARN})
+			require.Error(t, err)
+
+			var pErr *ProviderError
+			require.ErrorAs(t, err, &pErr)
+			assert.Equal(t, tc.want, pErr.Class)
+			// Wrapping must stay transparent so existing message assertions hold.
+			assert.Contains(t, err.Error(), "failed to invoke lambda")
+		})
+	}
+}
+
+func TestAWSLambdaInvokeWorker_SuccessIsUnwrapped(t *testing.T) {
+	stubLambdaClient(t, &mockLambdaClient{
+		invokeFn: func(context.Context, *lambda.InvokeInput, ...func(*lambda.Options)) (*lambda.InvokeOutput, error) {
+			return &lambda.InvokeOutput{}, nil
+		},
+	})
+
+	err := newLambdaProvider().InvokeWorker(
+		t.Context(), RequestContext{}, map[string]any{configAWSLambdaARN: testLambdaARN})
+	require.NoError(t, err)
+}
+
+func TestAWSECSUpdateWorkerSetSize_ClassifiesConfigFailure(t *testing.T) {
+	p := &awsECSComputeProvider{intermediaryRoles: [][]client.AWSIAMRoleRequest{}}
+
+	// Missing cluster fails before any AWS call; that's the customer's config.
+	err := p.UpdateWorkerSetSize(t.Context(), RequestContext{}, map[string]any{}, 2)
+	require.Error(t, err)
+
+	var pErr *ProviderError
+	require.ErrorAs(t, err, &pErr)
+	assert.Equal(t, FailureMisconfigured, pErr.Class)
+}

--- a/wci/workflow/compute_provider/aws_lambda.go
+++ b/wci/workflow/compute_provider/aws_lambda.go
@@ -81,6 +81,11 @@ func (p *awsLambdaComputeProvider) ValidateConfig(ctx context.Context, _ Request
 }
 
 func (p *awsLambdaComputeProvider) InvokeWorker(ctx context.Context, _ RequestContext, cfg ComputeProviderConfig) error {
+	err := p.invokeWorker(ctx, cfg)
+	return NewProviderError(classifyAWSFailure(err), err)
+}
+
+func (p *awsLambdaComputeProvider) invokeWorker(ctx context.Context, cfg ComputeProviderConfig) error {
 	lambdaClient, arn, err := p.getLambdaClientAndARN(ctx, cfg)
 	if err != nil {
 		return err

--- a/wci/workflow/compute_provider/errors.go
+++ b/wci/workflow/compute_provider/errors.go
@@ -1,0 +1,45 @@
+package computeprovider
+
+// FailureClass is the provider-agnostic classification of a compute provider
+// failure. Each provider maps its own SDK's error taxonomy onto it so callers can
+// distinguish failure kinds without knowing which provider produced the error.
+type FailureClass int
+
+const (
+	// FailureUnclassified is the zero value, used when a provider has no
+	// classification for an error.
+	FailureUnclassified FailureClass = iota
+	// FailureMisconfigured means the provider rejected the customer's configuration:
+	// a resource that does not exist, or credentials that lack permission to it.
+	FailureMisconfigured
+	// FailureUnavailable means the provider's API was unreachable or returned a
+	// server-side error.
+	FailureUnavailable
+	// FailureThrottled means the request was rate- or concurrency-limited. The
+	// configuration is valid; capacity just is not available right now.
+	FailureThrottled
+	// FailureInternal means the failure is attributable to worker-controller's own
+	// configuration or credentials rather than the customer's.
+	FailureInternal
+)
+
+// ProviderError carries a FailureClass alongside the underlying error. It is
+// transparent for message and unwrapping purposes, so wrapping an error in one
+// does not change how it reads or how errors.Is/As traverse it.
+type ProviderError struct {
+	Class FailureClass
+	cause error
+}
+
+func (e *ProviderError) Error() string { return e.cause.Error() }
+
+func (e *ProviderError) Unwrap() error { return e.cause }
+
+// NewProviderError attaches class to err, returning nil for a nil err so call
+// sites can wrap a result unconditionally.
+func NewProviderError(class FailureClass, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ProviderError{Class: class, cause: err}
+}

--- a/wci/workflow/compute_provider/errors.go
+++ b/wci/workflow/compute_provider/errors.go
@@ -9,9 +9,16 @@ const (
 	// FailureUnclassified is the zero value, used when a provider has no
 	// classification for an error.
 	FailureUnclassified FailureClass = iota
-	// FailureMisconfigured means the provider rejected the customer's configuration:
-	// a resource that does not exist, or credentials that lack permission to it.
-	FailureMisconfigured
+	// FailureRejected means the provider rejected a request made against the
+	// customer's configuration, for a reason the provider could not narrow further.
+	// The two values below are the narrowed cases.
+	FailureRejected
+	// FailureNotFound means the compute resource named by the customer's
+	// configuration does not exist.
+	FailureNotFound
+	// FailureAccessDenied means the resource exists but the role we assumed lacks
+	// permission to act on it.
+	FailureAccessDenied
 	// FailureUnavailable means the provider's API was unreachable or returned a
 	// server-side error.
 	FailureUnavailable


### PR DESCRIPTION
## What was changed

`error_type` on `worker_controller_instance_activities` now distinguishes four kinds of compute provider failure instead of reporting everything as `compute_provider_failed`:

`compute_provider_misconfigured`: AWS rejected the customer's config (bad ARN, missing IAM permissions).
`compute_provider_service_unavailable`: AWS was down or unreachable.
`compute_provider_throttled`: Rate/concurrency limited. Config is valid, but capacity isn't available.
`internal`: WCI's own credentials or intermediary role chain.

compute_provider_failed remains as the fallback for anything unclassified.

Changelist:

- computeprovider.FailureClass is a small provider-agnostic set of judgments; ProviderError carries one alongside the original error. It's transparent for Error()/Unwrap(), so messages and error inspection are unchanged.
- classifyAWSFailure (aws.go) picks a class using the AWS SDK's own client/server fault tagging, its published throttle-code list, and its connection-error checks.
- buildBaseAWSConfig marks its four failure paths with errWCIOwned, since every input there is ours rather than the customer's.
- Lambda's InvokeWorker and ECS's UpdateWorkerSetSize wrap their results with a class. Bodies are untouched.
- computeProviderErrorType (activities.go) maps class → tag at both call sites.

Scope: Lambda and ECS. GCP Cloud Run will need its own classifier.

## Why?

One label was covering three (very) different failure situations for aws lambda invokes, so the metric could not solve the paging issue. We desire different alarms with different thesholds regarding customer errors, API downages, and WCI faults. ECS may require this in the future, so preemptively gave it this functionality.

Addressed PR feedback:
`misconfigured` → `rejected` + condition split, and `compute_provider_unavailable` → `compute_provider_not_enabled`. 

Also renamed `internal` → `compute_provider_internal`.
