### PR TITLE
Add metrics for Cloud Run alarms

### DIFF
--- a/wci/workflow/compute_provider/aws.go
+++ b/wci/workflow/compute_provider/aws.go
@@ -21,12 +21,6 @@ type stsAPI interface {
 	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
 }
 
-// errWCIOwned marks a failure as attributable to worker-controller's own AWS setup
-// (base credentials, intermediary role chain) rather than the customer's config.
-// This has to be marked where it happens: intermediary and customer role
-// assumptions go through the same helper and fail indistinguishably.
-var errWCIOwned = errors.New("worker-controller AWS configuration error")
-
 var (
 	awsThrottleCheck   = retry.ThrottleErrorCode{Codes: retry.DefaultThrottleErrorCodes}
 	awsConnectionCheck = retry.RetryableConnectionError{}

--- a/wci/workflow/compute_provider/errors.go
+++ b/wci/workflow/compute_provider/errors.go
@@ -1,5 +1,14 @@
 package computeprovider
 
+import "errors"
+
+// errWCIOwned marks a failure as attributable to worker-controller's own setup
+// (base credentials, intermediary role/impersonation chain) rather than the
+// customer's config. It has to be marked where it happens: intermediary and
+// customer credential steps go through the same helpers and fail
+// indistinguishably. Shared across providers and read by their classify* funcs.
+var errWCIOwned = errors.New("worker-controller configuration error")
+
 // FailureClass is the provider-agnostic classification of a compute provider
 // failure. Each provider maps its own SDK's error taxonomy onto it so callers can
 // distinguish failure kinds without knowing which provider produced the error.

--- a/wci/workflow/compute_provider/gcp.go
+++ b/wci/workflow/compute_provider/gcp.go
@@ -45,6 +45,8 @@ func classifyGCPFailure(err error) FailureClass {
 			return FailureInternal
 		case codes.Canceled, codes.OK:
 			return FailureUnclassified
+		default:
+			// Client faults: narrowed by ownership below.
 		}
 		// Remaining codes are client faults. Our own missing resources and denied
 		// permissions page the same on-call the same way, so there is nothing to

--- a/wci/workflow/compute_provider/gcp.go
+++ b/wci/workflow/compute_provider/gcp.go
@@ -1,0 +1,72 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// classifyGCPFailure maps a Cloud Run (gRPC) error onto a FailureClass along two
+// axes: what kind of failure it was, read from the gRPC status code, and whose
+// config caused it, read from errWCIOwned. Errors carrying no gRPC status (a
+// transport failure, or a local error before the call) fall back to the ownership
+// axis.
+func classifyGCPFailure(err error) FailureClass {
+	if err == nil {
+		return FailureUnclassified
+	}
+
+	// A cancelled request tells us nothing about either axis; don't blame it on
+	// whoever's config happened to be in play.
+	if errors.Is(err, context.Canceled) {
+		return FailureUnclassified
+	}
+
+	// Ownership separates client-fault from WCI-fault errors. A throttled or
+	// server-side failure is the provider's regardless of whose config we used.
+	wciOwned := errors.Is(err, errWCIOwned)
+	ownerFault := FailureRejected
+	if wciOwned {
+		ownerFault = FailureInternal
+	}
+
+	if st, ok := status.FromError(err); ok {
+		// Server-side and transport faults are the provider's regardless of
+		// ownership, so they are checked before the fault split.
+		switch st.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Internal, codes.Unknown:
+			return FailureUnavailable
+		case codes.ResourceExhausted:
+			return FailureThrottled
+		case codes.Unauthenticated:
+			// A rejected token is worker-controller's own credential problem.
+			return FailureInternal
+		case codes.Canceled, codes.OK:
+			return FailureUnclassified
+		}
+		// Remaining codes are client faults. Our own missing resources and denied
+		// permissions page the same on-call the same way, so there is nothing to
+		// gain from narrowing them.
+		if wciOwned {
+			return FailureInternal
+		}
+		switch st.Code() {
+		case codes.NotFound:
+			return FailureNotFound
+		case codes.PermissionDenied:
+			return FailureAccessDenied
+		default:
+			return FailureRejected
+		}
+	}
+
+	// No modelled gRPC status: the request either failed in transport or never
+	// left the process. A transport deadline is an availability problem; local
+	// validation failures fall through to ownerFault.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return FailureUnavailable
+	}
+	return ownerFault
+}

