### PR TITLE
Fix all lint findings across the tree (to avoid a failed first release.)

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -6,6 +6,8 @@ import (
 	_ "time/tzdata" // embed tzdata as a fallback
 
 	"github.com/urfave/cli/v2"
+	"go.uber.org/fx"
+
 	"go.temporal.io/auto-scaled-workers/wci"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"
@@ -25,7 +27,6 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/temporal"
-	"go.uber.org/fx"
 )
 
 // main entry point for the temporal server

--- a/wci/client/fx.go
+++ b/wci/client/fx.go
@@ -1,13 +1,13 @@
 package client
 
 import (
-	"go.temporal.io/server/common/primitives"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/testing/testhooks"
 	"go.temporal.io/server/service/matching/hooks"

--- a/wci/client/workflow_interaction.go
+++ b/wci/client/workflow_interaction.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	"google.golang.org/protobuf/types/known/durationpb"
+
 	commonpb "go.temporal.io/api/common/v1"
 	deploymentpb "go.temporal.io/api/deployment/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -21,7 +23,6 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute/sadefs"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (

--- a/wci/fx.go
+++ b/wci/fx.go
@@ -2,6 +2,8 @@
 package wci
 
 import (
+	"go.uber.org/fx"
+
 	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/auto-scaled-workers/wci/workercomponent"
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
@@ -23,7 +25,6 @@ import (
 	"go.temporal.io/server/service/worker"
 	workercommon "go.temporal.io/server/service/worker/common"
 	"go.temporal.io/server/temporal"
-	"go.uber.org/fx"
 )
 
 var Module = fx.Options(

--- a/wci/workercomponent/fx.go
+++ b/wci/workercomponent/fx.go
@@ -1,10 +1,11 @@
 package workercomponent
 
 import (
+	"go.uber.org/fx"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/sdk"
 	workercommon "go.temporal.io/server/service/worker/common"
-	"go.uber.org/fx"
 )
 
 type (

--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithy "github.com/aws/smithy-go"
+
 	"go.temporal.io/auto-scaled-workers/wci/client"
 )
 

--- a/wci/workflow/compute_provider/aws_ecs.go
+++ b/wci/workflow/compute_provider/aws_ecs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+
 	"go.temporal.io/auto-scaled-workers/wci/client"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"

--- a/wci/workflow/compute_provider/aws_ecs_test.go
+++ b/wci/workflow/compute_provider/aws_ecs_test.go
@@ -35,7 +35,7 @@ func TestAWSECSCheckExternalID_ClusterARN_CallsFn(t *testing.T) {
 		configAWSECSRoleExternalID: "my-eid",
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+	if err := p.checkExternalID(t.Context(), cfg, testClusterARN); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !called {
@@ -68,7 +68,7 @@ func TestAWSECSCheckExternalID_PlainClusterWithRegionConfig_CallsFn(t *testing.T
 		configAWSECSRegion:         "eu-central-1",
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, "my-cluster"); err != nil {
+	if err := p.checkExternalID(t.Context(), cfg, "my-cluster"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !called {
@@ -94,7 +94,7 @@ func TestAWSECSCheckExternalID_PlainClusterNoRegion_ReturnsError(t *testing.T) {
 		// no region, plain cluster name
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, "my-cluster"); err == nil {
+	if err := p.checkExternalID(t.Context(), cfg, "my-cluster"); err == nil {
 		t.Fatal("expected error when region cannot be determined, got nil")
 	}
 }
@@ -113,7 +113,7 @@ func TestAWSECSCheckExternalID_NoExternalID_SkipsFn(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+	if err := p.checkExternalID(t.Context(), cfg, testClusterARN); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -132,7 +132,7 @@ func TestAWSECSCheckExternalID_NoRole_SkipsFn(t *testing.T) {
 		// no role
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err != nil {
+	if err := p.checkExternalID(t.Context(), cfg, testClusterARN); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -145,7 +145,7 @@ func TestAWSECSValidateConfig_MissingRole_ReturnsError(t *testing.T) {
 		// no role
 	}
 
-	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(t.Context(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when role is missing, got nil")
 	}
 }
@@ -159,7 +159,7 @@ func TestAWSECSValidateConfig_MissingExternalID_ReturnsError(t *testing.T) {
 		// no role_external_id
 	}
 
-	if err := p.ValidateConfig(context.Background(), RequestContext{}, cfg); err == nil {
+	if err := p.ValidateConfig(t.Context(), RequestContext{}, cfg); err == nil {
 		t.Fatal("expected error when external ID is missing, got nil")
 	}
 }
@@ -174,7 +174,7 @@ func TestAWSECSValidateConfig_OptOut_NoRoleOrEID_PassesMandatoryCheck(t *testing
 		// no role or external ID
 	}
 
-	err := p.ValidateConfig(context.Background(), RequestContext{}, cfg)
+	err := p.ValidateConfig(t.Context(), RequestContext{}, cfg)
 	// We expect a non-mandatory error (e.g. AWS call failure), not the mandatory check error.
 	if err != nil && (err.Error() == `ECS compute provider requires "role" to be configured` ||
 		err.Error() == `ECS compute provider requires "role_external_id" to be configured`) {
@@ -195,7 +195,7 @@ func TestAWSECSCheckExternalID_FnError_Propagated(t *testing.T) {
 		configAWSECSRoleExternalID: "my-eid",
 	}
 
-	if err := p.checkExternalID(context.Background(), cfg, testClusterARN); err == nil {
+	if err := p.checkExternalID(t.Context(), cfg, testClusterARN); err == nil {
 		t.Fatal("expected error to be propagated, got nil")
 	}
 }

--- a/wci/workflow/compute_provider/aws_test.go
+++ b/wci/workflow/compute_provider/aws_test.go
@@ -34,7 +34,7 @@ func TestCheckExternalIDEnforced_Enforced(t *testing.T) {
 			return nil, &mockAPIError{code: "AccessDenied"}
 		},
 	}
-	err := checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+	err := checkExternalIDEnforced(t.Context(), mock, "arn:aws:iam::123456789012:role/MyRole")
 	if err != nil {
 		t.Fatalf("expected nil (external ID enforced), got: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestCheckExternalIDEnforced_NotEnforced(t *testing.T) {
 		},
 	}
 	roleARN := "arn:aws:iam::123456789012:role/MyRole"
-	err := checkExternalIDEnforced(context.Background(), mock, roleARN)
+	err := checkExternalIDEnforced(t.Context(), mock, roleARN)
 	if err == nil {
 		t.Fatal("expected error (external ID not enforced), got nil")
 	}
@@ -62,7 +62,7 @@ func TestCheckExternalIDEnforced_InfraError_Surfaced(t *testing.T) {
 			return nil, errors.New("connection timeout")
 		},
 	}
-	err := checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+	err := checkExternalIDEnforced(t.Context(), mock, "arn:aws:iam::123456789012:role/MyRole")
 	if err == nil {
 		t.Fatal("expected error for infrastructure failure, got nil")
 	}
@@ -80,5 +80,5 @@ func TestCheckExternalIDEnforced_ProbeHasNoExternalID(t *testing.T) {
 			return nil, &mockAPIError{code: "AccessDenied"}
 		},
 	}
-	_ = checkExternalIDEnforced(context.Background(), mock, "arn:aws:iam::123456789012:role/MyRole")
+	_ = checkExternalIDEnforced(t.Context(), mock, "arn:aws:iam::123456789012:role/MyRole")
 }

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -68,7 +68,7 @@ func (p *gcpCloudRunComputeProvider) ValidateConfig(ctx context.Context, rc Requ
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	_, err = client.GetWorkerPool(ctx, &runpb.GetWorkerPoolRequest{Name: name})
 	if err != nil {
 		return fmt.Errorf("worker pool %q not found: %w", name, err)
@@ -85,7 +85,7 @@ func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	if _, err = client.UpdateWorkerPool(ctx, buildUpdateWorkerPoolRequest(name, count)); err != nil {
 		return fmt.Errorf("failed to update worker pool %q: %w", name, err)

--- a/wci/workflow/compute_provider/k8s.go
+++ b/wci/workflow/compute_provider/k8s.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"fmt"
 
-	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
-	"go.temporal.io/server/common/dynamicconfig"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
+	"go.temporal.io/server/common/dynamicconfig"
 )
 
 const (

--- a/wci/workflow/iface/spec.go
+++ b/wci/workflow/iface/spec.go
@@ -3,10 +3,11 @@ package iface
 import (
 	"slices"
 
+	"google.golang.org/protobuf/proto"
+
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-	"google.golang.org/protobuf/proto"
 )
 
 type (

--- a/wci/workflow/iface/spec_update.go
+++ b/wci/workflow/iface/spec_update.go
@@ -1,10 +1,11 @@
 package iface
 
 import (
+	"google.golang.org/protobuf/proto"
+
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/workflow"
-	"google.golang.org/protobuf/proto"
 )
 
 // applyFieldMask copies only the specified field paths from src to dst.

--- a/wci/workflow/scaling_algorithm/no_sync_match_test.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
@@ -30,7 +31,7 @@ func failScalingMetricsSnapshotGetter(t *testing.T) ScalingMetricsSnapshotGetter
 
 func TestNoSyncValidateConfig(t *testing.T) {
 	a := newNoSync()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil config", func(t *testing.T) {
 		require.NoError(t, a.ValidateConfig(ctx, nil))
@@ -120,13 +121,13 @@ func TestNoSyncValidateConfig(t *testing.T) {
 
 func TestNoSyncProcessTaskAdd(t *testing.T) {
 	a := newNoSync()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("sync match no batched no-sync", func(t *testing.T) {
 		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 0}
 		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("no-sync match nil state first call", func(t *testing.T) {
@@ -145,7 +146,7 @@ func TestNoSyncProcessTaskAdd(t *testing.T) {
 		event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
 		resp, err := a.ProcessTaskAdd(ctx, cfg, state, event)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("no-sync match outside cooloff", func(t *testing.T) {
@@ -192,7 +193,7 @@ func TestNoSyncProcessTaskAdd(t *testing.T) {
 		// Second call within cooloff: must not fire when prior state is threaded back.
 		resp2, err := a.ProcessTaskAdd(ctx, cfg, resp1.Status, event)
 		require.NoError(t, err)
-		assert.Len(t, resp2.Actions, 0)
+		assert.Empty(t, resp2.Actions)
 	})
 
 	t.Run("cooloff=0 state recent still fires", func(t *testing.T) {
@@ -216,7 +217,7 @@ func TestNoSyncCompatibleLaunchStrategies(t *testing.T) {
 
 func TestNoSyncProcessDeferredScalingDecisionNoop(t *testing.T) {
 	a := newNoSync()
-	ctx := context.Background()
+	ctx := t.Context()
 	priorState := iface.ScalingAlgorithmStatus{"custom": int64(1)}
 	event := iface.SignalTaskAddRequest{IsSyncMatch: false, TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW}
 
@@ -230,12 +231,12 @@ func TestNoSyncProcessDeferredScalingDecisionNoop(t *testing.T) {
 
 func TestNoSyncProcessMetricsPoll(t *testing.T) {
 	a := newNoSync()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("all nil metrics", func(t *testing.T) {
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, ScalingMetricsSnapshot{})
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		require.NotNil(t, resp.NextPoll)
 		assert.Equal(t, 60*time.Second, *resp.NextPoll)
 	})
@@ -254,7 +255,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("single queue backlog>0 no prior state", func(t *testing.T) {
@@ -278,7 +279,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("lifetime fires when within cooloff but past lifetime threshold", func(t *testing.T) {
@@ -328,7 +329,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("epsilon suppression on lifetime refresh path", func(t *testing.T) {
@@ -349,7 +350,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("epsilon does not suppress lifetime refresh when rate changed", func(t *testing.T) {
@@ -383,7 +384,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("epsilon suppression rate changed", func(t *testing.T) {
@@ -446,8 +447,8 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
-		assert.Equal(t, float64(7), resp.Status["workflow_last_dispatch_rate"])
+		assert.Empty(t, resp.Actions)
+		assert.InDelta(t, float64(7), resp.Status["workflow_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("epsilon suppression skipped on first poll no prior rate", func(t *testing.T) {
@@ -474,7 +475,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Actions, 1)
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-		assert.Equal(t, float64(0), resp.Status["activity_last_dispatch_rate"])
+		assert.InDelta(t, float64(0), resp.Status["activity_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("only nexus has backlog", func(t *testing.T) {
@@ -485,7 +486,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Actions, 1)
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-		assert.Equal(t, float64(0), resp.Status["nexus_last_dispatch_rate"])
+		assert.InDelta(t, float64(0), resp.Status["nexus_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("cooloff is shared across queue types", func(t *testing.T) {
@@ -499,7 +500,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("backlog exactly at threshold does not fire", func(t *testing.T) {
@@ -515,7 +516,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("nil config uses defaults", func(t *testing.T) {
@@ -542,8 +543,8 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
-		assert.Equal(t, float64(10), resp.Status["workflow_last_dispatch_rate"])
+		assert.Empty(t, resp.Actions)
+		assert.InDelta(t, float64(10), resp.Status["workflow_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("state threads correctly across two calls", func(t *testing.T) {
@@ -559,7 +560,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		// Second call within cooloff: must not fire when prior state is threaded back.
 		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp2.Actions, 0)
+		assert.Empty(t, resp2.Actions)
 	})
 
 	t.Run("lifetime state threads correctly across two calls", func(t *testing.T) {
@@ -582,7 +583,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		// Second call with the updated state: the lifetime timer was reset to nowMs, so 1s has not yet elapsed.
 		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp2.Actions, 0, "second call: lifetime not yet elapsed, must not fire")
+		assert.Empty(t, resp2.Actions, "second call: lifetime not yet elapsed, must not fire")
 	})
 
 	t.Run("epsilon at exact boundary suppresses", func(t *testing.T) {
@@ -598,7 +599,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0, "diff == 0 is within epsilon, must suppress")
+		assert.Empty(t, resp.Actions, "diff == 0 is within epsilon, must suppress")
 	})
 
 	t.Run("epsilon just above boundary fires", func(t *testing.T) {
@@ -634,7 +635,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		// Second call: same rate — epsilon suppresses scale-up using rate stored by first call.
 		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp2.Actions, 0)
+		assert.Empty(t, resp2.Actions)
 	})
 
 	t.Run("worker refresh does not fire when backlog is zero", func(t *testing.T) {
@@ -648,7 +649,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("backlog one above threshold fires", func(t *testing.T) {
@@ -679,7 +680,7 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 	})
 
 	t.Run("ProcessTaskAdd state suppresses ProcessMetricsPoll within cooloff", func(t *testing.T) {
@@ -696,6 +697,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		}
 		pollResp, err := a.ProcessMetricsPoll(ctx, cfg, taskAddResp.Status, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, pollResp.Actions, 0)
+		assert.Empty(t, pollResp.Actions)
 	})
 }

--- a/wci/workflow/scaling_algorithm/rate_based_test.go
+++ b/wci/workflow/scaling_algorithm/rate_based_test.go
@@ -103,7 +103,7 @@ func errorMetricsSnapshotGetter(err error, callCount *int) ScalingMetricsSnapsho
 
 func TestRateBasedValidateConfig(t *testing.T) {
 	a := newRateBased()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil config", func(t *testing.T) {
 		require.NoError(t, a.ValidateConfig(ctx, nil))
@@ -266,7 +266,7 @@ func TestRateBasedDefaultRegistration(t *testing.T) {
 	// init() registers the algorithm as the default for these compute providers.
 	// A regression that dropped one of the mappings would silently route the
 	// affected provider to a different algorithm (or none).
-	ctx := context.Background()
+	ctx := t.Context()
 	for _, providerType := range []iface.ComputeProviderType{
 		iface.ComputeProviderTypeAWSECS,
 		iface.ComputeProviderTypeK8s,
@@ -282,13 +282,13 @@ func TestRateBasedDefaultRegistration(t *testing.T) {
 
 func TestRateBasedProcessTaskAdd(t *testing.T) {
 	a := newRateBased()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("sync match no batched no-sync", func(t *testing.T) {
 		event := iface.SignalTaskAddRequest{IsSyncMatch: true, NoSyncMatchSignalsSinceLast: 0}
 		resp, err := a.ProcessTaskAdd(ctx, iface.ScalingAlgorithmConfig{}, nil, event)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.NotContains(t, resp.Status, stateRateBasedLastNoSyncMatchTimestamp)
 	})
 
@@ -485,7 +485,7 @@ func TestRateBasedProcessTaskAdd(t *testing.T) {
 
 func TestRateBasedProcessDeferredScalingDecision(t *testing.T) {
 	a := newRateBased()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("samples per-consumer capacity", func(t *testing.T) {
 		priorState := iface.ScalingAlgorithmStatus{
@@ -598,12 +598,12 @@ func TestRateBasedProcessDeferredScalingDecision(t *testing.T) {
 
 func TestRateBasedProcessMetricsPoll(t *testing.T) {
 	a := newRateBased()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("all nil metrics default poll", func(t *testing.T) {
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, ScalingMetricsSnapshot{})
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		require.NotNil(t, resp.NextPoll)
 		assert.Equal(t, 60*time.Second, *resp.NextPoll)
 		// With no contributing queues the EWMA update is gated off; the slots
@@ -630,7 +630,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, ScalingMetricsSnapshot{})
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 	})
 
@@ -647,9 +647,9 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
-		assert.Equal(t, float64(5), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0))
-		assert.Equal(t, float64(4), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0))
+		assert.Empty(t, resp.Actions)
+		assert.InDelta(t, float64(5), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 1e-9)
+		assert.InDelta(t, float64(4), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 1e-9)
 	})
 
 	t.Run("later cadence smooths ewma rates", func(t *testing.T) {
@@ -670,7 +670,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.InDelta(t, 5.0, resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 0.0001)
 		assert.InDelta(t, 2.5, resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 0.0001)
 	})
@@ -699,8 +699,8 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		require.NotNil(t, resp.Actions[0].Count)
 		assert.Equal(t, int32(1), *resp.Actions[0].Count)
 		assert.Equal(t, int64(1), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
-		assert.Equal(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, -1))
-		assert.Equal(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, -1))
+		assert.InDelta(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, -1), 1e-9)
+		assert.InDelta(t, float64(0), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, -1), 1e-9)
 	})
 
 	t.Run("raw dispatch prevents idle ewma snap-to-zero", func(t *testing.T) {
@@ -721,7 +721,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.InDelta(t, 3.0, resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 0.0001)
 		assert.InDelta(t, 2.5, resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 0.0001)
 	})
@@ -759,7 +759,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Equal(t, float64(10), resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0))
+		assert.InDelta(t, float64(10), resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, 0), 1e-9)
 	})
 
 	t.Run("desired capacity scale-up uses max step", func(t *testing.T) {
@@ -805,7 +805,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 	})
 
@@ -898,7 +898,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 		// Quiet-period block must not bump LastScaleDownTimestamp; otherwise every
 		// failed poll would silently delay every future scale-down by another cooldown.
@@ -914,7 +914,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, state, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.Equal(t, int64(3), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 		// Cooldown block must leave the timestamp at its prior value so the
 		// cooldown clock doesn't self-extend with each blocked poll.
@@ -937,9 +937,9 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
-		assert.Equal(t, float64(6), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0))
-		assert.Equal(t, float64(3), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0))
+		assert.Empty(t, resp.Actions)
+		assert.InDelta(t, float64(6), resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, 0), 1e-9)
+		assert.InDelta(t, float64(3), resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, 0), 1e-9)
 		assert.Equal(t, int64(2), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 	})
 
@@ -1073,7 +1073,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0, "backlog=0 must suppress drain rate so no scale-up occurs (scale-down blocked by no-sync quiet)")
+		assert.Empty(t, resp.Actions, "backlog=0 must suppress drain rate so no scale-up occurs (scale-down blocked by no-sync quiet)")
 	})
 
 	t.Run("non-finite stored capacity recovers to initial", func(t *testing.T) {
@@ -1247,7 +1247,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
 		stored := resp.Status.GetFloat64Field(stateRateBasedEWMAPerConsumerCapacity, math.NaN())
-		assert.Equal(t, priorCapacity, stored, "Workflow's backlog must drop with its NaN rates; gate must not trip; capacity slot must stay at prior value")
+		assert.InDelta(t, priorCapacity, stored, 1e-9, "Workflow's backlog must drop with its NaN rates; gate must not trip; capacity slot must stay at prior value")
 	})
 
 	t.Run("metrics-outage poll preserves prior EWMA (all queues rejected as non-finite)", func(t *testing.T) {
@@ -1267,8 +1267,8 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		storedArrival := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
 		storedDispatch := resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, math.NaN())
-		assert.Equal(t, float64(5), storedArrival, "prior arrival EWMA must be preserved verbatim on outage poll")
-		assert.Equal(t, float64(3), storedDispatch, "prior dispatch EWMA must be preserved verbatim on outage poll")
+		assert.InDelta(t, float64(5), storedArrival, 1e-9, "prior arrival EWMA must be preserved verbatim on outage poll")
+		assert.InDelta(t, float64(3), storedDispatch, 1e-9, "prior dispatch EWMA must be preserved verbatim on outage poll")
 	})
 
 	t.Run("metrics-outage poll preserves prior EWMA (no contributing queues)", func(t *testing.T) {
@@ -1286,8 +1286,8 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		storedArrival := resp.Status.GetFloat64Field(stateRateBasedEWMAArrivalRate, math.NaN())
 		storedDispatch := resp.Status.GetFloat64Field(stateRateBasedEWMADispatchRate, math.NaN())
-		assert.Equal(t, float64(5), storedArrival, "prior arrival EWMA must be preserved verbatim when no queue contributed")
-		assert.Equal(t, float64(3), storedDispatch, "prior dispatch EWMA must be preserved verbatim when no queue contributed")
+		assert.InDelta(t, float64(5), storedArrival, 1e-9, "prior arrival EWMA must be preserved verbatim when no queue contributed")
+		assert.InDelta(t, float64(3), storedDispatch, 1e-9, "prior dispatch EWMA must be preserved verbatim when no queue contributed")
 	})
 
 	t.Run("at min count with idle metrics emits no action", func(t *testing.T) {
@@ -1305,7 +1305,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 0)
+		assert.Empty(t, resp.Actions)
 		assert.Equal(t, int64(1), resp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 	})
 
@@ -1446,7 +1446,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 		// would otherwise trigger scale-down. Block must hold.
 		pollResp, err := a.ProcessMetricsPoll(ctx, cfg, taskAddResp.Status, ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{}})
 		require.NoError(t, err)
-		assert.Len(t, pollResp.Actions, 0, "scale-down must be blocked by no_sync_quiet on the poll immediately following a no-sync task-add")
+		assert.Empty(t, pollResp.Actions, "scale-down must be blocked by no_sync_quiet on the poll immediately following a no-sync task-add")
 		assert.Equal(t, taskAddResp.Status.GetInt64Field(stateRateBasedWorkerCount, 0), pollResp.Status.GetInt64Field(stateRateBasedWorkerCount, 0))
 		// The cleaner must preserve the bumped no-sync timestamp through the
 		// poll's clean/read cycle, since that timestamp IS the block signal.
@@ -1457,7 +1457,7 @@ func TestRateBasedProcessMetricsPoll(t *testing.T) {
 }
 
 func TestRateBasedAggregateMetrics(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("nil snapshot yields hasData=false and no dropped queues", func(t *testing.T) {
 		m := aggregateRateBasedMetrics(ctx, nil)
@@ -1480,8 +1480,8 @@ func TestRateBasedAggregateMetrics(t *testing.T) {
 		assert.True(t, m.hasData)
 		assert.Empty(t, m.droppedQueues)
 		assert.Equal(t, int64(15), m.backlog)
-		assert.Equal(t, float64(3), m.arrivalRate)
-		assert.Equal(t, float64(2), m.dispatchRate)
+		assert.InDelta(t, float64(3), m.arrivalRate, 1e-9)
+		assert.InDelta(t, float64(2), m.dispatchRate, 1e-9)
 	})
 
 	t.Run("partial-data poll records dropped queue and keeps hasData=true", func(t *testing.T) {
@@ -1492,8 +1492,8 @@ func TestRateBasedAggregateMetrics(t *testing.T) {
 		assert.True(t, m.hasData, "Activity contributed finite samples")
 		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
 		assert.Equal(t, int64(1), m.backlog, "Workflow's backlog must be excluded along with its NaN rates")
-		assert.Equal(t, float64(4), m.arrivalRate)
-		assert.Equal(t, float64(2), m.dispatchRate)
+		assert.InDelta(t, float64(4), m.arrivalRate, 1e-9)
+		assert.InDelta(t, float64(2), m.dispatchRate, 1e-9)
 	})
 
 	t.Run("all queues rejected yields hasData=false with every queue name listed", func(t *testing.T) {
@@ -1514,8 +1514,8 @@ func TestRateBasedAggregateMetrics(t *testing.T) {
 		assert.True(t, m.hasData, "Activity contributed finite samples")
 		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
 		assert.Equal(t, int64(1), m.backlog, "Workflow's backlog must be excluded along with its negative rate")
-		assert.Equal(t, float64(4), m.arrivalRate)
-		assert.Equal(t, float64(2), m.dispatchRate)
+		assert.InDelta(t, float64(4), m.arrivalRate, 1e-9)
+		assert.InDelta(t, float64(2), m.dispatchRate, 1e-9)
 	})
 
 	t.Run("negative dispatch rate sample is rejected like NaN", func(t *testing.T) {
@@ -1526,8 +1526,8 @@ func TestRateBasedAggregateMetrics(t *testing.T) {
 		assert.True(t, m.hasData)
 		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
 		assert.Equal(t, int64(1), m.backlog)
-		assert.Equal(t, float64(4), m.arrivalRate)
-		assert.Equal(t, float64(2), m.dispatchRate)
+		assert.InDelta(t, float64(4), m.arrivalRate, 1e-9)
+		assert.InDelta(t, float64(2), m.dispatchRate, 1e-9)
 	})
 
 	t.Run("negative backlog sample is rejected", func(t *testing.T) {
@@ -1538,7 +1538,7 @@ func TestRateBasedAggregateMetrics(t *testing.T) {
 		assert.True(t, m.hasData)
 		assert.Equal(t, []string{"workflow"}, m.droppedQueues)
 		assert.Equal(t, int64(10), m.backlog, "Activity's backlog stands alone; workflow's negative backlog must be excluded")
-		assert.Equal(t, float64(4), m.arrivalRate, "workflow's arrival rate dropped with its backlog")
-		assert.Equal(t, float64(2), m.dispatchRate)
+		assert.InDelta(t, float64(4), m.arrivalRate, 1e-9, "workflow's arrival rate dropped with its backlog")
+		assert.InDelta(t, float64(2), m.dispatchRate, 1e-9)
 	})
 }

--- a/wci/workflow/scaling_algorithm/safe_activity_logger_test.go
+++ b/wci/workflow/scaling_algorithm/safe_activity_logger_test.go
@@ -2,18 +2,18 @@ package scalingalgorithm
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	sdklog "go.temporal.io/sdk/log"
 )
 
 func TestFormatLoggerKeyvals(t *testing.T) {
 	t.Run("empty keyvals returns empty string", func(t *testing.T) {
-		assert.Equal(t, "", formatLoggerKeyvals(nil))
-		assert.Equal(t, "", formatLoggerKeyvals([]any{}))
+		assert.Empty(t, formatLoggerKeyvals(nil))
+		assert.Empty(t, formatLoggerKeyvals([]any{}))
 	})
 
 	t.Run("single pair", func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestSafeActivityLoggerFallsBackOutsideActivityContext(t *testing.T) {
 	fallbackStdlibLogger.SetOutput(&buf)
 	t.Cleanup(func() { fallbackStdlibLogger.SetOutput(original) })
 
-	logger := safeActivityLogger(context.Background())
+	logger := safeActivityLogger(t.Context())
 	require.NotNil(t, logger)
 	assert.Contains(t, buf.String(), "panicked")
 

--- a/wci/workflow/scaling_metrics_snapshot.go
+++ b/wci/workflow/scaling_metrics_snapshot.go
@@ -57,6 +57,9 @@ func (a *Activities) pullScalingMetricsSnapshot(ctx context.Context, namespaceNa
 			metricsSnapshot.Nexus.LastArrivalRate += versionedTaskQueue.Stats.TasksAddRate
 			metricsSnapshot.Nexus.LastProcessingRate += versionedTaskQueue.Stats.TasksDispatchRate
 			metricsSnapshot.Nexus.LastBacklogAge = max(metricsSnapshot.Nexus.LastBacklogAge, versionedTaskQueue.Stats.GetApproximateBacklogAge().AsDuration())
+		case enumspb.TASK_QUEUE_TYPE_UNSPECIFIED:
+			// using unspecified instead of default to ensure (future) unhandled values are caught by linter.
+			logger.Warn("Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s, buildId: %s).", namespaceName, deploymentName, deploymentBuildID)
 		}
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Fixed all the lint issues in preparation for adding support for release tags.
Here is a breakdown of changes
| Type | Count | Details|
|------|:-----:|--------|
|usetesting | 24 | changed `context.Background()` to `t.Context()` in tests|
|testifylint | 33 | changed `Len(x, 0)` to `Empty` check |
|testifylint | 26 | changed float comparison to ` InDelta`|
|testifylint | 2 | changed `Equal` to `Empty`|
| gci | 10 | `import` grouping|
| errcheck | 2 | check `client.Close()` in the Cloud Run provider |
| exhaustive  | 1 | log warning for `TASK_QUEUE_TYPE_UNSPECIFIED` in the task-queue-type switch |
## Why?
<!-- Tell your future self why have you made these changes -->
The process for adding release tags will run the linter without taking into account the origin branch. That is different than what it currently does for PR (where it only flags new issues.)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
