### PR TITLE
Add scale suppression when dispatch rate is within epsilon detection to no-sync scaling algo

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A group with no `task_types` acts as a catch-all for any task type not claimed b
 | `scale_up_backlog_threshold` | `0` | Scale up when backlog exceeds this value |
 | `scale_up_cooloff_ms` | `100` | Minimum milliseconds between scale-up actions |
 | `max_worker_lifetime_ms` | `600000` | Re-invoke workers at least this often (10 min) |
-| `scale_up_dispatch_rate_epsilon` | `0` | Suppress scale-up if dispatch rate is stable within this margin |
+| `scale_up_dispatch_rate_epsilon` | `0` | Relative band (a fraction of the dispatch rate, capped at `0.10`) for the flat-dispatch-rate detector; `0` disables it. When set, a queue type's scale-up is suppressed while its dispatch rate holds within this band under a material backlog. |
 | `metrics_poll_interval_ms` | `60000` | How often to poll task queue metrics |
 
 ## Client API

--- a/docs/simulators/function/SPEC.md
+++ b/docs/simulators/function/SPEC.md
@@ -10,8 +10,9 @@ existing workers are not keeping up. It has two scale-up paths:
 
 - Task-add signals from Matching, including direct no-sync matches and batched
   no-sync matches.
-- Periodic task-queue metric polls, based on backlog, worker lifetime refresh,
-  and dispatch-rate stability.
+- Periodic task-queue metric polls, based on backlog and worker lifetime
+  refresh, with an optional per-queue flat-dispatch-rate detector that gates
+  scale-up at a downstream/rate-limit ceiling.
 
 The algorithm does not scale down and does not set a target worker-set size.
 
@@ -24,14 +25,26 @@ The algorithm accepts only these config keys. Unknown keys are invalid.
 | `scale_up_cooloff_ms` | integer | `100` | `>= 0` | Minimum elapsed time between scale-up actions on the backlog-threshold path and task-add path. `0` disables cooloff. |
 | `scale_up_backlog_threshold` | integer | `0` | `>= 0` | Periodic metric polls request scale-up only when backlog is strictly greater than this threshold. |
 | `max_worker_lifetime_ms` | integer | `600000` | `>= 0` | Periodic metric polls request worker refresh when backlog is present and this much time has elapsed since the last scale-up. `0` disables this path. |
-| `scale_up_dispatch_rate_epsilon` | number | `0` | `>= 0` | Periodic metric polls suppress otherwise eligible scale-up when dispatch rate is unchanged within this epsilon. `0` disables suppression. |
+| `scale_up_dispatch_rate_epsilon` | number | `0` | `>= 0`, and `<= 0.10` when `> 0` | Enables the flat-dispatch-rate detector. `0` disables it. When `> 0` it is a **relative band** (a fraction of the dispatch rate): a queue's dispatch rate must stay within `epsilon * reference_rate` to count as flat. |
 | `metrics_poll_interval_ms` | integer | `60000` | `>= 10000` | Requested interval before the next periodic metric poll. |
+| `flat_dispatch_rate_confirm_ms` | integer | `90000` | `> metrics_poll_interval_ms` when `epsilon > 0` | A queue's dispatch rate must stay flat under a material backlog at least this long before suppression engages. Must exceed one poll interval, else suppression fires on the second flat poll regardless and the knob has no effect. |
+| `suppress_scale_up_ms` | integer | `120000` | `> suppress_poll_interval_ms` when `epsilon > 0` | Lifetime (TTL) of the suppression lease. Each flat poll renews it; if polling stops it self-expires after this. |
+| `suppress_poll_interval_ms` | integer | `90000` | `> 0` when `epsilon > 0` | Poll cadence while actively suppressing. Deliberately longer than `metrics_poll_interval_ms`. |
 
 Cross-field validation:
 
 - If `scale_up_cooloff_ms > 0`, `metrics_poll_interval_ms` must be greater than
   or equal to `scale_up_cooloff_ms`.
 - If `scale_up_cooloff_ms == 0`, the cross-field check is skipped.
+
+When `scale_up_dispatch_rate_epsilon > 0`:
+
+- `scale_up_dispatch_rate_epsilon` must be `<= 0.10` (a relative fraction).
+- `flat_dispatch_rate_confirm_ms` must be `> metrics_poll_interval_ms` (at or
+  below one poll interval the confirm window has no effect).
+- `suppress_poll_interval_ms` must be `> 0`.
+- `suppress_scale_up_ms` must be `> suppress_poll_interval_ms`, so the lease
+  never lapses between polls.
 
 ## State
 
@@ -40,9 +53,13 @@ The algorithm persists these state keys:
 | Key | Type | Meaning |
 | --- | --- | --- |
 | `last_scale_up_time_ms` | integer | Unix epoch milliseconds for the last emitted scale-up action. Shared by both decision paths. |
-| `last_dispatch_rate` | number | Last observed dispatch rate from a periodic poll. |
+| `<queue>_dispatch_flat_since_ms` | integer | When that queue's dispatch rate first went flat under a material backlog (`0` = not flat). |
+| `<queue>_dispatch_ref_rate` | number | Dispatch rate anchored when flat began (`-1` = none). |
+| `<queue>_suppress_scale_up_until_ms` | integer | Suppression lease: that queue's scale-up is gated while `now_ms < ` this value. Read by both scaling paths. |
 
-Unknown state keys are removed from the returned state.
+`<queue>` is the task queue type (`workflow`, `activity`, `nexus`); activity is the only rate-limited type today, but the detector runs per type. These keys are written only when the detector is enabled
+(`epsilon > 0`); a poll with the detector disabled deletes them. Unknown state
+keys are removed from the returned state.
 
 Nil config is treated as an empty config. Nil prior state is treated as an empty
 state.
@@ -53,6 +70,7 @@ state.
 
 - `IsSyncMatch`
 - `NoSyncMatchSignalsSinceLast`
+- `TaskQueueType` (workflow, activity, or nexus)
 
 ## Task-Add Signal Decision
 
@@ -68,7 +86,11 @@ For an eligible signal:
 ```text
 elapsed = now_ms - prior_state.last_scale_up_time_ms
 
-if elapsed >= scale_up_cooloff_ms:
+if now_ms < prior_state.<TaskQueueType>_suppress_scale_up_until_ms:
+  # obey the poll's per-queue lease (only rate-limited types ever get one)
+  emit no action
+  set throttled_count = NoSyncMatchSignalsSinceLast
+elif elapsed >= scale_up_cooloff_ms:
   emit one invoke-worker action
   set last_scale_up_time_ms = now_ms
 else:
@@ -76,7 +98,8 @@ else:
   set throttled_count = NoSyncMatchSignalsSinceLast
 ```
 
-When `scale_up_cooloff_ms == 0`, every eligible signal may emit a scale-up.
+When `scale_up_cooloff_ms == 0`, every eligible signal may emit a scale-up
+unless that queue's suppression lease gates it.
 
 ## Metrics Poll Inputs
 
@@ -93,42 +116,43 @@ returns the configured next-poll interval.
 
 ## Metrics Poll Decision
 
-On every metrics poll, the algorithm:
+The poll receives metrics for each configured queue type (workflow, activity,
+nexus). On every metrics poll, the algorithm:
 
-1. Sets `NextPoll` to `metrics_poll_interval_ms`.
-2. Computes `elapsed_since_scale_up` from the prior `last_scale_up_time_ms`.
-3. Evaluates the queue metrics.
-4. Emits at most one `invoke-worker` action for the poll if the queue remains
-   eligible after all guards.
+1. Runs the flat-dispatch-rate detector (below) for each queue type, persisting
+   each queue's verdict and returning whether that queue's scale-up is suppressed.
+2. Sets `NextPoll` to `suppress_poll_interval_ms` when suppressing, else
+   `metrics_poll_interval_ms`.
+3. Computes `elapsed_since_scale_up` from the prior `last_scale_up_time_ms`.
+4. Evaluates each queue and emits at most one `invoke-worker` action for the
+   whole poll (OR-ed across queue types).
 5. Updates `last_scale_up_time_ms` only if it emits a scale-up.
-6. Stores the current dispatch rate, even when no scale-up occurs or scale-up is
-   suppressed.
 
-Queue decision:
+Per-queue decision (OR-ed across queue types):
 
 ```text
-candidate = false
+scale_up = false
 
-if LastBacklogCount > scale_up_backlog_threshold
-   and elapsed_since_scale_up >= scale_up_cooloff_ms:
-  candidate = true
-
-if candidate == false
-   and max_worker_lifetime_ms > 0
-   and LastBacklogCount > 0
-   and elapsed_since_scale_up >= max_worker_lifetime_ms:
-  candidate = true
-
-if candidate == true
-   and scale_up_dispatch_rate_epsilon > 0
-   and prior last dispatch rate exists
-   and abs(LastProcessingRate - prior_last_dispatch_rate) <= scale_up_dispatch_rate_epsilon:
+for q in [workflow, activity, nexus] with metrics present:
   candidate = false
 
-store current dispatch rate in state
+  if q.LastBacklogCount > scale_up_backlog_threshold
+     and elapsed_since_scale_up >= scale_up_cooloff_ms:
+    candidate = true            # growth
+
+  if candidate and q_suppressed:
+    candidate = false           # gate this queue's growth at its ceiling
+
+  if candidate == false
+     and max_worker_lifetime_ms > 0
+     and q.LastBacklogCount > 0
+     and elapsed_since_scale_up >= max_worker_lifetime_ms:
+    candidate = true            # lifetime maintenance -- never gated
+
+  scale_up = scale_up or candidate
 ```
 
-If `candidate == true`, the poll emits one `invoke-worker` action and sets
+If `scale_up == true`, the poll emits one `invoke-worker` action and sets
 `last_scale_up_time_ms = now_ms`.
 
 ## Backlog Threshold Path
@@ -166,27 +190,55 @@ would still suppress the backlog-threshold path.
 Any scale-up from either task-add signals or metrics polls resets the shared
 lifetime timer by updating `last_scale_up_time_ms`.
 
-## Dispatch-Rate Epsilon Suppression
+## Flat-Dispatch-Rate Detector
 
-Dispatch-rate epsilon suppression applies only after the queue has become a
-scale-up candidate through the backlog threshold path or the worker lifetime
-refresh path.
+When `scale_up_dispatch_rate_epsilon > 0`, each metrics poll runs this detector
+**per queue type**. It confirms a queue's dispatch rate staying flat under a
+material backlog (a downstream or rate-limit ceiling that adding workers cannot
+lift), then persists a per-queue suppression lease that gates that queue's growth
+on both the poll path and the task-add fast path. When `epsilon <= 0` the detector
+is disabled: the per-queue keys are deleted and the poll reverts to baseline.
 
