### PR TITLE
COM-214: Add release tagging

### DIFF
--- a/.github/scripts/compute-release-tag.sh
+++ b/.github/scripts/compute-release-tag.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Compute the next WCI release tag for a release branch.
+#
+# Prints v<wciMajor>.<wciMinor>.<wciPatch>-<serverVersion>: major/minor come from the
+# release/vMAJOR.MINOR branch name, patch is one past the highest already tagged on that
+# line, and the suffix is the pinned server build tag flattened to digits and dots
+# (resolve-server-suffix.sh). Nothing is created or pushed — the caller does that.
+#
+# Reads tags from the current repo, so run it in a checkout with tags fetched
+# (fetch-depth: 0), on the commit being released.
+#
+# Args:
+#   $1  release branch (default: $BRANCH)
+#
+# Env:
+#   BRANCH         release branch, when not passed as $1
+#   GITHUB_TOKEN   inherited by resolve-server-suffix.sh for its clone
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# Semver numeric identifier: no leading zeros anywhere in the tag we mint, or Go and the
+# module proxy reject it as non-canonical.
+NUM='(0|[1-9][0-9]*)'
+WCI_TAG_RE="^v${NUM}[.]${NUM}[.]${NUM}(-${NUM}([.]${NUM})*)?$"
+# What the caller may push: the server suffix is mandatory, unlike WCI_TAG_RE above,
+# which also has to match older or hand-made tags when scanning the line.
+MODULE_TAG_RE="^v${NUM}[.]${NUM}[.]${NUM}-${NUM}([.]${NUM})+$"
+
+# Next WCI patch on the $1.$2 line, across any server suffix: one past the highest
+# existing tag by version sort — not git describe's nearest ancestor, which an
+# out-of-order tag on an older commit would reset. 0 when the line has no tags yet.
+next_patch() {
+  local major="$1" minor="$2" tag
+  tag=$(git tag --list "v${major}.${minor}.*" | grep -E "$WCI_TAG_RE" | sort -V | tail -1) || true
+  if [[ -z "$tag" ]]; then
+    printf '0\n'
+    return
+  fi
+  # Anchored on this line's major.minor, so BASH_REMATCH[1] is the patch.
+  if [[ ! "$tag" =~ ^v${major}[.]${minor}[.]${NUM}(-${NUM}([.]${NUM})*)?$ ]]; then
+    echo "tag '$tag' does not match v${major}.${minor}.PATCH[-build.rev]" >&2
+    exit 1
+  fi
+  printf '%s\n' "$((BASH_REMATCH[1] + 1))"
+}
+
+main() {
+  local branch="${1:-${BRANCH:-}}"
+  if [[ -z "$branch" ]]; then
+    echo "usage: $(basename "$0") <release/vMAJOR.MINOR>  (or set BRANCH)" >&2
+    exit 1
+  fi
+
+  # The branch encodes WCI's own major.minor.
+  if [[ ! "$branch" =~ ^release/v${NUM}[.]${NUM}$ ]]; then
+    echo "branch '$branch' does not match release/vMAJOR.MINOR" >&2
+    exit 1
+  fi
+  local major="${BASH_REMATCH[1]}" minor="${BASH_REMATCH[2]}"
+
+  # Re-run at an already-tagged commit (job re-run, or a push that changed nothing on
+  # this line): reuse that tag. Computing a successor would leave one commit carrying
+  # two release tags.
+  local tag
+  tag=$(git tag --points-at HEAD --list "v${major}.${minor}.*" | grep -E "$WCI_TAG_RE" | sort -V | tail -1) || true
+  if [[ -n "$tag" ]]; then
+    echo "HEAD is already tagged $tag" >&2
+  else
+    local suffix
+    suffix=$(bash "$SCRIPT_DIR/resolve-server-suffix.sh")
+    echo "server suffix: $suffix" >&2
+
+    local patch
+    patch=$(next_patch "$major" "$minor")
+    tag="v${major}.${minor}.${patch}-${suffix}"
+  fi
+
+  # The module proxy caches a pushed tag immutably, so check the assembled result before
+  # handing it to the caller — both paths build it from separately-validated parts.
+  if [[ ! "$tag" =~ $MODULE_TAG_RE ]]; then
+    echo "tag '$tag' is not a vMAJOR.MINOR.PATCH-<serverVersion> module version" >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$tag"
+}
+
+main "$@"

