### PR TITLE
CI: golangci-lint: Use go.mod for Go version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:


### PR DESCRIPTION
## What was changed
Use go.mod for Go version in golangci-lint job instead of the latest stable.

## Why?
Prevents the version from moving under us when Go releases new versions, and ties it to our go.mod file like all the other CI jobs.