--- a/wci/workflow/compute_provider/gcp_cloudrun.go
+++ b/wci/workflow/compute_provider/gcp_cloudrun.go
@@ -83,12 +83,12 @@ func (p *gcpCloudRunComputeProvider) InvokeWorker(_ context.Context, _ RequestCo
 func (p *gcpCloudRunComputeProvider) UpdateWorkerSetSize(ctx context.Context, rc RequestContext, config ComputeProviderConfig, count int32) error {
 	client, name, err := p.buildClientAndParams(ctx, rc, config)
 	if err != nil {
-		return err
+		return NewProviderError(classifyGCPFailure(err), err)
 	}
 	defer client.Close()
 
 	if _, err = client.UpdateWorkerPool(ctx, buildUpdateWorkerPoolRequest(name, count)); err != nil {
-		return fmt.Errorf("failed to update worker pool %q: %w", name, err)
+		return NewProviderError(classifyGCPFailure(err), fmt.Errorf("failed to update worker pool %q: %w", name, err))
 	}
 	return nil
 }
@@ -134,7 +134,7 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, r
 			GlobalSACandidates: candidates,
 		})
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to resolve impersonation chain: %w", err)
+			return nil, "", fmt.Errorf("%w: failed to resolve impersonation chain: %w", errWCIOwned, err)
 		}
 
 		scopes := []string{"https://www.googleapis.com/auth/cloud-platform"}
@@ -155,7 +155,7 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, r
 				Scopes:          scopes,
 			})
 			if err != nil {
-				return nil, "", fmt.Errorf("failed to impersonate global service account %q: %w", chainDelegates[0], err)
+				return nil, "", fmt.Errorf("%w: failed to impersonate global service account %q: %w", errWCIOwned, chainDelegates[0], err)
 			}
 			baseOpts = []option.ClientOption{option.WithTokenSource(baseTS)}
 			chainDelegates = chainDelegates[1:]
@@ -174,7 +174,7 @@ func (p *gcpCloudRunComputeProvider) buildClientAndParams(ctx context.Context, r
 
 	client, err := run.NewWorkerPoolsClient(ctx, opts...)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create Cloud Run client: %w", err)
+		return nil, "", fmt.Errorf("%w: failed to create Cloud Run client: %w", errWCIOwned, err)
 	}
 	return client, name, nil
 }