--- a/.github/scripts/resolve-server-suffix.sh
+++ b/.github/scripts/resolve-server-suffix.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Resolve the server-release suffix for a WCI module tag.
+#
+# The WCI tag is v<wciMajor>.<wciMinor>.<wciPatch>-<serverVersion>, where
+# <serverVersion> is the pinned go.temporal.io/server build tag flattened to digits
+# and dots (v1.32.0-158.3 -> 1.32.0.158.3). This prints that suffix.
+#
+# Resolution:
+#   1. Read the go.temporal.io/server pin from go.mod (or arg $1).
+#   2. If it's already a clean build tag (vX.Y.Z-BUILD.REV), reformat and use it.
+#   3. Otherwise it's a pseudo-version (safety net): extract the commit hash, find
+#      the earliest server build tag that *contains* that commit, and use that. (Go
+#      bases a pseudo-version on the nearest ancestor tag, which can sit many builds
+#      behind — and on a different minor line — from where the commit really shipped.)
+#
+# Failure modes (both exit non-zero):
+#   - commit not reachable in temporal    -> can't build against it anyway
+#   - commit ahead of every release tag   -> WCI must track a *released* server
+#
+# Env:
+#   EMIT           "suffix" (default) prints the flattened suffix (1.32.0.158.3);
+#                  "tag" prints the resolved server build tag (v1.32.0-158.3) — used
+#                  by the release guard to suggest a repin target.
+#   TEMPORAL_DIR   use an existing temporal checkout instead of cloning (tests)
+#   GITHUB_TOKEN   auth for the clone (public repo; avoids the unauth rate limit)
+#   SERVER_REPO    override clone URL (default github.com/temporalio/temporal)
+set -euo pipefail
+
+# A semver numeric identifier: no leading zeros. Server build tag v1.32.0-158.03 would
+# flatten to the suffix 1.32.0.158.03, and `1.0.0-1.32.0.158.03` is not valid semver —
+# Go and the module proxy reject it. Fail here instead of at tag-push time.
+NUM='(0|[1-9][0-9]*)'
+RELEASE_TAG_RE="^v${NUM}[.]${NUM}[.]${NUM}-${NUM}[.]${NUM}$"
+
+# Flatten a server build tag to the WCI-tag suffix: v1.32.0-158.3 -> 1.32.0.158.3
+# (drop the leading v, turn the base/build separator '-' into '.').
+to_suffix() {
+  local tag="${1#v}"
+  printf '%s\n' "${tag/-/.}"
+}
+
+# Emit the resolved server build tag ($1): the flattened suffix by default, or the
+# tag itself when EMIT=tag (the guard uses that to suggest a repin target).
+emit() {
+  if [[ "${EMIT:-suffix}" == "tag" ]]; then
+    printf '%s\n' "$1"
+  else
+    to_suffix "$1"
+  fi
+}
+
+# Set only when we create a throwaway clone; removed on exit.
+CLONE_DIR=""
+cleanup() { [[ -n "$CLONE_DIR" ]] && rm -rf "$CLONE_DIR"; return 0; }
+trap cleanup EXIT
+
+server_pin() {
+  if [[ $# -ge 1 && -n "${1:-}" ]]; then
+    printf '%s\n' "$1"
+    return
+  fi
+  local ver
+  ver=$(grep 'go\.temporal\.io/server ' "${GOMOD:-go.mod}" | awk '{print $2}')
+  [[ -n "$ver" ]] || { echo "no go.temporal.io/server pin in ${GOMOD:-go.mod}" >&2; exit 1; }
+  printf '%s\n' "$ver"
+}
+
+# Earliest server release tag (by globally-monotonic build number) that contains
+# $1 in its history. Empty output if none.
+earliest_containing() {
+  local hash="$1"
+  git -C "$TEMPORAL_DIR" tag --contains "$hash" --list 'v*' 2>/dev/null \
+    | grep -E "$RELEASE_TAG_RE" \
+    | sort -t- -k2 -V \
+    | head -1
+}
+
+main() {
+  local ver
+  ver=$(server_pin "${1:-}")
+
+  # Already a clean build tag — no lookup needed.
+  if [[ "$ver" =~ $RELEASE_TAG_RE ]]; then
+    emit "$ver"
+    return
+  fi
+
+  # Build-tag shape but not canonical semver — say so, rather than reporting it as an
+  # unrecognised pin below.
+  if [[ "$ver" =~ ^v[0-9]+[.][0-9]+[.][0-9]+-[0-9]+[.][0-9]+$ ]]; then
+    echo "server pin '$ver' has a leading-zero component; the flattened suffix would not be valid semver" >&2
+    exit 1
+  fi
+
+  # Pseudo-version: the commit hash is the final dash-delimited segment.
+  local hash="${ver##*-}"
+  if [[ ! "$hash" =~ ^[0-9a-f]{12}$ ]]; then
+    echo "server pin '$ver' is neither a release tag nor a pseudo-version" >&2
+    exit 1
+  fi
+
+  # Get a commit graph (no trees/blobs) unless one was provided.
+  if [[ -z "${TEMPORAL_DIR:-}" ]]; then
+    TEMPORAL_DIR=$(mktemp -d)
+    CLONE_DIR="$TEMPORAL_DIR"
+    local url="${SERVER_REPO:-https://github.com/temporalio/temporal.git}"
+    if [[ -n "${GITHUB_TOKEN:-}" && "$url" == https://github.com/* ]]; then
+      url="https://x-access-token:${GITHUB_TOKEN}@${url#https://}"
+    fi
+    git clone --filter=tree:0 --no-checkout --quiet "$url" "$TEMPORAL_DIR"
+  fi
+
+  # Failure mode 1: commit not reachable in the repo.
+  if ! git -C "$TEMPORAL_DIR" cat-file -e "${hash}^{commit}" 2>/dev/null; then
+    echo "server commit ${hash} is not reachable in temporal (force-pushed, unmerged, or private)" >&2
+    exit 1
+  fi
+
+  local earliest
+  earliest=$(earliest_containing "$hash")
+
+  # Failure mode 2: reachable but not yet in any release.
+  if [[ -z "$earliest" ]]; then
+    echo "server commit ${hash} is not in any server release yet; WCI must track a released server build" >&2
+    exit 1
+  fi
+
+  emit "$earliest"
+}
+
+main "$@"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  # Called by release-auto-tag.yml as a release gate, before it pushes a tag.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit, branch, or tag to validate (empty = the triggering ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -20,6 +27,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Empty means "the ref for the triggering event", so pull_request and
+          # push are unaffected; only workflow_call sets this.
+          ref: ${{ inputs.ref }}
 
       - name: Check go.mod consistency between root and tests/
         run: |
@@ -60,6 +71,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -110,6 +123,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,6 +1,13 @@
 name: Linting
 on:
   pull_request:
+  # Called by release-auto-tag.yml as a release gate, before it pushes a tag.
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Commit, branch, or tag to lint (empty = the triggering ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Empty means "the ref for the triggering event", so pull_request is
+          # unaffected; only workflow_call sets this.
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -20,4 +30,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12
-          args: --new-from-rev=${{ github.event.pull_request.base.sha }}
+          # PRs lint only what they changed; a release gate lints the whole tree.
+          args: >-
+            ${{ (github.event_name == 'pull_request'
+              && format('--new-from-rev={0}', github.event.pull_request.base.sha))
+            || '' }}

--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -1,0 +1,130 @@
+name: Auto-tag Release
+
+# A WCI module release is tagged v<wciMajor>.<wciMinor>.<wciPatch>-<serverBuild>.<serverRev>:
+# WCI owns the semver core; the server suffix is the earliest go.temporal.io/server
+# release that actually contains the commit go.mod builds against (resolved by
+# .github/scripts/resolve-server-suffix.sh). Push to release/v<major>.<minor> and this
+# checks the pin, runs the release gates, computes the next patch, appends the
+# server suffix, and pushes the tag.
+#
+# The tag is the whole release: consumers `go get` it through the module proxy. No
+# GitHub Release is published — WCI is a library, and there are no artifacts to attach.
+#
+# Design notes:
+#   - Tags are bare vX.Y.Z-<build>.<rev> (the module is at the repo root), e.g.
+#     v1.0.0-158.0.
+#   - The server release is a `-` prerelease suffix, not `+` build metadata: Go
+#     rejects build metadata for module versions (only +incompatible is legal).
+#   - Gates run *before* the tag push: a published tag is immediately resolvable by
+#     `go get` and the module proxy caches it immutably, so a tag that fails lint or
+#     tests cannot be retracted — only superseded.
+on:
+  push:
+    branches:
+      - 'release/v*'
+
+permissions:
+  contents: write # push the tag
+
+concurrency: # serialize so back-to-back pushes always tag off the previous tag
+  group: release-auto-tag-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  # Gates depend on this job rather than running alongside it: it finishes in seconds,
+  # and a bad server pin is the likeliest failure on a fresh release branch.
+  check-pin:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      # A release must depend on a server build-tag release, not a pseudo-version.
+      # For a pseudo-version, it resolves the earliest server build tag containing
+      # the commit and suggest it as the exact repin target.
+      - name: Require a tagged server release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Numeric identifiers reject leading zeros: the pin is flattened into the WCI
+          # tag's prerelease, where a zero-padded component is invalid semver.
+          NUM='(0|[1-9][0-9]*)'
+          VER=$(grep 'go\.temporal\.io/server ' go.mod | awk '{print $2}')
+          if [[ "$VER" =~ ^v${NUM}[.]${NUM}[.]${NUM}-${NUM}[.]${NUM}$ ]]; then
+            echo "server pin OK: ${VER}"
+            exit 0
+          fi
+          echo "go.mod pins go.temporal.io/server at '${VER}' — not a build-tag release." >&2
+          if SUGGESTED=$(EMIT=tag bash .github/scripts/resolve-server-suffix.sh 2>/dev/null); then
+            echo "Repin to the earliest server build tag containing that commit:" >&2
+            echo "  go get go.temporal.io/server@${SUGGESTED} && go mod tidy" >&2
+          else
+            echo "Could not resolve a containing build tag — the commit may not be in any" >&2
+            echo "server release yet. Repin to a released build tag:" >&2
+            echo "  go get go.temporal.io/server@<vX.Y.Z-BUILD.REV> && go mod tidy" >&2
+          fi
+          exit 1
+
+  # The release gates are the same workflows PRs run — go.mod sync, unit and
+  # integration tests, lint — called here so they block the tag push rather than
+  # racing it. `pull-requests: write` is for ci.yaml's coverage-report jobs; they
+  # skip off a pull_request event, but a called workflow can only narrow the
+  # permissions its caller grants, so the grant has to cover them.
+  ci:
+    needs: check-pin
+    uses: ./.github/workflows/ci.yaml
+    with:
+      ref: ${{ github.sha }}
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+
+  lint:
+    needs: check-pin
+    uses: ./.github/workflows/golangci-lint.yaml
+    with:
+      ref: ${{ github.sha }}
+    permissions:
+      contents: read
+
+  auto-tag:
+    needs: [ci, lint]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      # Pin to the commit the gates ran against, not the branch tip: a push that
+      # lands mid-run must not get tagged as though it had been validated.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Compute and push next tag
+        env:
+          BRANCH: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          NEW_TAG=$(bash .github/scripts/compute-release-tag.sh)
+
+          if EXISTING_SHA=$(git rev-parse "${NEW_TAG}" 2>/dev/null); then
+            HEAD_SHA=$(git rev-parse HEAD)
+            if [[ "${EXISTING_SHA}" == "${HEAD_SHA}" ]]; then
+              echo "Tag ${NEW_TAG} already exists and points at HEAD, skipping"
+              exit 0
+            fi
+            echo "Tag ${NEW_TAG} already exists but points at ${EXISTING_SHA}, not HEAD (${HEAD_SHA}); refusing to overwrite" >&2
+            exit 1
+          fi
+
+          echo "Creating tag ${NEW_TAG} at $(git rev-parse HEAD)"
+          git tag "${NEW_TAG}" HEAD
+          git push origin tag "${NEW_TAG}"

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,98 @@
+# Releasing `temporal-auto-scaled-workers`
+
+A release is a git tag `v<major>.<minor>.<patch>-<serverVersion>` — WCI's own semver
+core plus the `go.temporal.io/server` build tag that `go.mod` pins. Server's build tag is flattened to
+digits and dots (server `v1.32.0-158.3` results in WCI `v1.0.0-1.32.0.158.3`). Downstream
+consumers `go get` that tag.
+
+The tag *is* the release. No GitHub Release is published — WCI is consumed as a Go
+library, so there are no artifacts to attach to one.
+
+Tagging and the gates are automated and are triggered by pushing a release branch
+
+## Cut a release (manual step)
+
+Pick `MAJOR` and `MINOR` for WCI's own version and a base commit on `main`. **The branch name
+`release/vMAJOR.MINOR` is the only place you declare MAJOR.MINOR** — there's no
+version file or variable to edit. The automation parses them off the branch and
+computes PATCH and the server suffix for you.
+
+- **New feature:** cut a new MINOR release: `release/v1.1`
+- **Breaking API change:** cut a new MAJOR release: `release/v2.0`
+- **Bug fix on an existing version:** don't cut anything; merge it on the existing
+  `release/vMAJOR.MINOR` branch and PATCH auto-increments (see [Patches](#patches)).
+
+**Prerequisite: `go.mod` must pin `go.temporal.io/server` to a build-tag release**
+(`vX.Y.Z-BUILD.REV`, e.g. `v1.32.0-158.3`), not a pseudo-version. This sets the
+release dependency on a released server build *and* pins WCI's own CI to the exact build the tag
+will claim. The release **fails** otherwise.
+
+**That pin belongs on the release branch, not on `main`.** `main` tracks server tip as
+a pseudo-version and keeps doing so; the repin is a release-time change. What matters
+is that the build tag is in the commit at the tip of the branch when you push it —
+that's the commit `check-pin` and the gates run against. Cutting the branch from
+`origin/main` takes nothing from your working tree, so repin after the branch exists:
+
+```shell
+RELEASE_BRANCH="release/v1.0"          # MAJOR.MINOR live here
+BASE="origin/main"                     # or a specific reviewed SHA
+
+git fetch origin main
+git switch -c "${RELEASE_BRANCH}" "${BASE}"
+
+# The resolver prints the earliest build tag containing the commit go.mod points at.
+# Pin that, or a later build you've validated, in both modules.
+TAG=$(EMIT=tag bash .github/scripts/resolve-server-suffix.sh)   # e.g. v1.32.0-158.0
+go get "go.temporal.io/server@${TAG}" && go mod tidy
+( cd tests && go get "go.temporal.io/server@${TAG}" && go mod tidy )   # tests/ is a separate module
+git commit -am "chore: pin go.temporal.io/server ${TAG}"
+
+git push -u origin "${RELEASE_BRANCH}"  # this triggers .github/workflows/release-auto-tag.yml
+```
+
+If the branch already pins a build tag, `go get` changes nothing and `git commit` has
+nothing to commit — skip both. If you skip the pin entirely, `check-pin` fails and
+prints this same command.
+
+## What happens automatically after the push
+
+Pushing the branch runs **`release-auto-tag.yml`**, which validates, then tags:
+
+- `check-pin` guards that `go.mod`'s server pin is a build-tag release. Anything else —
+  a pseudo-version, or a plain `vX.Y.Z` — fails, and it prints the repin command,
+  naming the exact build tag when `resolve-server-suffix.sh` can resolve one. It reads
+  the root `go.mod`; `tests/go.mod` is covered by `ci.yaml`'s go.mod sync check below.
+- `ci` and `lint` run the same gates a PR runs — `ci.yaml` (go.mod sync between the
+  root and `tests/`, unit tests, integration tests) and `golangci-lint.yaml` — against
+  the commit being released. Both are called, not merely triggered, so they block the
+  tag push instead of racing it. Lint covers the whole tree here; on a PR it is
+  limited to the diff.
+- `auto-tag` runs `.github/scripts/compute-release-tag.sh` and pushes what it returns:
+  the next WCI patch on the `vMAJOR.MINOR.*` version (seeding at `.0`), suffixed with the
+  pinned build tag flattened by `resolve-server-suffix.sh` (`v1.32.0-158.3` flattens to
+  `1.32.0.158.3`). Runs are serialized, so back-to-back pushes tag in order.
+
+That push is the end of the process — the tag is the release.
+
+## Patches
+
+Land the fix on the same `release/vMAJOR.MINOR` branch (cherry-pick or PR into it).
+Each push re-runs the automation and cuts the next patch (`v1.0.1-…`, `v1.0.2-…`).
+The suffix follows whatever server build tag `go.mod` pins on that branch (bump it
+with `go get go.temporal.io/server@<build-tag>` to move to a newer server).
+
+## New minor / major 
+
+Cut a fresh branch (`release/v1.1`, `release/v2.0`); it seeds its own `.0` patch.
+
+## Break-glass
+
+- Re-run a failed `release-auto-tag.yml` from the Actions UI. It re-runs on the same
+  commit, and if that commit is already tagged it reuses the tag instead of cutting a
+  second one, so a re-run after a partial failure is safe.
+- Preview the tag a branch would get, without pushing anything:
+  `BRANCH=release/v1.0 .github/scripts/compute-release-tag.sh`
+- A tag pushed **by hand** bypasses all of this. Nothing validates it and nothing
+  re-runs the gates, and the module proxy caches it the moment it resolves, so it
+  cannot be retracted — only superseded by a higher patch. Let the automation cut
+  tags.

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
 go = "1.26.4"
 golangci-lint = "2.12.2"
+actionlint = "1.7.12"
+shellcheck = "0.11.0" # actionlint shell-lints `run:` blocks only when this is on PATH
 
 # Integration tests live in the ./tests module and require the test_dep build tag
 # (compute-observer spy hooks). TEMPORAL_ROOT keeps testcore's .testoutput out of the


### PR DESCRIPTION
## What was changed

Adds release tags to the module. Tags are `v<major>.<minor>.<patch>-<serverVersion>`: WCI's semver core suffixed with the `go.temporal.io/server` build tag `go.mod` pins, flattened to digits and dots (server `v1.32.0-158.3` gives WCI `v1.0.0-1.32.0.158.3`). The suffix means a WCI version names the server build it was compiled against, so compatibility is readable from the version alone.

The tag is the whole release. Nothing publishes a GitHub Release — WCI is consumed as a Go library, so there are no artifacts to attach to one.

* Cutting a `release/vMAJOR.MINOR` branch is the only manual step. Its push runs `release-auto-tag.yml`: check the server pin, run the gates, compute the next patch, push the tag.
* The gates are the workflows PRs already run. `ci.yaml` and `golangci-lint.yaml` gained a `workflow_call` trigger and an optional `ref` input, so the release path calls them as `needs` dependencies instead of racing a parallel run. An empty `ref` means "the triggering ref", so `pull_request` and `push` are unaffected. That also puts `check-go-mod-sync` on the release path, which matters because a release requires the server pin to agree between `go.mod` and `tests/go.mod`.
* `.github/scripts/compute-release-tag.sh` assembles the tag: MAJOR.MINOR off the branch name, the highest existing patch on that line by version sort plus one, then the suffix. If HEAD already carries a tag on the line it returns that tag instead of a successor, so a job re-run at the same commit can't leave one commit with two release tags.
* `.github/scripts/resolve-server-suffix.sh` derives the suffix from the `go.mod` pin, falling back to the earliest server release containing the pinned commit when the pin is a pseudo-version.
* `docs/release.md` documents the process, the version scheme, and why the server version is flattened.
* Pins `actionlint` and `shellcheck` in `mise.toml` (`actionlint` only shell-lints `run:` blocks when `shellcheck` is on `PATH`).

## Why?

`temporal-auto-scaled-workers` has no tags, so its pseudo-version has a bare `v0.0.0-` base and `@latest` can only ever resolve to the tip of the default branch — there is no way to ask for a release. Improving the build process for Temporal Cloud requires a proper semver for the module.

## Changed since the last review

`release-tag.yml` and its GitHub Release publishing are gone, along with the `check-tag` job and the `workflow_dispatch` trigger on `release-auto-tag.yml`. WCI is a library and there are no artifacts to attach yet, so the tag is the release. That also removes the `push: tags` entry point, which could only ever withhold a Release: by the time it ran the tag already existed and was resolvable by `go get`.

Also in response to review: the inline tag-computation script moved out of the workflow into `.github/scripts/`, and re-running the tagger at an already-tagged commit now reuses the tag rather than minting a successor.

## Checklist

1. Closes <!-- add issue number here -->

3. How was this tested:

   Locally: `actionlint` and `shellcheck` clean; `compute-release-tag.sh` exercised against throwaway repos covering patch seeding, increment, version-sort ordering (`.10` over `.9`), reuse at an already-tagged commit, out-of-order tags on older commits, and rejection of malformed or suffix-less tags.

   The end-to-end path can't run before merge — the tagger only triggers on a `release/v*` push, and Actions are disabled for forks. Two throwaway-workflow dry runs validated the auto-tag mechanics, though they predate the changes above and so cover the earlier shape of the release path:
   - https://github.com/temporalio/temporal-auto-scaled-workers/actions/runs/32181923932
   - https://github.com/temporalio/temporal-auto-scaled-workers/actions/runs/32183412144

4. Any docs updates needed?

   Included: `docs/release.md`.
