### PR TITLE
Log task queue names alongside scaling metrics snapshot

### DIFF
--- a/wci/workflow/scaling_metrics_snapshot.go
+++ b/wci/workflow/scaling_metrics_snapshot.go
@@ -36,6 +36,9 @@ func (a *Activities) pullScalingMetricsSnapshot(ctx context.Context, namespaceNa
 		Activity: &iface.QueueTypeScalingMetrics{},
 		Nexus:    &iface.QueueTypeScalingMetrics{},
 	}
+	taskQueueCount := 0
+	const taskQueueSampleMax = 3
+	taskQueueSample := []string{}
 	for _, versionedTaskQueue := range deploymentVersionDetails.VersionTaskQueues {
 		if versionedTaskQueue == nil || versionedTaskQueue.Stats == nil {
 			continue
@@ -61,9 +64,23 @@ func (a *Activities) pullScalingMetricsSnapshot(ctx context.Context, namespaceNa
 			// using unspecified instead of default to ensure (future) unhandled values are caught by linter.
 			logger.Warn("Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s, buildId: %s).", namespaceName, deploymentName, deploymentBuildID)
 		}
+
+		taskQueueCount++
+		// Unclear what we should rank task queues by here, so just use array order
+		if len(taskQueueSample) < taskQueueSampleMax {
+			// Task queue names are user-specified identifiers, but are validated by the server to be valid UTF-8
+			// and limited to a reasonable length (default 1000 bytes), so are safe to log verbatim.
+			taskQueueSample = append(taskQueueSample, "["+versionedTaskQueue.Type.String()+"]"+versionedTaskQueue.Name)
+		}
 	}
 
-	logger.Info("Pulled scaling metrics snapshot", "workflow_count", metricsSnapshot.Workflow.LastBacklogCount, "activity_count", metricsSnapshot.Activity.LastBacklogCount, "nexus_count", metricsSnapshot.Nexus.LastBacklogCount)
+	logger.Info("Pulled scaling metrics snapshot",
+		"workflow_count", metricsSnapshot.Workflow.LastBacklogCount,
+		"activity_count", metricsSnapshot.Activity.LastBacklogCount,
+		"nexus_count", metricsSnapshot.Nexus.LastBacklogCount,
+		"task_queue_count", taskQueueCount,
+		"task_queue_sample", taskQueueSample,
+	)
 
 	return &metricsSnapshot, nil
 }


### PR DESCRIPTION
## What was changed
Add the first 3 task queue names and task queue count to logging for scaling metrics snapshots.

## Why?
This should make it easier to associate worker deployment versions with the task queues they poll. In most cases we should expect relatively few task queues per WDV, but also log the task queue count so we can tell if there's omissions in logging.

## Checklist

1. How was this tested:
Ran workflow through local temporal server with serverless workers configured, viewed logs. Example log entry (some fields omitted)

```json
{"level":"info",msg":"Pulled scaling metrics snapshot","workflow_count":0,"activity_count":0,"nexus_count":0,"task_queue_count":2,"topk_task_queues":["[Workflow]test-tasks","[Activity]test-tasks"]}
```