### PR TITLE
Skip coverage report on PRs from forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
 
   unit-code-coverage:
     name: "Unit test coverage report"
-    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # Do not run when workflow is triggered by push to main branch or is from a fork
     runs-on: ubuntu-latest
     needs: unit-test
     permissions:
@@ -137,7 +137,7 @@ jobs:
 
   integ-code-coverage:
     name: "Integration test coverage report"
-    if: github.event_name == 'pull_request' # Do not run when workflow is triggered by push to main branch
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository # Do not run when workflow is triggered by push to main branch or is from a fork
     runs-on: ubuntu-latest
     needs: integration-test
     permissions:

--- a/.github/workflows/nightly-integration.yaml
+++ b/.github/workflows/nightly-integration.yaml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Nightly Integration Test
 on:
   schedule:
     - cron: "0 2 * * *"


### PR DESCRIPTION
## What was changed
Changes the CI actions to skip code coverage reports if the PR is from a forked repo. GHA cannot leave comments on forked PRs and so the job always fails.

We already have similar checks in place within the Unit and Integration test jobs, skipping the coverage writing steps on forks. This change extends the same logic to the report jobs, skipping them entirely.

Additionally, this renames the Nightly CI workflow so it's not the same as the regular CI workflow.