### PR TITLE
Add additional context to cancel timers when deleting WCI

### DIFF
--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -48,6 +48,11 @@ const (
 	// Signals the version workflow after each ValidationStatus change so the
 	// deployment workflow can maintain an aggregate connectivity summary in its memo.
 	SignalVersionWorkflowVersion
+
+	// Cancels the child context which is attached to the timer futures,
+	// which, on deletion, will mark the future as failed and prevent the body of
+	// the associated callback from running.
+	CancelTimersOnDeleteVersion
 )
 
 type (
@@ -449,7 +454,9 @@ func (d *WorkflowRunner) validateDeleteInstance(args *iface.DeleteWorkerControll
 // task context - so that any further tasks will abort on next invocation.
 func (d *WorkflowRunner) markDeleted() {
 	d.deleteInstance = true
-	d.cancelTimerTasks()
+	if d.hasMinVersion(CancelTimersOnDeleteVersion) {
+		d.cancelTimerTasks()
+	}
 }
 
 func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.DeleteWorkerControllerInstanceRequest) (*iface.DeleteWorkerControllerInstanceResponse, error) {

--- a/wci/workflow/workflow.go
+++ b/wci/workflow/workflow.go
@@ -69,6 +69,8 @@ type (
 		unsafeMaxVersion                 func() int
 		unsafePeriodicValidationInterval func() time.Duration
 
+		cancelTimerTasks workflow.CancelFunc
+
 		// stateChanged is used to track if the state of the workflow has undergone a local state change since the last signal/update.
 		// This prevents a workflow from continuing-as-new if the state has not changed.
 		stateChanged  bool
@@ -125,6 +127,11 @@ func Workflow(ctx workflow.Context, unsafeWorkflowVersionGetter func() WorkerCon
 
 func (d *WorkflowRunner) run(ctx workflow.Context) error {
 	var err error
+
+	// Create a Context to use for periodic background tasks.
+	// This allows us to cancel these tasks when the WCI is deleted.
+	timerCtx, cancelTimerTasks := workflow.WithCancel(ctx)
+	d.cancelTimerTasks = cancelTimerTasks
 
 	// make sure we got all fields we want
 	if d.State == nil {
@@ -192,15 +199,15 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 
 	var addStatsPullTimer func(nextPoll time.Duration)
 	addStatsPullTimer = func(nextPoll time.Duration) {
-		timerFuture := workflow.NewTimer(ctx, nextPoll)
+		timerFuture := workflow.NewTimer(timerCtx, nextPoll)
 		d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
-			if err = f.Get(ctx, nil); err != nil {
+			if err = f.Get(timerCtx, nil); err != nil {
 				d.logger.Debug("Periodic stats timer cancelled, not re-arming", "error", err)
 
 				// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
 				return
 			}
-			nextPollDuration := d.pullStatsAndUpdate(ctx)
+			nextPollDuration := d.pullStatsAndUpdate(timerCtx)
 
 			// for now we don't want to mark things as dirty to avoid excessive CaN
 			// d.stateChanged = true
@@ -217,15 +224,15 @@ func (d *WorkflowRunner) run(ctx workflow.Context) error {
 
 		var addPeriodicValidationTimer func()
 		addPeriodicValidationTimer = func() {
-			timerFuture := workflow.NewTimer(ctx, validationInterval)
+			timerFuture := workflow.NewTimer(timerCtx, validationInterval)
 			d.signalHandler.signalSelector.AddFuture(timerFuture, func(f workflow.Future) {
-				if err = f.Get(ctx, nil); err != nil {
+				if err = f.Get(timerCtx, nil); err != nil {
 					d.logger.Debug("Periodic validation timer cancelled, not re-arming", "error", err)
 
 					// Context was cancelled (e.g., continue-as-new). Do not validate or re-arm.
 					return
 				}
-				d.periodicValidateSpec(ctx)
+				d.periodicValidateSpec(timerCtx)
 				addPeriodicValidationTimer()
 			})
 		}
@@ -360,7 +367,7 @@ func (d *WorkflowRunner) handleUpdateInstance(ctx workflow.Context, args *iface.
 		// if there are no scaling groups after the update, it is seen as implicit delete
 		// that way no orphaned workflows stick around and waste cycles
 		if len(updatedSpec.ScalingGroupSpecs) == 0 {
-			d.deleteInstance = true
+			d.markDeleted()
 			d.State.ConflictToken = args.ConflictToken
 			d.State.Spec = updatedSpec
 
@@ -438,6 +445,13 @@ func (d *WorkflowRunner) validateDeleteInstance(args *iface.DeleteWorkerControll
 	return nil
 }
 
+// markDeleted sets the deleteInstance flag to true as well as cancelling the background
+// task context - so that any further tasks will abort on next invocation.
+func (d *WorkflowRunner) markDeleted() {
+	d.deleteInstance = true
+	d.cancelTimerTasks()
+}
+
 func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.DeleteWorkerControllerInstanceRequest) (*iface.DeleteWorkerControllerInstanceResponse, error) {
 	if err := d.preUpdateChecks(ctx); err != nil {
 		return &iface.DeleteWorkerControllerInstanceResponse{}, err
@@ -456,7 +470,7 @@ func (d *WorkflowRunner) handleDeleteInstance(ctx workflow.Context, args *iface.
 		d.lock.Unlock()
 	}()
 
-	d.deleteInstance = true
+	d.markDeleted()
 
 	d.recordUpdate(wcimetrics.UpdateTypeDeleteInstance, wcimetrics.ErrorTypeNone, wcimetrics.ActivityErrorTypeNone)
 

--- a/wci/workflow/workflow_test.go
+++ b/wci/workflow/workflow_test.go
@@ -1,0 +1,131 @@
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/sdk/testsuite"
+	sdkworkflow "go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/common/sdk"
+)
+
+// TestDeleteInstanceCancelsPendingTimer covers the race this fix targets: a delete
+// arrives (explicitly via DeleteWorkerControllerInstance, or implicitly via an
+// UpdateWorkerControllerInstance that removes the last scaling group) while the
+// stats-pull timer is still pending. Before CancelTimersOnDeleteVersion, the main
+// select loop has no way to notice the delete until that timer fires on its own, so
+// PullStats still runs at least once after deletion. At CancelTimersOnDeleteVersion,
+// markDeleted cancels the shared timer context, so the pending timer future resolves
+// immediately, wakes the loop, and the workflow returns without PullStats ever firing.
+func TestDeleteInstanceCancelsPendingTimer(t *testing.T) {
+	scalingConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(iface.ScalingAlgorithmConfig{})
+	require.NoError(t, err)
+	computeConfigPayload, err := sdk.PreferProtoDataConverter.ToPayload(map[string]any{})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name              string
+		workflowVersion   WorkerControllerInstanceWorkflowVersion
+		wantPullStatsCall bool
+		// wantPromptCompletion distinguishes the fix from the empty-spec short-circuit
+		// in pullStatsAndUpdate: for the implicit-delete path, that short-circuit alone
+		// already keeps PullStats from firing regardless of this fix, since the update
+		// also empties d.State.Spec.ScalingGroupSpecs. So the fix's effect there is only
+		// observable as completion timing, not as a PullStats call/no-call difference.
+		wantPromptCompletion bool
+		updateName           string
+		updateArgs           any
+	}{
+		{
+			name:                 "explicit delete, pre-fix version leaves the timer pending; PullStats still fires once after delete",
+			workflowVersion:      SignalVersionWorkflowVersion,
+			wantPullStatsCall:    true,
+			wantPromptCompletion: false,
+			updateName:           iface.DeleteWorkerControllerInstance,
+			updateArgs:           &iface.DeleteWorkerControllerInstanceRequest{},
+		},
+		{
+			name:                 "explicit delete, fixed version cancels the pending timer; PullStats never fires after delete",
+			workflowVersion:      CancelTimersOnDeleteVersion,
+			wantPullStatsCall:    false,
+			wantPromptCompletion: true,
+			updateName:           iface.DeleteWorkerControllerInstance,
+			updateArgs:           &iface.DeleteWorkerControllerInstanceRequest{},
+		},
+		{
+			name:                 "implicit delete (last scaling group removed), pre-fix version waits out the pending timer before completing",
+			workflowVersion:      SignalVersionWorkflowVersion,
+			wantPullStatsCall:    false,
+			wantPromptCompletion: false,
+			updateName:           iface.UpdateWorkerControllerInstance,
+			updateArgs:           &iface.UpdateWorkerControllerInstanceRequest{RemoveScalingGroups: []string{"workflow"}},
+		},
+		{
+			name:                 "implicit delete (last scaling group removed), fixed version cancels the pending timer and completes promptly",
+			workflowVersion:      CancelTimersOnDeleteVersion,
+			wantPullStatsCall:    false,
+			wantPromptCompletion: true,
+			updateName:           iface.UpdateWorkerControllerInstance,
+			updateArgs:           &iface.UpdateWorkerControllerInstanceRequest{RemoveScalingGroups: []string{"workflow"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			activities := NewActivities(nil, nil, nil)
+			args := &iface.WorkerControllerInstanceWorkflowArgs{
+				NamespaceName:  "test-namespace",
+				DeploymentName: "test-deployment",
+				BuildId:        "test-build",
+				State: &iface.WorkerControllerInstanceLocalState{
+					Spec: &iface.WorkerControllerInstanceSpec{
+						ScalingGroupSpecs: map[string]iface.ScalingGroupSpec{
+							"workflow": newTestScalingGroupSpec(enumspb.TASK_QUEUE_TYPE_WORKFLOW, scalingConfigPayload, computeConfigPayload),
+						},
+					},
+				},
+			}
+
+			// Mirrors how wci/workercomponent/component.go wires Workflow, but pins
+			// the version directly instead of reading it from dynamic config.
+			testWorkflow := func(ctx sdkworkflow.Context, args *iface.WorkerControllerInstanceWorkflowArgs) error {
+				return Workflow(ctx,
+					func() WorkerControllerInstanceWorkflowVersion { return tc.workflowVersion },
+					func() int { return 100 },
+					func() time.Duration { return periodicValidationInterval },
+					args, activities)
+			}
+
+			var suite testsuite.WorkflowTestSuite
+			env := suite.NewTestWorkflowEnvironment()
+			env.RegisterWorkflow(testWorkflow)
+
+			pullStatsCalled := false
+			env.OnActivity(activities.PullStats, mock.Anything, mock.Anything).
+				Return(&PullStatsActivityResponse{NextPollSeconds: uint32(maxPollInterval.Seconds())}, nil).
+				Run(func(mock.Arguments) { pullStatsCalled = true })
+
+			env.RegisterDelayedCallback(func() {
+				env.UpdateWorkflowNoRejection(tc.updateName, "update-1", t, tc.updateArgs)
+			}, time.Millisecond)
+
+			startTime := env.Now()
+			env.ExecuteWorkflow(testWorkflow, args)
+			elapsed := env.Now().Sub(startTime)
+
+			require.True(t, env.IsWorkflowCompleted())
+			require.NoError(t, env.GetWorkflowError())
+			require.Equal(t, tc.wantPullStatsCall, pullStatsCalled)
+			if tc.wantPromptCompletion {
+				require.Less(t, elapsed, time.Second, "expected the workflow to complete promptly after delete, without waiting out the pending timer")
+			} else {
+				require.GreaterOrEqual(t, elapsed, maxPollInterval, "expected the workflow to wait out the pending stats-pull timer before completing")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was changed
Adds a new child `Context` derived from the main one which is used to spawn the PullStats and Validate timers, as well as within the timer callbacks. This sub-context is cancelled when the WCI receives a deletion (either directly or implied). Thus, we prevent these timed functions from running after the WCI has been deleted.

## Why?
As it stands, the deletion flag is checked on every iteration of the `for` loop that checks for incoming signals. However, since the `select` call blocks the main routine until it's woken by a task add or a timer wakeup, one of these _must_ occur before the flag can be checked and break the loop. 

So when a WCI receives the update to delete itself, it still must wait for one of these things to happen before it can exit. In practice, this is almost certainly going to be the PullStats timer since a) it runs every minute, and b) if a WCI is deleted it probably isn't receiving new tasks.

This is a problem because when PullStats runs, it fails because the WDV doesn't exist anymore, producing error/alarm noise.

By adding a new sub-context, we can have the deletion function also cancel that context, which will immediately unblock the select. The PullStats activity doesn't run, the loop is allowed to continue and thus exit, and the workflow ends cleanly.

## Checklist (tk)
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Added a new unit test to cover the explicit and implicit deletion pathways (the current two ways a WCI can be marked as deleted)

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
