### PR TITLE
Fix log message on unspecified task queue type in metrics snapshots

### DIFF
--- a/wci/workflow/scaling_metrics_snapshot.go
+++ b/wci/workflow/scaling_metrics_snapshot.go
@@ -62,7 +62,7 @@ func (a *Activities) pullScalingMetricsSnapshot(ctx context.Context, namespaceNa
 			metricsSnapshot.Nexus.LastBacklogAge = max(metricsSnapshot.Nexus.LastBacklogAge, versionedTaskQueue.Stats.GetApproximateBacklogAge().AsDuration())
 		case enumspb.TASK_QUEUE_TYPE_UNSPECIFIED:
 			// using unspecified instead of default to ensure (future) unhandled values are caught by linter.
-			logger.Warn("Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s, buildId: %s).", namespaceName, deploymentName, deploymentBuildID)
+			logger.Warn("Unspecified task queue type for scaling metrics snapshot", "namespace", namespaceName, "task_queue", versionedTaskQueue.Name)
 		}
 
 		taskQueueCount++


### PR DESCRIPTION
## What was changed
Use structured log fields instead of a format string. Also log the task queue name with the unspecified type, and omit the worker deployment version fields as they're already implicitly logged in the common WorkflowID field.

## Why?
Most structured loggers (including Zap's base logger) don't support format strings in log messages.

## Checklist
1. How was this tested:
Local server. Abridged output before/after:

```jsonc
// Before
{"msg":"Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s, buildId: %s).","WorkflowID":"temporal-sys-worker-controller-instance:serverless-test:v1","default":"serverless-test","v1":"no value"}

// After
{"msg":"Unspecified task queue type for scaling metrics snapshot","WorkflowID":"temporal-sys-worker-controller-instance:serverless-test:v1","namespace":"default","task_queue":"test-tasks"}
```