### PR TITLE
Change default compute provider config behavior

### DIFF
--- a/tests/integration/env.go
+++ b/tests/integration/env.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.temporal.io/auto-scaled-workers/wci/client"
+	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/tests/testcore"
 )
@@ -27,6 +28,10 @@ func createWCITestEnv(t *testing.T) *testcore.TestEnv {
 		testcore.WithDedicatedCluster(),
 		testcore.WithWorkerService("WCI"),
 		testcore.WithDynamicConfig(client.WorkerControllerEnabled, true),
+		testcore.WithDynamicConfig(client.WorkerControllerEnabledComputeProviders, []string{
+			string(iface.ComputeProviderTypeTestInvoke),
+			string(iface.ComputeProviderTypeTestWorkerSet),
+		}),
 		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusRefreshInterval, testVersionDrainageRefreshInterval),
 		testcore.WithDynamicConfig(dynamicconfig.VersionDrainageStatusVisibilityGracePeriod, testVersionDrainageVisibilityGracePeriod),
 		// Effectively disable no-sync-match signal batching so each backlogged

--- a/wci/workflow/activities_test.go
+++ b/wci/workflow/activities_test.go
@@ -18,6 +18,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/auto-scaled-workers/wci/client"
 	wcimetrics "go.temporal.io/auto-scaled-workers/wci/metrics"
 	computeprovider "go.temporal.io/auto-scaled-workers/wci/workflow/compute_provider"
 	"go.temporal.io/auto-scaled-workers/wci/workflow/iface"
@@ -27,6 +28,7 @@ import (
 	sdkworkflow "go.temporal.io/sdk/workflow"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/sdk"
 )
@@ -897,10 +899,19 @@ func rateBasedWorkerSetGroup(t *testing.T, taskType enumspb.TaskQueueType, initi
 	}
 }
 
+func NewTestDynamicConfigCollection() *dynamicconfig.Collection {
+	staticConfig := map[dynamicconfig.Key]any{
+		client.WorkerControllerEnabledComputeProviders.Key(): []string{
+			string(iface.ComputeProviderTypeTestWorkerSet),
+		},
+	}
+	return dynamicconfig.NewCollection(dynamicconfig.StaticClient(staticConfig), log.NewNoopLogger())
+}
+
 func runInvokeWorkersToRegisterTaskQueues(t *testing.T, fake *fakeWorkflowServiceClient, spec iface.WorkerControllerInstanceSpec, scalingStatus map[string]iface.ScalingAlgorithmStatus) *InvokeWorkersToRegisterTaskQueuesResponse {
 	t.Helper()
 	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, "active")
-	activities := NewActivities(ns, dynamicconfig.NewNoopCollection(), fake)
+	activities := NewActivities(ns, NewTestDynamicConfigCollection(), fake)
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()
@@ -925,7 +936,7 @@ func runInvokeWorkersToRegisterTaskQueues(t *testing.T, fake *fakeWorkflowServic
 func runInvokeWorkersToRegisterTaskQueuesErr(t *testing.T, fake *fakeWorkflowServiceClient, spec iface.WorkerControllerInstanceSpec) (*InvokeWorkersToRegisterTaskQueuesResponse, error) {
 	t.Helper()
 	ns := namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Name: "test-namespace"}, nil, "active")
-	activities := NewActivities(ns, dynamicconfig.NewNoopCollection(), fake)
+	activities := NewActivities(ns, NewTestDynamicConfigCollection(), fake)
 
 	var suite testsuite.WorkflowTestSuite
 	env := suite.NewTestActivityEnvironment()

--- a/wci/workflow/compute_provider/registry.go
+++ b/wci/workflow/compute_provider/registry.go
@@ -71,7 +71,7 @@ func RegisterComputeProvider(providerType iface.ComputeProviderType, ctor Comput
 
 func GetComputeProvider(ctx context.Context, providerType iface.ComputeProviderType, namespaceName string, dc *dynamicconfig.Collection) (ComputeProvider, error) {
 	enabledProviders := client.WorkerControllerEnabledComputeProviders.Get(dc)(namespaceName)
-	if enabledProviders != nil && !slices.Contains(enabledProviders, string(providerType)) {
+	if !slices.Contains(enabledProviders, string(providerType)) {
 		return nil, nil
 	}
 

--- a/wci/workflow/compute_provider/subprocess.go
+++ b/wci/workflow/compute_provider/subprocess.go
@@ -1,4 +1,4 @@
-//go:build !release
+//go:build computeprovider_subprocess && !release
 
 package computeprovider
 


### PR DESCRIPTION
## What was changed
Default to an empty compute provider allowlist rather than a full one.

## Why?
This makes the config behave as written, instead of assigning a special meaning to the null value.