-Suppression is active only when:
+Activity queues are the only ones that can be rate-limited today, but the detector
+works for any queue type -- a non-rate-limited queue's dispatch rises as workers
+are added, so it moves out of the band and never confirms.
+
+Per queue `q`, inputs from its metrics: `rate = LastProcessingRate`,
+`backlog = LastBacklogCount`. Let `ref` be `<q>_dispatch_ref_rate`.
 
 ```text
-scale_up_dispatch_rate_epsilon > 0
-prior dispatch rate exists
-abs(current dispatch rate - prior dispatch rate) <= scale_up_dispatch_rate_epsilon
+material = backlog > scale_up_backlog_threshold
+band     = scale_up_dispatch_rate_epsilon * ref     # relative band
+moved    = ref >= 0 and abs(rate - ref) > band
+
+if not material or moved or rate <= 0:
+  # no material backlog, dispatch moved off the reference, or zero throughput
+  # (a stall, not a flat plateau) -> resume: clear the verdict
+  <q>_dispatch_flat_since_ms     = 0
+  <q>_dispatch_ref_rate          = -1
+  <q>_suppress_scale_up_until_ms = 0
+elif <q>_dispatch_flat_since_ms == 0:
+  # flat + material backlog -> start confirming; anchor the reference rate
+  <q>_dispatch_flat_since_ms = now_ms
+  <q>_dispatch_ref_rate      = rate
+elif now_ms - <q>_dispatch_flat_since_ms >= flat_dispatch_rate_confirm_ms:
+  # confirmed flat under backlog -> (re)new the suppression lease
+  <q>_suppress_scale_up_until_ms = now_ms + suppress_scale_up_ms
+
+q_suppressed = <q>_suppress_scale_up_until_ms > now_ms
 ```
 
-The comparison is inclusive. A difference exactly equal to epsilon suppresses
-the candidate.
+Notes:
 
-Suppression is skipped on the first poll because no prior dispatch rate exists.
-
-The current dispatch rate is written to state whether the candidate is emitted,
-suppressed, or never created.
+- The reference rate is anchored once when flatness begins and is compared
+  against on every subsequent poll; a move beyond `band` in either direction
+  resumes scale-up.
+- Zero throughput under a backlog is treated as a stall (recover), never as a
+  flat plateau to suppress.
+- Only a suppressed queue's growth is gated. Lifetime maintenance on every queue
+  is never gated.
+- The lease is consulted by `ProcessTaskAdd` for that queue's task-adds, so the
+  metrics-blind fast path obeys the same ceiling.
 
 ## Shared Cooloff and State
 
@@ -215,7 +267,8 @@ Consequences:
 
 - `Actions`: empty or one `invoke-worker` action.
 - `Status`: updated algorithm state.
-- `NextPoll`: `metrics_poll_interval_ms`.
+- `NextPoll`: `metrics_poll_interval_ms`, or `suppress_poll_interval_ms` while
+  any queue's suppression lease is active.
 
 The caller is responsible for adding the scaling group key to emitted actions,
 executing the invoke request, persisting returned status, and applying any

--- a/docs/simulators/function/index.html
+++ b/docs/simulators/function/index.html
@@ -27,6 +27,7 @@
             </ol>
           </li>
         </ol>
+        <p class="detector-note"><strong>ε &gt; 0 enables the flat dispatch rate detection (proposal):</strong> the poll's "dispatch flat despite a backlog" verdict is confirmed over a window, persisted, and read by the <em>task-add</em> path, which simply obeys the suppression lease — so growth is gated on both paths, while <em>lifetime maintenance</em> stays on the poll path; the poll backs off (re-checks less often) while suppressing. <strong>ε = 0 is exactly today's behavior.</strong> Cold start and the dispatch-rate window model real-world physics; the fast path fires per ~500&nbsp;ms no-sync signal batch (fixed).</p>
       </div>
       <div>
         <h3>Scale-down</h3>
@@ -45,6 +46,11 @@
     <div class="column-left">
     <section class="controls panel">
       <h2>Parameters</h2>
+      <div class="profiles">
+        <span class="profiles-label">Presets:</span>
+        <button type="button" class="profile-btn" data-profile="realistic">Realistic ceiling</button>
+        <button type="button" class="profile-btn" data-profile="baseline">Ceiling, ε=0 (today)</button>
+      </div>
       <div class="control-group">
         <h3>Simulation Parameters</h3>
         <div class="control-grid">
@@ -77,6 +83,10 @@
             <input type="number" id="workerExitAfter" min="0" step="1" value="50">
           </label>
           <label>
+            <span>Worker cold start (s, 0=none)</span>
+            <input type="number" id="coldStart" min="0" step="0.5" value="0">
+          </label>
+          <label>
             <span>Max workers (sim guard)</span>
             <input type="number" id="maxWorkers" min="1" max="50" value="10">
           </label>
@@ -102,8 +112,25 @@
             <input type="number" id="maxWorkerLifetime" min="0" value="600000">
           </label>
           <label>
-            <span>Dispatch rate epsilon (items/s)</span>
-            <input type="number" id="scaleUpDispatchRateEpsilon" min="0" step="0.1" value="0">
+            <span>Dispatch-rate ε (0=off; &gt;0 enables detector, relative band)</span>
+            <input type="number" id="scaleUpDispatchRateEpsilon" min="0" step="0.01" value="0">
+          </label>
+        </div>
+      </div>
+      <div class="control-group">
+        <h3>Flat dispatch rate detection <span class="detector-hint">— engages when ε &gt; 0</span></h3>
+        <div class="control-grid">
+          <label>
+            <span>Confirm window (ms)</span>
+            <input type="number" id="dispatchConfirm" min="0" value="90000">
+          </label>
+          <label>
+            <span>Suppress TTL (ms)</span>
+            <input type="number" id="dispatchSuppress" min="0" value="120000">
+          </label>
+          <label>
+            <span>Suppress poll interval (ms, back-off)</span>
+            <input type="number" id="suppressPollInterval" min="5000" value="90000">
           </label>
         </div>
       </div>
@@ -133,12 +160,12 @@
           <span id="slotUtilization" class="metric-value">0 / 0 slots in use</span>
         </div>
         <div class="metric-col">
-          <span class="metric-label">Arrival rate <span class="metric-note">(last 10s)</span></span>
+          <span class="metric-label">Arrival rate <span class="metric-note">(30s avg)</span></span>
           <span id="actualArrivalRate" class="metric-value">—</span>
           <span class="metric-unit">items/s</span>
         </div>
         <div class="metric-col">
-          <span class="metric-label">Dispatch rate <span class="metric-note">(last 10s)</span></span>
+          <span class="metric-label">Dispatch rate <span class="metric-note">(30s avg)</span></span>
           <span id="dispatchRate" class="metric-value">—</span>
           <span class="metric-unit">items/s</span>
         </div>
@@ -146,6 +173,10 @@
           <span class="metric-label">Age of oldest Task</span>
           <span id="oldestQueueAge" class="metric-value">—</span>
           <span class="metric-unit">s</span>
+        </div>
+        <div class="metric-col">
+          <span class="metric-label">Flat dispatch rate detection</span>
+          <span id="detectorState" class="metric-value detector-off">off</span>
         </div>
       </div>
       <div class="consumers-slots" id="consumersSlots">