--- a/wci/workflow/compute_provider/gcp_errors_test.go
+++ b/wci/workflow/compute_provider/gcp_errors_test.go
@@ -1,0 +1,99 @@
+package computeprovider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestClassifyGCPFailure(t *testing.T) {
+	wciOwned := func(err error) error { return fmt.Errorf("%w: %w", errWCIOwned, err) }
+
+	cases := []struct {
+		name string
+		err  error
+		want FailureClass
+	}{
+		{"nil", nil, FailureUnclassified},
+		{"canceled", context.Canceled, FailureUnclassified},
+		{"grpc canceled", status.Error(codes.Canceled, "cancelled"), FailureUnclassified},
+
+		// Server-side and transport faults, regardless of ownership.
+		{"unavailable", status.Error(codes.Unavailable, "backend down"), FailureUnavailable},
+		{"deadline", status.Error(codes.DeadlineExceeded, "slow"), FailureUnavailable},
+		{"internal", status.Error(codes.Internal, "server error"), FailureUnavailable},
+		{"unknown", status.Error(codes.Unknown, "?"), FailureUnavailable},
+		{"transport deadline", context.DeadlineExceeded, FailureUnavailable},
+		{"wci-owned server fault", wciOwned(status.Error(codes.Unavailable, "x")), FailureUnavailable},
+
+		// Throttles: valid config, capacity unavailable right now.
+		{"resource exhausted", status.Error(codes.ResourceExhausted, "quota"), FailureThrottled},
+
+		// A rejected token is worker-controller's own credential problem.
+		{"unauthenticated", status.Error(codes.Unauthenticated, "bad token"), FailureInternal},
+
+		// Customer-owned client faults, narrowed by code.
+		{"not found", status.Error(codes.NotFound, "no pool"), FailureNotFound},
+		{"permission denied", status.Error(codes.PermissionDenied, "denied"), FailureAccessDenied},
+		{"invalid argument", status.Error(codes.InvalidArgument, "bad"), FailureRejected},
+		{"failed precondition", status.Error(codes.FailedPrecondition, "state"), FailureRejected},
+		{"aborted", status.Error(codes.Aborted, "conflict"), FailureRejected},
+
+		// WCI-owned client faults are not narrowed: our own missing resource and our
+		// own denied permission page the same on-call.
+		{"wci-owned not found", wciOwned(status.Error(codes.NotFound, "x")), FailureInternal},
+		{"wci-owned permission denied", wciOwned(status.Error(codes.PermissionDenied, "x")), FailureInternal},
+
+		// Non-gRPC local failures fall through to the ownership axis.
+		{"local error", errors.New("project not found in config"), FailureRejected},
+		{"wci-owned local error", wciOwned(errors.New("failed to create Cloud Run client")), FailureInternal},
+
+		// Classification must survive the wrapping the provider applies.
+		{"wrapped", fmt.Errorf("failed to update worker pool %q: %w", "wp", status.Error(codes.Unavailable, "x")), FailureUnavailable},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyGCPFailure(tc.err))
+		})
+	}
+}
+
+// UpdateWorkerSetSize must surface a *ProviderError so the activity's
+// computeProviderErrorType can map it onto a fine-grained error_type tag.
+func TestGCPCloudRunUpdateWorkerSetSize_ClassifiesChainFailureAsInternal(t *testing.T) {
+	// A broken impersonation chain is worker-controller's own setup.
+	setChainProviderForTest(t, &captureChainProvider{err: errors.New("boom")})
+	p := &gcpCloudRunComputeProvider{}
+
+	err := p.UpdateWorkerSetSize(t.Context(), RequestContext{NamespaceName: "my-ns"}, ComputeProviderConfig{
+		configGCPCloudRunProject:        "p",
+		configGCPCloudRunRegion:         "r",
+		configGCPCloudRunWorkerPool:     "wp",
+		configGCPCloudRunServiceAccount: "cust@example.com",
+	}, 2)
+	require.Error(t, err)
+
+	var pErr *ProviderError
+	require.ErrorAs(t, err, &pErr)
+	assert.Equal(t, FailureInternal, pErr.Class)
+}
+
+func TestGCPCloudRunUpdateWorkerSetSize_ClassifiesMissingConfigAsRejected(t *testing.T) {
+	p := &gcpCloudRunComputeProvider{}
+
+	// A missing worker-pool name fails before any GCP call; that's the customer's
+	// config, with no gRPC code to narrow it.
+	err := p.UpdateWorkerSetSize(t.Context(), RequestContext{}, ComputeProviderConfig{}, 2)
+	require.Error(t, err)
+
+	var pErr *ProviderError
+	require.ErrorAs(t, err, &pErr)
+	assert.Equal(t, FailureRejected, pErr.Class)
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Disambiguation of Cloud Run errors in our metrics

## Why?
<!-- Tell your future self why have you made these changes -->
So that we can alarm only on faults we have control over

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
