### PR TITLE
Add loggercheck to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     # - gomodguard
     - govet
     - iotamixing
+    - loggercheck
     - staticcheck
     - testifylint
     - usetesting
@@ -27,6 +28,13 @@ linters:
     usetesting:
       context-background: true
       context-todo: true
+    loggercheck:
+      no-printf-like: true
+      rules:
+        - '(go.temporal.io/sdk/log.Logger).Debug'
+        - '(go.temporal.io/sdk/log.Logger).Info'
+        - '(go.temporal.io/sdk/log.Logger).Warn'
+        - '(go.temporal.io/sdk/log.Logger).Error'
     testifylint:
       enable-all: true
       disable:


### PR DESCRIPTION
## What was changed
Enable the loggercheck linter, which is built into golangci-lint.

## Why?
This allows us to catch common structured logging errors with the Temporal SDK logger.

## Checklist
1. How was this tested:
Tested against the bad log call from https://github.com/temporalio/temporal-auto-scaled-workers/pull/119

```
wci/workflow/scaling_metrics_snapshot.go:65:122: odd number of arguments passed as key-value pairs for logging (loggercheck)
                        logger.Warn("Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s, buildId: %s).", namespaceName, deploymentName, deploymentBuildID)
```

```
wci/workflow/scaling_metrics_snapshot.go:65:16: logging message should not use format specifier "%s" (loggercheck)
                        logger.Warn("Unspecified task queue type for scaling metrics snapshot (namespace: %s, deployment: %s).", namespaceName, deploymentName)
```