--- a/docs/simulators/function/simulator.css
+++ b/docs/simulators/function/simulator.css
@@ -354,3 +354,30 @@ main.two-column {
 .history-outcome.no-action {
   color: var(--muted);
 }
+
+/* ---- flat-dispatch-rate detection extension ---- */
+.slot-bar .slot.warming {
+  background: repeating-linear-gradient(45deg, var(--border) 0 3px, rgba(255,152,0,0.45) 3px 6px);
+}
+.history-outcome.suppressed { color: #c792ea; font-weight: 600; }
+
+.detector-hint { font-weight: 400; color: var(--muted); font-size: 0.85rem; }
+.detector-note {
+  margin: 0.6rem 0 0; padding: 0.6rem 0.8rem; font-size: 0.85rem; line-height: 1.5;
+  background: var(--bg); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 6px;
+}
+
+.metric-value.detector-off,
+.detector-off { color: var(--muted); }
+.metric-value.detector-clear { color: var(--success); }
+.metric-value.detector-confirming { color: var(--warn); }
+.metric-value.detector-suppressed { color: #c792ea; }
+
+.profiles { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+.profiles-label { color: var(--muted); font-size: 0.85rem; }
+.profile-btn {
+  background: var(--bg); color: var(--text); border: 1px solid var(--border);
+  border-radius: 6px; padding: 5px 11px; font-size: 0.85rem; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.profile-btn:hover { border-color: var(--accent); color: var(--accent); }

--- a/docs/simulators/function/simulator.js
+++ b/docs/simulators/function/simulator.js
@@ -14,7 +14,14 @@
   let nextWorkId = 1;
   let nextConsumerId = 1;
   let lastMetricsPollRealTime = 0;
-  let lastDispatchRate = -1;
+  // --- flat dispatch rate detection state (engages only when dispatch-rate epsilon > 0) ---
+  let flatSinceMs = 0;          // when dispatch first went flat with a backlog (0 = not flat)
+  let suppressUntilMs = 0;      // fast-path suppression flag: growth gated while now < this
+  let refRate = -1;             // dispatch rate anchored when flat began; must move off it to resume (-1 = none)
+  let nextPollIntervalMs = 0;   // adaptive poll: 0 = use the configured interval
+  let gatingStatus = 'off';     // 'off' | 'clear' | 'confirming' | 'suppressed'
+  let noSyncPending = false;    // a no-sync match occurred this batch window (for ~500ms task-add batching)
+  let lastBatchRealTime = 0;
   let arrivalTimestamps = [];
   let dispatchTimestamps = [];
   let chartData = [];
@@ -22,8 +29,9 @@
   let chart = null;
   let rateChartData = [];
   let rateChart = null;
-  const RATE_WINDOW_MS = 10000;
-  const RATE_TRIM_MS = 60000;
+  const RATE_WINDOW_MS = 30000; // dispatch/arrival averaging window — models the server's fixed ~30s metric window (not a tunable config)
+  const RATE_TRIM_MS = 90000;
+  const TASK_ADD_BATCH_MS = 500;   // client batches no-sync signals (MinSignalIntervalNoSyncMatch default); fixed infra
   const CHART_WINDOW_MS = 300000;
   const CHART_SAMPLE_MS = 500;
 
@@ -68,6 +76,24 @@
       scaleUpDispatchRateEpsilon: (function () {
         var v = parseFloat(document.getElementById('scaleUpDispatchRateEpsilon').value);
         return (isNaN(v) || v < 0) ? 0 : v;
+      })(),
+      // --- physics / fidelity knobs (mirror the real world) ---
+      coldStartMs: (function () {
+        var v = parseFloat(document.getElementById('coldStart').value);
+        return (isNaN(v) || v < 0) ? 0 : v * 1000;
+      })(),
+      // --- flat dispatch rate detection knobs (engage only when epsilon > 0) ---
+      dispatchConfirmMs: (function () {
+        var v = parseInt(document.getElementById('dispatchConfirm').value, 10);
+        return (isNaN(v) || v < 0) ? 90000 : v;
+      })(),
+      dispatchSuppressMs: (function () {
+        var v = parseInt(document.getElementById('dispatchSuppress').value, 10);
+        return (isNaN(v) || v < 0) ? 120000 : v;
+      })(),
+      suppressPollIntervalMs: (function () {
+        var v = parseInt(document.getElementById('suppressPollInterval').value, 10);
+        return (isNaN(v) || v < 5000) ? 90000 : v;
       })()
     };
   }
@@ -103,6 +129,7 @@
 
   function findFreeSlot() {
     for (let c = 0; c < consumers.length; c++) {
+      if (consumers[c].readyAt !== undefined && simTime < consumers[c].readyAt) continue; // still cold-starting
       for (let s = 0; s < consumers[c].slots.length; s++) {
         if (consumers[c].slots[s] === null) return { consumer: consumers[c], index: s };
       }
@@ -203,6 +230,7 @@
     consumers.push({
       id: nextConsumerId++,
       createdAt: simTime,
+      readyAt: simTime + config.coldStartMs,   // cold start: can't dispatch until warmed
       slots: slots
     });
     lastScaleUpTimeMs = Date.now();
@@ -249,8 +277,14 @@
 
     const config = getConfig();
     const now = Date.now();
-    const elapsed = now - lastScaleUpTimeMs;
 
+    // flat dispatch rate detection: the fast path just obeys the poll's persisted suppression lease.
+    if (now < suppressUntilMs) {
+      logEvent('suppressed', 'Suppressed', 'Task-add gated (flat dispatch rate)');
+      return;
+    }
+
+    const elapsed = now - lastScaleUpTimeMs;
     if (elapsed >= config.scaleUpCooloffMs) {
       invokeWorker('Task-add no-sync');
     } else {
@@ -258,46 +292,59 @@
     }
   }
 
-  function processMetricsPoll() {
-    const config = getConfig();
+  // Confirm whether dispatch is at a flat-rate ceiling; persists the verdict (flat_since, ref_rate, suppress lease)
+  // that the fast path reads, and returns whether growth is currently suppressed. epsilon <= 0 clears the verdict and
+  // returns false, reverting to today's behavior. Mirrors detectDispatchCeiling in the Go algorithm (no branch-off).
+  function detectFlatDispatch(config) {
+    if (config.scaleUpDispatchRateEpsilon <= 0) {
+      suppressUntilMs = 0; flatSinceMs = 0; refRate = -1;
+      gatingStatus = 'off';
+      return false;
+    }
+
     const now = Date.now();
     const backlog = queue.length;
-    const dispatchRate = currentDispatchRate(now);
-    const elapsed = now - lastScaleUpTimeMs;
-    let candidate = false;
-    let reason = '';
+    const rate = currentDispatchRate(now);
 
-    if (backlog > config.scaleUpBacklogThreshold && elapsed >= config.scaleUpCooloffMs) {
-      candidate = true;
-      reason = 'Backlog > threshold';
-    } else if (backlog > config.scaleUpBacklogThreshold) {
-      reason = 'Scale-up cooloff';
+    const material = backlog > config.scaleUpBacklogThreshold;
+    const band = config.scaleUpDispatchRateEpsilon * refRate;         // RELATIVE band (fraction of dispatch)
+    const moved = refRate >= 0 && Math.abs(rate - refRate) > band;    // dispatch rose OR dropped
+
+    if (!material || moved || rate <= 0) {
+      suppressUntilMs = 0; flatSinceMs = 0; refRate = -1;             // resume: clear the verdict
+    } else if (flatSinceMs === 0) {
+      flatSinceMs = now; refRate = rate;                             // anchor the bar; start confirming
+    } else if (now - flatSinceMs >= config.dispatchConfirmMs) {
+      suppressUntilMs = now + config.dispatchSuppressMs;             // confirmed flat dispatch -> suppress
     }
 
-    if (!candidate && config.maxWorkerLifetimeMs > 0 && backlog > 0 && elapsed >= config.maxWorkerLifetimeMs) {
-      candidate = true;
-      reason = 'Worker lifetime refresh';
-    }
+    const suppressed = suppressUntilMs > now;
+    gatingStatus = suppressed ? 'suppressed' : (flatSinceMs !== 0 ? 'confirming' : 'clear');
+    return suppressed;
+  }
 
-    if (candidate && config.scaleUpDispatchRateEpsilon > 0 && lastDispatchRate >= 0 &&
-        Math.abs(dispatchRate - lastDispatchRate) <= config.scaleUpDispatchRateEpsilon) {
-      candidate = false;
-      reason = 'Dispatch rate unchanged';
-    }
+  // One scale-up per poll: growth (gated by the suppression verdict) OR maintenance (lifetime refresh, never gated).
+  // Cadence backs off while suppressing. epsilon <= 0 -> detectFlatDispatch returns false -> exactly today's behavior.
+  function processMetricsPoll() {
+    const config = getConfig();
+    const suppressed = detectFlatDispatch(config);
+    nextPollIntervalMs = suppressed ? config.suppressPollIntervalMs : config.metricsPollIntervalMs;
 
-    lastDispatchRate = dispatchRate;
+    const now = Date.now();
+    const backlog = queue.length;
+    const growth = backlog > config.scaleUpBacklogThreshold && (now - lastScaleUpTimeMs) >= config.scaleUpCooloffMs;
+    const maintenance = config.maxWorkerLifetimeMs > 0 && backlog > 0 && (now - lastScaleUpTimeMs) >= config.maxWorkerLifetimeMs;
 
-    if (candidate) {
-      invokeWorker('Metrics poll: ' + reason);
-      return;
-    }
-
-    if (backlog === 0) {
-      logEvent('no-action', 'No action', 'Metrics poll: queue empty');
-    } else if (reason) {
-      logEvent('no-action', 'No action', 'Metrics poll: ' + reason);
+    if (growth && !suppressed) {
+      invokeWorker('Poll: backlog growth');
+    } else if (maintenance) {
+      invokeWorker('Poll: maintenance (lifetime refresh)');
+    } else if (suppressed) {
+      logEvent('suppressed', 'Suppressed', 'Poll: growth gated (flat dispatch rate)');
+    } else if (backlog === 0) {
+      logEvent('no-action', 'No action', 'Poll: queue empty');
     } else {
-      logEvent('no-action', 'No action', 'Metrics poll: below threshold');
+      logEvent('no-action', 'No action', 'Poll: ' + gatingStatus);
     }
   }
 
@@ -309,9 +356,8 @@
       queue.push(Object.assign(createWorkItem(config), { enqueuedAt: now }));
     }
     assignWorkToSlots(config);
-    if (queue.length > 0) {
-      processTaskAdd(Math.min(count, queue.length));
-    }
+    // a no-sync match this arrival → defer to the batch flush in tick() (the client batches no-sync signals)
+    if (queue.length > 0) noSyncPending = true;
   }
 
   function freeCompletedSlots() {
@@ -337,7 +383,16 @@
     expireWorkers(config);
     assignWorkToSlots(config);
 
-    if (nowReal - lastMetricsPollRealTime >= config.metricsPollIntervalMs) {
+    // fast path fires once per batch window (the client batches no-sync signals; fixed ~500ms)
+    if (nowReal - lastBatchRealTime >= TASK_ADD_BATCH_MS) {
+      lastBatchRealTime = nowReal;
+      if (noSyncPending) processTaskAdd(1);
+      noSyncPending = false;
+    }
+
+    const pollInterval = (config.scaleUpDispatchRateEpsilon > 0 && nextPollIntervalMs > 0)
+      ? nextPollIntervalMs : config.metricsPollIntervalMs;
+    if (nowReal - lastMetricsPollRealTime >= pollInterval) {
       lastMetricsPollRealTime = nowReal;
       processMetricsPoll();
     }
@@ -355,10 +410,37 @@
     if (n > 0) addItems(n);
   }
 
+  // shade the Workers & backlog chart during flat-dispatch suppression windows
+  const suppressionShadePlugin = {
+    id: 'suppressionShade',
+    beforeDatasetsDraw: function (c) {
+      const area = c.chartArea;
+      if (!area || chartData.length === 0) return;
+      const ctx = c.ctx;
+      const xs = c.scales.x;
+      ctx.save();
+      ctx.fillStyle = 'rgba(199, 146, 234, 0.13)';   // translucent purple = suppressed
+      let start = null;
+      for (let i = 0; i <= chartData.length; i++) {
+        const sup = i < chartData.length && chartData[i].suppressed;
+        if (sup && start === null) {
+          start = chartData[i].t;
+        } else if (!sup && start !== null) {
+          const end = (i < chartData.length ? chartData[i] : chartData[i - 1]).t;
+          const x0 = Math.max(area.left, xs.getPixelForValue(start));
+          const x1 = Math.min(area.right, xs.getPixelForValue(end));
+          if (x1 > x0) ctx.fillRect(x0, area.top, x1 - x0, area.bottom - area.top);
+          start = null;
+        }
+      }
+      ctx.restore();
+    }
+  };
+
   function initChart() {
     const canvas = document.getElementById('chart');
     if (!canvas) return;
-    chart = new Chart(canvas, createChartConfig(
+    const cfg = createChartConfig(
       [
         {
           label: 'Workers',
@@ -397,7 +479,9 @@
           grid: { drawOnChartArea: false }
         }
       }
-    ));
+    );
+    cfg.plugins = [suppressionShadePlugin];
+    chart = new Chart(canvas, cfg);
   }
 
   function renderChart() {
@@ -463,7 +547,7 @@
 
     if (now - lastChartSampleTime >= CHART_SAMPLE_MS) {
       lastChartSampleTime = now;
-      chartData.push({ t: now, consumers: consumers.length, queue: queue.length });
+      chartData.push({ t: now, consumers: consumers.length, queue: queue.length, suppressed: gatingStatus === 'suppressed' });
       chartData = chartData.filter(function (d) { return d.t >= now - CHART_WINDOW_MS; });
       rateChartData.push({
         t: now,
@@ -504,11 +588,20 @@
     document.getElementById('dispatchRate').textContent = dispatchTimestamps.length > 0 ? dispatchRateVal : '—';
     document.getElementById('oldestQueueAge').textContent = oldestAge;
 
+    const detectorEl = document.getElementById('detectorState');
+    if (detectorEl) {
+      const on = config.scaleUpDispatchRateEpsilon > 0;
+      const state = on ? gatingStatus : 'off';
+      detectorEl.textContent = on ? state : 'off (ε=0)';
+      detectorEl.className = 'metric-value detector-' + state;
+    }
+
     const container = document.getElementById('consumersSlots');
     if (consumers.length === 0) {
       container.innerHTML = '<p class="muted">No workers. Start the simulation or add tasks.</p>';
     } else {
       container.innerHTML = consumers.map(function (c) {
+        const warming = c.readyAt !== undefined && simTime < c.readyAt;
         const bar = c.slots.map(function (s) {
           if (s !== null) {
             const tooltip = 'Task #' + s.workItem.id +
@@ -516,11 +609,11 @@
               '\nEnd:   ' + formatSimTime(s.endTime);
             return '<span class="slot busy" title="' + tooltip + '"></span>';
           }
-          return '<span class="slot"></span>';
+          return '<span class="slot' + (warming ? ' warming' : '') + '"></span>';
         }).join('');
         return (
           '<div class="consumer-row">' +
-          '<span class="consumer-id">Worker ' + c.id + '</span>' +
+          '<span class="consumer-id">Worker ' + c.id + (warming ? ' ⏳' : '') + '</span>' +
           '<span class="slot-bar">' + bar + '</span>' +
           '</div>'
         );
@@ -571,9 +664,17 @@
     pause();
     queue = [];
     consumers = [];
+    nextConsumerId = 1;
+    nextWorkId = 1;
     lastScaleUpTimeMs = 0;
     lastMetricsPollRealTime = 0;
-    lastDispatchRate = -1;
+    flatSinceMs = 0;
+    suppressUntilMs = 0;
+    refRate = -1;
+    nextPollIntervalMs = 0;
+    gatingStatus = 'off';
+    noSyncPending = false;
+    lastBatchRealTime = 0;
     creationHistory = [];
     simTime = 0;
     lastRealTime = 0;
@@ -585,6 +686,43 @@
     lastChartSampleTime = 0;
     render();
   }
+
+  // One-click parameter presets. Realistic ceiling and its ε=0 baseline share the same workload
+  // (arrival 30 vs dispatch cap 15) and differ only in the detector epsilon, so flipping between
+  // them shows the detector's effect directly. Fills the inputs, resets, and starts.
+  const PROFILES = {
+    realistic: {
+      slotsPerConsumer: 5, workDurationMin: 8, workDurationMax: 12,
+      arrivalRate: 30, itemsPerClick: 1, maxDispatchRate: 15,
+      workerExitAfter: 120, coldStart: 3, maxWorkers: 150,
+      scaleUpCooloff: 200, metricsPollInterval: 15000, scaleUpBacklogThreshold: 200,
+      maxWorkerLifetime: 90000, scaleUpDispatchRateEpsilon: 0.05,
+      dispatchConfirm: 15000, dispatchSuppress: 60000, suppressPollInterval: 15000
+    },
+    baseline: {
+      slotsPerConsumer: 5, workDurationMin: 8, workDurationMax: 12,
+      arrivalRate: 30, itemsPerClick: 1, maxDispatchRate: 15,
+      workerExitAfter: 120, coldStart: 3, maxWorkers: 150,
+      scaleUpCooloff: 200, metricsPollInterval: 15000, scaleUpBacklogThreshold: 200,
+      maxWorkerLifetime: 90000, scaleUpDispatchRateEpsilon: 0,
+      dispatchConfirm: 15000, dispatchSuppress: 60000, suppressPollInterval: 15000
+    }
+  };
+
+  function applyProfile(name) {
+    const p = PROFILES[name];
+    if (!p) return;
+    Object.keys(p).forEach(function (id) {
+      const el = document.getElementById(id);
+      if (el) el.value = p[id];
+    });
+    reset();
+    start();
+  }
+
+  document.querySelectorAll('.profile-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () { applyProfile(btn.getAttribute('data-profile')); });
+  });
 
   document.getElementById('btnStart').addEventListener('click', start);
   document.getElementById('btnPause').addEventListener('click', pause);

--- a/wci/workflow/scaling_algorithm/no_sync_match.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
@@ -34,22 +35,51 @@ const (
 	configNoSyncMaxWorkerLifetimeMsKey     = "max_worker_lifetime_ms"
 	configNoSyncMaxWorkerLifetimeMsDefault = 10 * 60 * 1000 // default is 10min
 
-	// configNoSyncScaleUpDispatchRateEpsilonKey: in ProcessMetricsPoll, skip scale-up when the current
-	// processing rate (QueueTypeScalingMetrics.LastProcessingRate) is within this epsilon of the previous
-	// poll's value, stored per queue under the state key "<queue>_last_dispatch_rate" (see stateLastDispatchRateKeyFmt).
-	// 0 means disabled. Suppression is skipped on the first poll for a queue when no prior rate is recorded in state.
+	// configNoSyncScaleUpDispatchRateEpsilonKey enables the flat-dispatch-rate detection (see the block
+	// comment below). 0 disables it. > 0 is a relative band (fraction of dispatch, capped at 0.10): a queue's
+	// dispatch rate must stay within it to count as flat.
 	configNoSyncScaleUpDispatchRateEpsilonKey     = "scale_up_dispatch_rate_epsilon"
 	configNoSyncScaleUpDispatchRateEpsilonDefault = 0
+	// configNoSyncScaleUpDispatchRateEpsilonMax caps the band; wider would suppress scale-up on dispatch
+	// that is still meaningfully moving.
+	configNoSyncScaleUpDispatchRateEpsilonMax = 0.10
 
 	// configNoSyncMetricsPollIntervalMsKey is the interval in milliseconds between metrics poll calls.
 	configNoSyncMetricsPollIntervalMsKey     = "metrics_poll_interval_ms"
 	configNoSyncMetricsPollIntervalMsDefault = int64(60_000) // 60s
 
 	stateLastScaleUpTimestampKey = "last_scale_up_time_ms"
-	// stateLastDispatchRateKeyFmt is a format string for per-queue dispatch rate state keys.
-	// The %s placeholder is replaced by the queue type name ("workflow", "activity", "nexus"),
-	// producing keys such as "workflow_last_dispatch_rate".
-	stateLastDispatchRateKeyFmt = "%s_last_dispatch_rate"
+
+	// --- flat dispatch rate detection (engages only when scale_up_dispatch_rate_epsilon > 0) ---
+	//
+	// When epsilon > 0 it is reinterpreted as a RELATIVE band (a fraction of dispatch):
+	// ProcessMetricsPoll confirms, per queue type, a flat dispatch rate under a material backlog, then
+	// persists a suppression verdict that the metrics-blind ProcessTaskAdd (fast) path reads and obeys.
+	// Growth is gated on both paths; the poll path's lifetime maintenance is never gated. epsilon <= 0 is
+	// unchanged.
+
+	// configNoSyncFlatDispatchRateConfirmMsKey: dispatch must stay flat this long before suppression engages.
+	// Must exceed metrics_poll_interval_ms (validated); at or below one poll interval suppression fires on the
+	// second flat poll regardless, so the knob is a no-op. Default 90s (1.5 default polls) confirms on the 3rd.
+	configNoSyncFlatDispatchRateConfirmMsKey     = "flat_dispatch_rate_confirm_ms"
+	configNoSyncFlatDispatchRateConfirmMsDefault = int64(90_000)
+
+	// configNoSyncSuppressScaleUpMsKey is the suppression lease duration: on a confirmed-flat poll the detector
+	// sets <queue>_suppress_scale_up_until_ms = now + this (re-set each flat poll). Must exceed
+	// suppress_poll_interval_ms so the lease never lapses between polls.
+	configNoSyncSuppressScaleUpMsKey     = "suppress_scale_up_ms"
+	configNoSyncSuppressScaleUpMsDefault = int64(120_000)
+
+	// configNoSyncSuppressPollIntervalMsKey: the poll cadence while actively suppressing. Backed off longer
+	// than the normal poll -- finer than the ~30s dispatch-rate averaging window adds no signal.
+	configNoSyncSuppressPollIntervalMsKey     = "suppress_poll_interval_ms"
+	configNoSyncSuppressPollIntervalMsDefault = int64(90_000)
+
+	// Per-queue flat-dispatch-rate detection state keys. The %s placeholder is the queue type name
+	// ("workflow", "activity", "nexus"), producing keys such as "activity_dispatch_flat_since_ms".
+	stateDispatchFlatSinceKeyFmt    = "%s_dispatch_flat_since_ms"     // dispatch first went flat under a material backlog (0 = not flat)
+	stateSuppressScaleUpUntilKeyFmt = "%s_suppress_scale_up_until_ms" // suppression lease both scaling paths compare against
+	stateDispatchRefRateKeyFmt      = "%s_dispatch_ref_rate"          // dispatch rate anchored when flat began (-1 = none)
 )
 
 var _ ScalingAlgorithm = (*scalingAlgorithmNoSync)(nil)
@@ -60,14 +90,29 @@ var noSyncValidConfigKeys = map[string]struct{}{
 	configNoSyncMaxWorkerLifetimeMsKey:        {},
 	configNoSyncScaleUpDispatchRateEpsilonKey: {},
 	configNoSyncMetricsPollIntervalMsKey:      {},
+	configNoSyncFlatDispatchRateConfirmMsKey:  {},
+	configNoSyncSuppressScaleUpMsKey:          {},
+	configNoSyncSuppressPollIntervalMsKey:     {},
 }
 
-var noSyncValidStateKeys = map[string]struct{}{
-	stateLastScaleUpTimestampKey:                         {},
-	fmt.Sprintf(stateLastDispatchRateKeyFmt, "workflow"): {},
-	fmt.Sprintf(stateLastDispatchRateKeyFmt, "activity"): {},
-	fmt.Sprintf(stateLastDispatchRateKeyFmt, "nexus"):    {},
+// queueTypeName maps each task queue type to its per-queue state-key prefix; an unrecognized type maps to "".
+// These prefixes are part of the persisted state-key format, so they are pinned explicitly here rather than
+// derived from Enum.String(), which is owned upstream and could change.
+var queueTypeName = map[enumspb.TaskQueueType]string{
+	enumspb.TASK_QUEUE_TYPE_WORKFLOW: "workflow",
+	enumspb.TASK_QUEUE_TYPE_ACTIVITY: "activity",
+	enumspb.TASK_QUEUE_TYPE_NEXUS:    "nexus",
 }
+
+var noSyncValidStateKeys = func() map[string]struct{} {
+	keys := map[string]struct{}{stateLastScaleUpTimestampKey: {}}
+	for _, qName := range queueTypeName {
+		keys[fmt.Sprintf(stateDispatchFlatSinceKeyFmt, qName)] = struct{}{}
+		keys[fmt.Sprintf(stateSuppressScaleUpUntilKeyFmt, qName)] = struct{}{}
+		keys[fmt.Sprintf(stateDispatchRefRateKeyFmt, qName)] = struct{}{}
+	}
+	return keys
+}()
 
 type (
 	scalingAlgorithmNoSync struct{}
@@ -120,6 +165,15 @@ func (a *scalingAlgorithmNoSync) ValidateConfig(ctx context.Context, config ifac
 	if err := config.ValidateInt64Field(configNoSyncMetricsPollIntervalMsKey, 10000); err != nil {
 		return err
 	}
+	if err := config.ValidateInt64Field(configNoSyncFlatDispatchRateConfirmMsKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateInt64Field(configNoSyncSuppressScaleUpMsKey, 0); err != nil {
+		return err
+	}
+	if err := config.ValidateInt64Field(configNoSyncSuppressPollIntervalMsKey, 0); err != nil {
+		return err
+	}
 
 	// Cross-field: if poll interval < cooloff, metric-driven scale-ups can never fire.
 	// The guard `cooloff > 0` reflects the "0 means disabled" semantics: when cooloff is
@@ -128,6 +182,27 @@ func (a *scalingAlgorithmNoSync) ValidateConfig(ctx context.Context, config ifac
 	cooloff := config.GetInt64Field(configNoSyncScaleUpCooloffMsKey, configNoSyncScaleUpCooloffMsDefault)
 	if cooloff > 0 && pollInterval < cooloff {
 		return fmt.Errorf("metrics_poll_interval_ms (%d) must be >= scale_up_cooloff_ms (%d), otherwise metric-driven scale-ups will never fire", pollInterval, cooloff)
+	}
+
+	// Flat-dispatch-rate detection (epsilon > 0) cross-field checks.
+	if epsilon := config.GetFloat64Field(configNoSyncScaleUpDispatchRateEpsilonKey, configNoSyncScaleUpDispatchRateEpsilonDefault); epsilon > 0 {
+		// epsilon is a RELATIVE band (fraction of the dispatch rate); too wide and it suppresses scale-up on
+		// dispatch that is still meaningfully moving.
+		if epsilon > configNoSyncScaleUpDispatchRateEpsilonMax {
+			return fmt.Errorf("scale_up_dispatch_rate_epsilon (%v) must be <= %v: it is a relative band (fraction of the dispatch rate)", epsilon, configNoSyncScaleUpDispatchRateEpsilonMax)
+		}
+		confirmMs := config.GetInt64Field(configNoSyncFlatDispatchRateConfirmMsKey, configNoSyncFlatDispatchRateConfirmMsDefault)
+		suppressMs := config.GetInt64Field(configNoSyncSuppressScaleUpMsKey, configNoSyncSuppressScaleUpMsDefault)
+		suppressPollMs := config.GetInt64Field(configNoSyncSuppressPollIntervalMsKey, configNoSyncSuppressPollIntervalMsDefault)
+		if confirmMs <= pollInterval {
+			return fmt.Errorf("flat_dispatch_rate_confirm_ms (%d) must be > metrics_poll_interval_ms (%d): at or below one poll interval, suppression fires on the second flat poll regardless and the confirm window has no effect", confirmMs, pollInterval)
+		}
+		if suppressPollMs <= 0 {
+			return fmt.Errorf("suppress_poll_interval_ms (%d) must be > 0 when scale_up_dispatch_rate_epsilon > 0", suppressPollMs)
+		}
+		if suppressMs <= suppressPollMs {
+			return fmt.Errorf("suppress_scale_up_ms (%d) must be > suppress_poll_interval_ms (%d), otherwise the suppression lease lapses between polls", suppressMs, suppressPollMs)
+		}
 	}
 
 	return nil
@@ -162,7 +237,15 @@ func (a *scalingAlgorithmNoSync) ProcessTaskAdd(ctx context.Context, config ifac
 		nowMs := time.Now().UnixMilli() // safe: called from activity context, not workflow
 		elapsedMs := nowMs - lastScaleUpMs
 
-		if elapsedMs >= cooloffMs {
+		// Obey the poll's per-queue suppression lease for this task-add's queue type.
+		// Activity is the only rate-limited type today, but the detector runs per queue type.
+		qName := queueTypeName[event.TaskQueueType]
+		suppressed := nowMs < priorState.GetInt64Field(fmt.Sprintf(stateSuppressScaleUpUntilKeyFmt, qName), 0)
+
+		if suppressed {
+			logger.Info("Suppressed scale-up (flat dispatch rate)", "queue_type", qName, "elapsed_ms", elapsedMs)
+			throttledCount = event.NoSyncMatchSignalsSinceLast
+		} else if elapsedMs >= cooloffMs {
 			actions = append(actions, ScalingAction{Action: ActionTypeInvokeWorker})
 			updatedState[stateLastScaleUpTimestampKey] = nowMs
 		} else {
@@ -199,50 +282,119 @@ func (a *scalingAlgorithmNoSync) ProcessMetricsPoll(ctx context.Context, config 
 	}
 
 	pollIntervalMs := config.GetInt64Field(configNoSyncMetricsPollIntervalMsKey, configNoSyncMetricsPollIntervalMsDefault)
-	nextPoll := time.Duration(pollIntervalMs) * time.Millisecond
 	cooloffMs := config.GetInt64Field(configNoSyncScaleUpCooloffMsKey, configNoSyncScaleUpCooloffMsDefault)
 	backlogThreshold := config.GetInt64Field(configNoSyncScaleUpBacklogThresholdKey, configNoSyncScaleUpBacklogThresholdDefault)
 	maxWorkerLifetimeMs := config.GetInt64Field(configNoSyncMaxWorkerLifetimeMsKey, configNoSyncMaxWorkerLifetimeMsDefault)
-	epsilon := config.GetFloat64Field(configNoSyncScaleUpDispatchRateEpsilonKey, configNoSyncScaleUpDispatchRateEpsilonDefault)
 	lastScaleUpMs := priorState.GetInt64Field(stateLastScaleUpTimestampKey, 0)
 	nowMs := time.Now().UnixMilli() // safe: called from activity context, not workflow
 	elapsedSinceScaleUp := nowMs - lastScaleUpMs
 
+	// Flat-dispatch-rate detection runs per queue type: it persists each queue's verdict and gates that
+	// queue's growth. One scale-up per poll, OR-ed across queue types: growth (backlog + cooloff, gated
+	// when that queue is suppressed) OR lifetime-refresh maintenance (never gated).
+	suppressedAny := false
 	scaleUp := false
 	for _, q := range []struct {
-		qName   string
+		qType   enumspb.TaskQueueType
 		metrics *iface.QueueTypeScalingMetrics
 	}{
-		{"workflow", metricsSnapshot.Workflow},
-		{"activity", metricsSnapshot.Activity},
-		{"nexus", metricsSnapshot.Nexus},
+		{enumspb.TASK_QUEUE_TYPE_WORKFLOW, metricsSnapshot.Workflow},
+		{enumspb.TASK_QUEUE_TYPE_ACTIVITY, metricsSnapshot.Activity},
+		{enumspb.TASK_QUEUE_TYPE_NEXUS, metricsSnapshot.Nexus},
 	} {
+		suppressed := a.detectDispatchCeiling(ctx, config, priorState, updatedState, queueTypeName[q.qType], q.metrics, nowMs, backlogThreshold)
+		suppressedAny = suppressedAny || suppressed
 		if q.metrics == nil {
 			continue
 		}
 		backlog := q.metrics.LastBacklogCount
-		currentRate := float64(q.metrics.LastProcessingRate)
-		lastDispatchRateKey := fmt.Sprintf(stateLastDispatchRateKeyFmt, q.qName)
-		lastRate := priorState.GetFloat64Field(lastDispatchRateKey, -1)
 
 		perTypeScaleUp := false
 		if backlog > backlogThreshold && elapsedSinceScaleUp >= cooloffMs {
 			perTypeScaleUp = true
 		}
+		if perTypeScaleUp && suppressed {
+			perTypeScaleUp = false
+		}
 		if !perTypeScaleUp && maxWorkerLifetimeMs > 0 && backlog > 0 && elapsedSinceScaleUp >= maxWorkerLifetimeMs {
 			perTypeScaleUp = true
 		}
-		if perTypeScaleUp && epsilon > 0 && lastRate >= 0 && math.Abs(currentRate-lastRate) <= epsilon {
-			perTypeScaleUp = false
-		}
-
 		scaleUp = scaleUp || perTypeScaleUp
-		updatedState[lastDispatchRateKey] = currentRate
 	}
 	if scaleUp {
 		actions = append(actions, ScalingAction{Action: ActionTypeInvokeWorker})
 		updatedState[stateLastScaleUpTimestampKey] = nowMs
 	}
 
+	// Back off to the (longer) suppress interval while any queue is actively suppressing -- finer than the
+	// ~30s dispatch-rate averaging window adds no signal.
+	nextPollMs := pollIntervalMs
+	if suppressedAny {
+		nextPollMs = config.GetInt64Field(configNoSyncSuppressPollIntervalMsKey, configNoSyncSuppressPollIntervalMsDefault)
+	}
+	nextPoll := time.Duration(nextPollMs) * time.Millisecond
+
 	return &MetricsPollResponse{Actions: actions, Status: updatedState, NextPoll: &nextPoll}, nil
+}
+
+// detectDispatchCeiling runs flat-dispatch-rate detection for one queue type. When epsilon > 0 it confirms
+// the queue's dispatch rate staying flat (within a relative band) under a material backlog over
+// flat_dispatch_rate_confirm_ms, persists the per-queue verdict (<queue>_dispatch_flat_since_ms,
+// _dispatch_ref_rate, and the _suppress_scale_up_until_ms lease) into updatedState, and returns whether that
+// queue's scale-up is currently suppressed. epsilon <= 0 disables it: the persisted verdict is cleared and
+// it returns false, so both paths revert to baseline. Activity queues are the only ones that can be
+// rate-limited today, but the detector works for any type -- a non-rate-limited queue's dispatch usually
+// rises out of the band before confirming (a sub-band-per-poll ramp can confirm briefly, then self-corrects).
+func (a *scalingAlgorithmNoSync) detectDispatchCeiling(ctx context.Context, config iface.ScalingAlgorithmConfig, priorState iface.ScalingAlgorithmStatus, updatedState map[string]any, qName string, metrics *iface.QueueTypeScalingMetrics, nowMs int64, backlogThreshold int64) bool {
+	flatSinceKey := fmt.Sprintf(stateDispatchFlatSinceKeyFmt, qName)
+	suppressUntilKey := fmt.Sprintf(stateSuppressScaleUpUntilKeyFmt, qName)
+	refRateKey := fmt.Sprintf(stateDispatchRefRateKeyFmt, qName)
+
+	epsilon := config.GetFloat64Field(configNoSyncScaleUpDispatchRateEpsilonKey, configNoSyncScaleUpDispatchRateEpsilonDefault)
+	if epsilon <= 0 {
+		delete(updatedState, suppressUntilKey)
+		delete(updatedState, flatSinceKey)
+		delete(updatedState, refRateKey)
+		return false
+	}
+
+	if metrics == nil {
+		// This queue type isn't in the group -- no ceiling to detect; leave any prior verdict untouched.
+		return false
+	}
+	rate := float64(metrics.LastProcessingRate)
+	backlog := metrics.LastBacklogCount
+
+	flatSince := priorState.GetInt64Field(flatSinceKey, 0)
+	suppressUntil := priorState.GetInt64Field(suppressUntilKey, 0)
+	refRate := priorState.GetFloat64Field(refRateKey, -1)
+
+	confirmMs := config.GetInt64Field(configNoSyncFlatDispatchRateConfirmMsKey, configNoSyncFlatDispatchRateConfirmMsDefault)
+	suppressMs := config.GetInt64Field(configNoSyncSuppressScaleUpMsKey, configNoSyncSuppressScaleUpMsDefault)
+
+	material := backlog > backlogThreshold
+	band := epsilon * refRate                              // relative band (fraction of dispatch)
+	moved := refRate >= 0 && math.Abs(rate-refRate) > band // dispatch rose OR dropped
+
+	switch {
+	case !material || moved || rate <= 0:
+		// no material backlog, dispatch moved, or zero throughput (a stall, not a flat dispatch rate
+		// to suppress) -> resume: clear the verdict so normal scale-up can recover
+		suppressUntil, flatSince, refRate = 0, 0, -1
+	case flatSince == 0:
+		// dispatch flat + material backlog -> start confirming; anchor the reference rate
+		flatSince, refRate = nowMs, rate
+	case nowMs-flatSince >= confirmMs:
+		// confirmed flat under backlog -> suppress; log only on the transition into suppression
+		if suppressUntil <= nowMs {
+			safeActivityLogger(ctx).Info("Flat dispatch rate: suppressing scale-up", "queue_type", qName, "dispatch_rate", rate, "backlog", backlog)
+		}
+		suppressUntil = nowMs + suppressMs
+	}
+
+	updatedState[flatSinceKey] = flatSince
+	updatedState[refRateKey] = refRate
+	updatedState[suppressUntilKey] = suppressUntil
+
+	return suppressUntil > nowMs
 }

--- a/wci/workflow/scaling_algorithm/no_sync_match_test.go
+++ b/wci/workflow/scaling_algorithm/no_sync_match_test.go
@@ -2,6 +2,7 @@ package scalingalgorithm
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +13,18 @@ import (
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 )
+
+// Per-queue detector state keys. The prefix is the queue-type name ("workflow"/"activity"/"nexus"); the
+// detector keys its verdict per type, so a test builds the keys for whichever queue it drives.
+func flatSinceKey(qName string) string {
+	return fmt.Sprintf(stateDispatchFlatSinceKeyFmt, qName)
+}
+func suppressUntilKey(qName string) string {
+	return fmt.Sprintf(stateSuppressScaleUpUntilKeyFmt, qName)
+}
+func refRateKey(qName string) string {
+	return fmt.Sprintf(stateDispatchRefRateKeyFmt, qName)
+}
 
 func newNoSync() *scalingAlgorithmNoSync {
 	algo, err := NewScalingAlgorithmNoSync(context.Background())
@@ -114,6 +127,87 @@ func TestNoSyncValidateConfig(t *testing.T) {
 		cfg := iface.ScalingAlgorithmConfig{
 			configNoSyncMetricsPollIntervalMsKey: int64(60000),
 			configNoSyncScaleUpCooloffMsKey:      int64(60000),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("flat_dispatch_rate_confirm_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncFlatDispatchRateConfirmMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("suppress_scale_up_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncSuppressScaleUpMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("suppress_poll_interval_ms negative", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncSuppressPollIntervalMsKey: int64(-1)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon at the 0.10 cap accepted", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.10)}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon just above the 0.10 cap rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.11)}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon>0 with confirm window <= 0 rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncFlatDispatchRateConfirmMsKey:  int64(0),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon>0 with suppress_poll_interval_ms <= 0 rejected", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncSuppressPollIntervalMsKey:     int64(0),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon>0 with suppress lease <= suppress poll interval rejected", func(t *testing.T) {
+		// The lease must outlast the suppress poll cadence, else it lapses between polls.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncSuppressScaleUpMsKey:          int64(90_000),
+			configNoSyncSuppressPollIntervalMsKey:     int64(90_000),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon>0 with confirm window <= poll interval rejected", func(t *testing.T) {
+		// At or below one poll interval the confirm window can't outlast the anchor poll, so it is a no-op.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncFlatDispatchRateConfirmMsKey:  int64(60_000),
+			configNoSyncMetricsPollIntervalMsKey:      int64(60_000),
+		}
+		require.Error(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("epsilon>0 with valid timers accepted", func(t *testing.T) {
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncFlatDispatchRateConfirmMsKey:  int64(90_000),
+			configNoSyncSuppressScaleUpMsKey:          int64(120_000),
+			configNoSyncSuppressPollIntervalMsKey:     int64(90_000),
+		}
+		require.NoError(t, a.ValidateConfig(ctx, cfg))
+	})
+
+	t.Run("disabled epsilon skips the timer cross-field checks", func(t *testing.T) {
+		// With epsilon=0 the detector is off, so an otherwise-invalid lease/poll relationship is allowed.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0),
+			configNoSyncSuppressScaleUpMsKey:          int64(90_000),
+			configNoSyncSuppressPollIntervalMsKey:     int64(90_000),
 		}
 		require.NoError(t, a.ValidateConfig(ctx, cfg))
 	})
@@ -332,88 +426,32 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		assert.Empty(t, resp.Actions)
 	})
 
-	t.Run("epsilon suppression on lifetime refresh path", func(t *testing.T) {
-		// Lifetime path triggers scale-up but epsilon suppresses it because rate is unchanged.
-		// Backlog threshold is set high so only the lifetime path would fire.
+	t.Run("flat dispatch rate detection never gates the lifetime-refresh (maintenance) path", func(t *testing.T) {
+		// The detector is driven into an ACTIVE suppressing state (material backlog, flat past the confirm
+		// window) and the last scale-up predates the lifetime. Growth is gated, but maintenance (lifetime
+		// refresh) must still fire -- an expired worker is replaced even at the dispatch ceiling.
+		now := time.Now().UnixMilli()
 		state := iface.ScalingAlgorithmStatus{
-			stateLastScaleUpTimestampKey:  int64(0),
-			"workflow_last_dispatch_rate": float64(10),
+			stateLastScaleUpTimestampKey:                          now - 10_000, // older than the 1s lifetime
+			fmt.Sprintf(stateDispatchFlatSinceKeyFmt, "workflow"): now - 46_000, // flat past the 45s confirm window
+			fmt.Sprintf(stateDispatchRefRateKeyFmt, "workflow"):   float64(10),
 		}
 		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncMaxWorkerLifetimeMsKey:        int64(1000),
-			configNoSyncScaleUpBacklogThresholdKey:    int64(100),
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
+			configNoSyncMaxWorkerLifetimeMsKey:        int64(1_000), // 1s — already elapsed
+			configNoSyncScaleUpBacklogThresholdKey:    int64(0),     // any backlog is material
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.05),
 			configNoSyncScaleUpCooloffMsKey:           int64(0),
+			configNoSyncFlatDispatchRateConfirmMsKey:  int64(45_000),
+			configNoSyncSuppressScaleUpMsKey:          int64(120_000),
+			configNoSyncSuppressPollIntervalMsKey:     int64(90_000),
 		}
 		snapshot := ScalingMetricsSnapshot{
 			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 10},
 		}
 		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
 		require.NoError(t, err)
-		assert.Empty(t, resp.Actions)
-	})
-
-	t.Run("epsilon does not suppress lifetime refresh when rate changed", func(t *testing.T) {
-		state := iface.ScalingAlgorithmStatus{
-			stateLastScaleUpTimestampKey:  int64(0),
-			"workflow_last_dispatch_rate": float64(10),
-		}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncMaxWorkerLifetimeMsKey:        int64(1000),
-			configNoSyncScaleUpBacklogThresholdKey:    int64(100),
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 3, LastProcessingRate: 15},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 1)
-		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-	})
-
-	t.Run("epsilon suppression rate unchanged", func(t *testing.T) {
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Empty(t, resp.Actions)
-	})
-
-	t.Run("epsilon suppression rate changed", func(t *testing.T) {
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 15},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 1)
-		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-	})
-
-	t.Run("epsilon disabled rate unchanged fires", func(t *testing.T) {
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 1)
+		assert.Greater(t, resp.Status.GetInt64Field(fmt.Sprintf(stateSuppressScaleUpUntilKeyFmt, "workflow"), 0), now, "precondition: detector is actively suppressing growth")
+		assert.Len(t, resp.Actions, 1, "maintenance fires despite active suppression")
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
 	})
 
@@ -441,32 +479,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
 	})
 
-	t.Run("dispatch rate saved in state without scale-up", func(t *testing.T) {
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 0, LastProcessingRate: 7},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, iface.ScalingAlgorithmConfig{}, nil, snapshot)
-		require.NoError(t, err)
-		assert.Empty(t, resp.Actions)
-		assert.InDelta(t, float64(7), resp.Status["workflow_last_dispatch_rate"], 1e-9)
-	})
-
-	t.Run("epsilon suppression skipped on first poll no prior rate", func(t *testing.T) {
-		// With no prior rate in state, lastRate defaults to -1 which skips the epsilon guard.
-		// A scale-up must still fire even when epsilon is enabled.
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 1)
-		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-	})
-
 	t.Run("only activity has backlog", func(t *testing.T) {
 		snapshot := ScalingMetricsSnapshot{
 			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5},
@@ -475,7 +487,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Actions, 1)
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-		assert.InDelta(t, float64(0), resp.Status["activity_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("only nexus has backlog", func(t *testing.T) {
@@ -486,7 +497,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, resp.Actions, 1)
 		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-		assert.InDelta(t, float64(0), resp.Status["nexus_last_dispatch_rate"], 1e-9)
 	})
 
 	t.Run("cooloff is shared across queue types", func(t *testing.T) {
@@ -530,23 +540,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		assert.Equal(t, 60*time.Second, *resp.NextPoll)
 	})
 
-	t.Run("dispatch rate saved in state after epsilon suppression", func(t *testing.T) {
-		// When scale-up is suppressed by epsilon, the rate should still be updated in state
-		// so that the next poll has the correct reference point.
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Empty(t, resp.Actions)
-		assert.InDelta(t, float64(10), resp.Status["workflow_last_dispatch_rate"], 1e-9)
-	})
-
 	t.Run("state threads correctly across two calls", func(t *testing.T) {
 		// First call: backlog triggers a scale-up and stores the timestamp in state.
 		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(30_000)}
@@ -584,58 +577,6 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
 		require.NoError(t, err)
 		assert.Empty(t, resp2.Actions, "second call: lifetime not yet elapsed, must not fire")
-	})
-
-	t.Run("epsilon at exact boundary suppresses", func(t *testing.T) {
-		// |currentRate - lastRate| == epsilon: the <= comparison must suppress the scale-up.
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		// Use rate that differs by exactly epsilon from lastRate via float arithmetic (10 + 0.5 = 10.5).
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10.5}, // diff = 0.0 <= 0.5
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Empty(t, resp.Actions, "diff == 0 is within epsilon, must suppress")
-	})
-
-	t.Run("epsilon just above boundary fires", func(t *testing.T) {
-		// |currentRate - lastRate| > epsilon: the scale-up must proceed.
-		state := iface.ScalingAlgorithmStatus{"workflow_last_dispatch_rate": float64(10)}
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			// LastProcessingRate is int32; use a value whose float64 diff is > 0.5.
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 11}, // diff = 1.0 > 0.5
-		}
-		resp, err := a.ProcessMetricsPoll(ctx, cfg, state, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp.Actions, 1, "diff > epsilon, must fire")
-		assert.Equal(t, ActionTypeInvokeWorker, resp.Actions[0].Action)
-	})
-
-	t.Run("dispatch rate state threads correctly across two calls", func(t *testing.T) {
-		// First call: stores dispatch rate in state.
-		cfg := iface.ScalingAlgorithmConfig{
-			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.5),
-			configNoSyncScaleUpCooloffMsKey:           int64(0),
-		}
-		snapshot := ScalingMetricsSnapshot{
-			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 5, LastProcessingRate: 10},
-		}
-		resp1, err := a.ProcessMetricsPoll(ctx, cfg, nil, snapshot)
-		require.NoError(t, err)
-		assert.Len(t, resp1.Actions, 1) // first poll: no prior rate, epsilon skipped
-
-		// Second call: same rate — epsilon suppresses scale-up using rate stored by first call.
-		resp2, err := a.ProcessMetricsPoll(ctx, cfg, resp1.Status, snapshot)
-		require.NoError(t, err)
-		assert.Empty(t, resp2.Actions)
 	})
 
 	t.Run("worker refresh does not fire when backlog is zero", func(t *testing.T) {
@@ -698,5 +639,360 @@ func TestNoSyncProcessMetricsPoll(t *testing.T) {
 		pollResp, err := a.ProcessMetricsPoll(ctx, cfg, taskAddResp.Status, snapshot)
 		require.NoError(t, err)
 		assert.Empty(t, pollResp.Actions)
+	})
+}
+
+// TestNoSyncFlatDispatchRateDetection covers the epsilon>0 flat-dispatch-rate detection end to end.
+// The detector is queue-type-agnostic: activity is the only rate-capped queue today, but the same
+// anchor -> confirm -> suppress -> resume lifecycle runs for every type. The per-type table drives that
+// full lifecycle against workflow, activity, AND nexus and asserts on each queue's own state keys; the
+// cross-queue cases that follow exercise interactions no single type can.
+func TestNoSyncFlatDispatchRateDetection(t *testing.T) {
+	a := newNoSync()
+	ctx := t.Context()
+
+	active := func() iface.ScalingAlgorithmConfig {
+		return iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+			configNoSyncFlatDispatchRateConfirmMsKey:  int64(45_000),
+			configNoSyncSuppressScaleUpMsKey:          int64(120_000),
+			configNoSyncSuppressPollIntervalMsKey:     int64(90_000),
+			configNoSyncMetricsPollIntervalMsKey:      int64(60_000),
+			configNoSyncMaxWorkerLifetimeMsKey:        int64(600_000),
+		}
+	}
+
+	type detectorQueue struct {
+		name string
+		typ  enumspb.TaskQueueType
+		snap func(backlog int64, rate float32) ScalingMetricsSnapshot
+	}
+	queues := []detectorQueue{
+		{"workflow", enumspb.TASK_QUEUE_TYPE_WORKFLOW, func(b int64, r float32) ScalingMetricsSnapshot {
+			return ScalingMetricsSnapshot{Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: b, LastProcessingRate: r}}
+		}},
+		{"activity", enumspb.TASK_QUEUE_TYPE_ACTIVITY, func(b int64, r float32) ScalingMetricsSnapshot {
+			return ScalingMetricsSnapshot{Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: b, LastProcessingRate: r}}
+		}},
+		{"nexus", enumspb.TASK_QUEUE_TYPE_NEXUS, func(b int64, r float32) ScalingMetricsSnapshot {
+			return ScalingMetricsSnapshot{Nexus: &iface.QueueTypeScalingMetrics{LastBacklogCount: b, LastProcessingRate: r}}
+		}},
+	}
+
+	// --- generic detector lifecycle, proven identically for every queue type ---
+	for _, q := range queues {
+		kFlat, kSuppress, kRef := flatSinceKey(q.name), suppressUntilKey(q.name), refRateKey(q.name)
+		flatSnap := q.snap(100, 5)
+
+		t.Run(q.name, func(t *testing.T) {
+			t.Run("first flat poll anchors and persists; growth still fires", func(t *testing.T) {
+				now := time.Now().UnixMilli()
+				state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now} // recent -> maintenance can't mask growth
+				r, err := a.ProcessMetricsPoll(ctx, active(), state, flatSnap)
+				require.NoError(t, err)
+				assert.Len(t, r.Actions, 1, "growth fires while still confirming")
+				assert.Contains(t, r.Status, kFlat)
+				assert.Contains(t, r.Status, kRef)
+				assert.Contains(t, r.Status, kSuppress)
+				assert.NotEqualValues(t, 0, r.Status[kFlat], "confirm timer anchored")
+				assert.EqualValues(t, 5, r.Status[kRef], "reference rate anchored")
+				assert.EqualValues(t, 0, r.Status[kSuppress], "not suppressed yet")
+				require.NotNil(t, r.NextPoll)
+				assert.Equal(t, 60_000*time.Millisecond, *r.NextPoll, "normal poll cadence while confirming")
+			})
+
+			t.Run("still flat past the confirm window -> suppress; fast path obeys; poll backs off", func(t *testing.T) {
+				cfg := active()
+				now := time.Now().UnixMilli()
+				state := iface.ScalingAlgorithmStatus{
+					stateLastScaleUpTimestampKey: now,          // recent -> poll sees no maintenance
+					kFlat:                        now - 46_000, // began before the 45s confirm window
+					kRef:                         float64(5),
+				}
+				r, err := a.ProcessMetricsPoll(ctx, cfg, state, flatSnap)
+				require.NoError(t, err)
+				assert.Greater(t, r.Status.GetInt64Field(kSuppress, 0), now, "suppression lease set into the future")
+				assert.Empty(t, r.Actions, "growth gated once suppressed")
+				require.NotNil(t, r.NextPoll)
+				assert.Equal(t, 90_000*time.Millisecond, *r.NextPoll, "poll backs off while suppressing")
+
+				// The persisted lease gates this queue's fast (task-add) path.
+				fr, err := a.ProcessTaskAdd(ctx, cfg, r.Status, iface.SignalTaskAddRequest{TaskQueueType: q.typ, NoSyncMatchSignalsSinceLast: 3})
+				require.NoError(t, err)
+				assert.Empty(t, fr.Actions, "fast-path growth suppressed at the ceiling")
+				assert.Equal(t, 3, fr.ThrottledCount)
+			})
+
+			t.Run("suppression lease renews on a sustained flat rate", func(t *testing.T) {
+				now := time.Now().UnixMilli()
+				// Already confirmed and actively suppressed; a near-term lease makes the renewal observable.
+				state := iface.ScalingAlgorithmStatus{
+					stateLastScaleUpTimestampKey: now,
+					kFlat:                        now - 100_000,
+					kRef:                         float64(5),
+					kSuppress:                    now + 10_000,
+				}
+				r, err := a.ProcessMetricsPoll(ctx, active(), state, flatSnap)
+				require.NoError(t, err)
+				assert.Greater(t, r.Status.GetInt64Field(kSuppress, 0), now+100_000, "lease renewed well beyond the prior near-term expiry")
+				assert.Empty(t, r.Actions, "growth stays gated while suppressing")
+			})
+
+			t.Run("reference anchored once; drift past the fixed band resumes", func(t *testing.T) {
+				// epsilon 0.08 on ref 100 -> band 8. A slow drift stays within band of each previous reading but
+				// eventually exceeds the band around the FIXED anchor; the detector never re-anchors, so it catches
+				// the cumulative drift (a rolling anchor would not).
+				cfg := active()
+				now := time.Now().UnixMilli()
+				r1, err := a.ProcessMetricsPoll(ctx, cfg, iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now}, q.snap(100, 100))
+				require.NoError(t, err)
+				assert.EqualValues(t, 100, r1.Status[kRef], "anchored at the first flat rate")
+				anchored := r1.Status[kFlat]
+
+				r2, err := a.ProcessMetricsPoll(ctx, cfg, r1.Status, q.snap(100, 105)) // within band of the anchor
+				require.NoError(t, err)
+				assert.EqualValues(t, 100, r2.Status[kRef], "reference NOT re-anchored on a subsequent flat poll")
+				assert.EqualValues(t, anchored, r2.Status[kFlat], "confirm timer not restarted")
+
+				r3, err := a.ProcessMetricsPoll(ctx, cfg, r2.Status, q.snap(100, 110)) // |110-100|=10 > band 8 vs the fixed anchor
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r3.Status[kSuppress], "verdict cleared once drift exceeds the fixed band")
+				assert.EqualValues(t, 0, r3.Status[kFlat], "confirm timer reset on movement")
+				assert.EqualValues(t, -1, r3.Status[kRef], "reference cleared on movement")
+			})
+
+			t.Run("band edge: exactly at the band suppresses, just past it resumes", func(t *testing.T) {
+				// ref 100, epsilon 0.08 -> band 8.0. |delta| must be strictly greater than the band to count as moved.
+				cfg := active()
+				now := time.Now().UnixMilli()
+				edge := iface.ScalingAlgorithmStatus{
+					stateLastScaleUpTimestampKey: now,
+					kFlat:                        now - 46_000, // confirm window elapsed
+					kRef:                         float64(100),
+				}
+				r, err := a.ProcessMetricsPoll(ctx, cfg, edge, q.snap(100, 108)) // |108-100|=8, not > 8 -> still flat
+				require.NoError(t, err)
+				assert.Greater(t, r.Status.GetInt64Field(kSuppress, 0), now, "exactly at the band counts as flat and suppresses")
+
+				r2, err := a.ProcessMetricsPoll(ctx, cfg, edge, q.snap(100, 109)) // |109-100|=9 > 8 -> moved
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r2.Status[kSuppress], "just past the band resumes")
+				assert.EqualValues(t, -1, r2.Status[kRef], "reference cleared on movement")
+			})
+
+			t.Run("dispatch dropping past the band resumes", func(t *testing.T) {
+				cfg := active()
+				now := time.Now().UnixMilli()
+				state := iface.ScalingAlgorithmStatus{
+					stateLastScaleUpTimestampKey: now,
+					kRef:                         float64(100),
+					kFlat:                        now - 100_000,
+					kSuppress:                    now + 100_000, // actively suppressed before the drop
+				}
+				// |90-100|=10 > band 8, under a still-material backlog: a real throughput drop, not a stall.
+				r, err := a.ProcessMetricsPoll(ctx, cfg, state, q.snap(100, 90))
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r.Status[kSuppress], "lease cleared when dispatch drops past the band")
+				assert.Len(t, r.Actions, 1, "growth resumes on a downward move too")
+			})
+
+			t.Run("zero dispatch under backlog is a stall, not a plateau", func(t *testing.T) {
+				cfg := active()
+				now := time.Now().UnixMilli()
+				zero := q.snap(100, 0)
+				// First poll: zero rate + material backlog must NOT anchor; growth fires to recover.
+				r1, err := a.ProcessMetricsPoll(ctx, cfg, iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now}, zero)
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r1.Status[kFlat], "zero rate does not start confirming")
+				assert.EqualValues(t, -1, r1.Status[kRef], "no reference anchored at zero throughput")
+				assert.Len(t, r1.Actions, 1, "growth fires to recover from a stall")
+
+				// Even with a stale zero-anchor past the confirm window, zero throughput never suppresses.
+				state := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now, kFlat: now - 200_000, kRef: float64(0)}
+				r2, err := a.ProcessMetricsPoll(ctx, cfg, state, zero)
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r2.Status[kSuppress], "zero throughput never suppresses")
+				assert.Len(t, r2.Actions, 1, "growth keeps firing under a stall")
+			})
+
+			t.Run("backlog draining clears an active lease", func(t *testing.T) {
+				cfg := active()
+				now := time.Now().UnixMilli()
+				state := iface.ScalingAlgorithmStatus{
+					kFlat:     now - 100_000,
+					kRef:      float64(5),
+					kSuppress: now + 100_000, // active lease
+				}
+				r, err := a.ProcessMetricsPoll(ctx, cfg, state, q.snap(0, 5)) // backlog drained
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r.Status[kSuppress], "lease cleared once backlog drains")
+				assert.EqualValues(t, 0, r.Status[kFlat], "confirm timer cleared")
+				assert.EqualValues(t, -1, r.Status[kRef], "reference cleared")
+			})
+
+			t.Run("backlog at the material threshold is not material -> resume", func(t *testing.T) {
+				// material := backlog > backlog_threshold (strict). At the threshold the queue is not material,
+				// so an active verdict clears; one above it stays material and suppresses.
+				cfg := active()
+				cfg[configNoSyncScaleUpBacklogThresholdKey] = int64(100)
+				now := time.Now().UnixMilli()
+				base := func() iface.ScalingAlgorithmStatus {
+					return iface.ScalingAlgorithmStatus{
+						stateLastScaleUpTimestampKey: now,
+						kFlat:                        now - 46_000,
+						kRef:                         float64(5),
+						kSuppress:                    now + 100_000,
+					}
+				}
+				r, err := a.ProcessMetricsPoll(ctx, cfg, base(), q.snap(100, 5)) // backlog == threshold
+				require.NoError(t, err)
+				assert.EqualValues(t, 0, r.Status[kSuppress], "backlog == threshold is not material; verdict clears")
+
+				r2, err := a.ProcessMetricsPoll(ctx, cfg, base(), q.snap(101, 5)) // one above the threshold
+				require.NoError(t, err)
+				assert.Greater(t, r2.Status.GetInt64Field(kSuppress, 0), now, "one above the threshold stays material and suppresses")
+			})
+
+			t.Run("fast path: an expired lease fires, an aged-out active lease still gates", func(t *testing.T) {
+				// The fast path is a pure lease consumer: it never checks epsilon or worker lifetime.
+				cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(0)} // no epsilon
+				now := time.Now().UnixMilli()
+
+				expired := iface.ScalingAlgorithmStatus{kSuppress: now - 1_000}
+				fr, err := a.ProcessTaskAdd(ctx, cfg, expired, iface.SignalTaskAddRequest{TaskQueueType: q.typ, NoSyncMatchSignalsSinceLast: 1})
+				require.NoError(t, err)
+				assert.Len(t, fr.Actions, 1, "expired lease no longer gates the fast path")
+				assert.Equal(t, 0, fr.ThrottledCount)
+
+				// Active lease and the worker has long aged out -> still gated (lifetime replacement is the poll's job).
+				held := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now - 700_000, kSuppress: now + 100_000}
+				fr2, err := a.ProcessTaskAdd(ctx, cfg, held, iface.SignalTaskAddRequest{TaskQueueType: q.typ, NoSyncMatchSignalsSinceLast: 2})
+				require.NoError(t, err)
+				assert.Empty(t, fr2.Actions, "active lease gates the fast path even past worker lifetime")
+				assert.Equal(t, 2, fr2.ThrottledCount)
+			})
+		})
+	}
+
+	// --- cross-queue interactions (no single queue type can exercise these) ---
+
+	t.Run("a queue's lease never gates another queue's fast path", func(t *testing.T) {
+		now := time.Now().UnixMilli()
+		for _, held := range queues {
+			for _, other := range queues {
+				if other.typ == held.typ {
+					continue
+				}
+				state := iface.ScalingAlgorithmStatus{
+					stateLastScaleUpTimestampKey: now, // recent -> no maintenance confusion
+					suppressUntilKey(held.name):  now + 100_000,
+				}
+				fr, err := a.ProcessTaskAdd(ctx, active(), state, iface.SignalTaskAddRequest{TaskQueueType: other.typ, NoSyncMatchSignalsSinceLast: 1})
+				require.NoError(t, err)
+				assert.Lenf(t, fr.Actions, 1, "a %s lease must not gate the %s fast path", held.name, other.name)
+			}
+		}
+	})
+
+	t.Run("each queue's verdict uses only its own dispatch rate", func(t *testing.T) {
+		now := time.Now().UnixMilli()
+		// Workflow flat at the ceiling (suppresses on its OWN rate, ignoring activity's spike); activity
+		// backlog spiking (must still grow). Workflow is iterated before activity, so if suppression leaked
+		// across queue types, activity's later growth would be wrongly gated -- this ordering catches that.
+		snap := ScalingMetricsSnapshot{
+			Workflow: &iface.QueueTypeScalingMetrics{LastBacklogCount: 100, LastProcessingRate: 5},
+			Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 100, LastProcessingRate: 999},
+		}
+		state := iface.ScalingAlgorithmStatus{
+			stateLastScaleUpTimestampKey: now,
+			flatSinceKey("workflow"):     now - 46_000,
+			refRateKey("workflow"):       float64(5), // anchored on workflow
+		}
+		r, err := a.ProcessMetricsPoll(ctx, active(), state, snap)
+		require.NoError(t, err)
+		assert.Greater(t, r.Status.GetInt64Field(suppressUntilKey("workflow"), 0), now, "workflow flatness suppresses on its own verdict, regardless of activity's rate")
+		// lastScaleUp is recent so this action can only be activity growth, not maintenance -- proving one
+		// queue's suppression never gates a different queue's scale-up in the same poll.
+		assert.Len(t, r.Actions, 1, "activity growth still fires while workflow is suppressed")
+		assert.Equal(t, ActionTypeInvokeWorker, r.Actions[0].Action)
+	})
+
+	t.Run("maintenance (lifetime refresh) fires even while a queue is suppressed", func(t *testing.T) {
+		now := time.Now().UnixMilli()
+		// Confirmed-flat (will suppress) and the last scale-up predates the 600s lifetime.
+		state := iface.ScalingAlgorithmStatus{
+			stateLastScaleUpTimestampKey: now - 700_000,
+			flatSinceKey("activity"):     now - 46_000,
+			refRateKey("activity"):       float64(5),
+		}
+		snap := ScalingMetricsSnapshot{Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 100, LastProcessingRate: 5}}
+		r, err := a.ProcessMetricsPoll(ctx, active(), state, snap)
+		require.NoError(t, err)
+		assert.Greater(t, r.Status.GetInt64Field(suppressUntilKey("activity"), 0), now, "still suppressing growth")
+		assert.Len(t, r.Actions, 1, "maintenance fires even while suppressed")
+	})
+
+	t.Run("disabled detector (epsilon<=0) clears any persisted verdict", func(t *testing.T) {
+		now := time.Now().UnixMilli()
+		cfg := iface.ScalingAlgorithmConfig{configNoSyncScaleUpCooloffMsKey: int64(0)} // epsilon defaults to 0
+		state := iface.ScalingAlgorithmStatus{
+			suppressUntilKey("activity"): now + 100_000,
+			flatSinceKey("activity"):     now - 50_000,
+			refRateKey("activity"):       float64(5),
+		}
+		snap := ScalingMetricsSnapshot{Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 100, LastProcessingRate: 5}}
+		r, err := a.ProcessMetricsPoll(ctx, cfg, state, snap)
+		require.NoError(t, err)
+		assert.NotContains(t, r.Status, suppressUntilKey("activity"), "lease cleared when detector disabled")
+		assert.NotContains(t, r.Status, flatSinceKey("activity"), "flat-since cleared when detector disabled")
+		assert.NotContains(t, r.Status, refRateKey("activity"), "ref-rate cleared when detector disabled")
+	})
+
+	t.Run("no metrics for a queue leaves its prior verdict untouched", func(t *testing.T) {
+		now := time.Now().UnixMilli()
+		state := iface.ScalingAlgorithmStatus{
+			stateLastScaleUpTimestampKey: now,
+			flatSinceKey("activity"):     now - 100_000,
+			refRateKey("activity"):       float64(5),
+			suppressUntilKey("activity"): now + 100_000,
+		}
+		// Empty snapshot: with no metrics for any queue, every persisted verdict is left as-is.
+		r, err := a.ProcessMetricsPoll(ctx, active(), state, ScalingMetricsSnapshot{})
+		require.NoError(t, err)
+		assert.EqualValues(t, now+100_000, r.Status[suppressUntilKey("activity")], "lease preserved on a no-metrics poll")
+		assert.EqualValues(t, now-100_000, r.Status[flatSinceKey("activity")], "flat-since preserved")
+		assert.EqualValues(t, 5, r.Status[refRateKey("activity")], "ref-rate preserved")
+	})
+
+	t.Run("timing knobs fall back to defaults when unset", func(t *testing.T) {
+		// Only epsilon + cooloff set; confirm/suppress/suppress-poll use the 90s/120s/90s defaults.
+		cfg := iface.ScalingAlgorithmConfig{
+			configNoSyncScaleUpDispatchRateEpsilonKey: float64(0.08),
+			configNoSyncScaleUpCooloffMsKey:           int64(0),
+		}
+		flatSnap := ScalingMetricsSnapshot{Activity: &iface.QueueTypeScalingMetrics{LastBacklogCount: 100, LastProcessingRate: 5}}
+
+		// Flat but 1s short of the default 90s confirm window -> not suppressed; normal poll cadence.
+		now := time.Now().UnixMilli()
+		before := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now, flatSinceKey("activity"): now - 89_000, refRateKey("activity"): float64(5)}
+		rb, err := a.ProcessMetricsPoll(ctx, cfg, before, flatSnap)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, rb.Status[suppressUntilKey("activity")], "not confirmed before the default 90s window")
+		require.NotNil(t, rb.NextPoll)
+		assert.Equal(t, 60_000*time.Millisecond, *rb.NextPoll, "normal poll while confirming")
+
+		// Flat past the default 90s window -> suppress with the default 120s lease; poll backs off to 90s.
+		now = time.Now().UnixMilli()
+		after := iface.ScalingAlgorithmStatus{stateLastScaleUpTimestampKey: now, flatSinceKey("activity"): now - 91_000, refRateKey("activity"): float64(5)}
+		lo := time.Now().UnixMilli()
+		ra, err := a.ProcessMetricsPoll(ctx, cfg, after, flatSnap)
+		require.NoError(t, err)
+		hi := time.Now().UnixMilli()
+		lease := ra.Status.GetInt64Field(suppressUntilKey("activity"), 0)
+		assert.GreaterOrEqual(t, lease, lo+120_000, "default 120s suppress lease (lower bound)")
+		assert.LessOrEqual(t, lease, hi+120_000, "default 120s suppress lease (upper bound)")
+		require.NotNil(t, ra.NextPoll)
+		assert.Equal(t, 90_000*time.Millisecond, *ra.NextPoll, "default 90s suppress poll while suppressing")
 	})
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds queue metrics based flat dispatch rate detection to no-sync scaling algorithm, gated on `scale_up_dispatch_rate_epsilon > 0`:

- A metrics poll confirms the queue's dispatch rate staying flat under a material backlog and persists a suppression lease.
- The lease gates the scale-up on **both** the poll path and the task-add fast path. 
- `epsilon = 0` (default) is unchanged from today's behavior.

## Why?
<!-- Tell your future self why have you made these changes -->
This is to suppress the scale up actions that are based on the presence of no-sync matches from matching outcome or backlog whenever we observe that the dispatch rate is trending flat even with workers being added. 

## Checklist
<!--- add/delete as needed --->

1. Closes COM-366
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Ran a load that drives arrival > dispatch rate and simulates the flat dispatch rate behavior, validated that suppression engages. 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
Yes, will follow up with the doc and CLI changes in the next PRs
