### PR TITLE
Close the per-namespace SDK client when the worker stops

### DIFF
--- a/wci/workercomponent/component.go
+++ b/wci/workercomponent/component.go
@@ -33,7 +33,6 @@ func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *worke
 }
 
 func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Namespace, details workercommon.RegistrationDetails) func() {
-	// there is no need to close the sdkClient as it uses an existing grpc connection
 	sdkClient := s.sdkClientFactory.NewClient(sdkclient.Options{
 		Namespace:     ns.Name().String(),
 		DataConverter: sdk.PreferProtoDataConverter,
@@ -60,5 +59,5 @@ func (s *workerComponent) Register(registry sdkworker.Registry, ns *namespace.Na
 	registry.RegisterWorkflowWithOptions(validateWorkflow, workflow.RegisterOptions{Name: iface.WorkerControllerInstanceValidateWorkflowType})
 	registry.RegisterActivity(activities)
 
-	return nil
+	return func() { sdkClient.Close() }
 }


### PR DESCRIPTION
## What changed?

`workerComponent.Register` returns a cleanup that closes the SDK client it created, instead of `nil`.

## Why?
Found while removing the goroutine-leak ignores in temporalio/temporal (temporalio/temporal#11438). Instrumenting the SDK client factory showed this as the one derived client still open at cluster shutdown.

## How did you test it?
- [x] built
- [x] covered by existing tests

Verified against temporalio/temporal with a local `replace`: with this change, that repo's `make leak-test` passes with its SDK-client tracking removed entirely, which it does not today.