### PR TITLE
Bump default WCI version to 3

### DIFF
--- a/wci/client/config.go
+++ b/wci/client/config.go
@@ -32,7 +32,7 @@ var (
 	)
 	WorkerControllerInstanceWorkflowVersion = dynamicconfig.NewNamespaceIntSetting(
 		"workercontroller.instanceWorkflowVersion",
-		2,
+		3,
 		`WorkerControllerInstanceWorkflowVersion controls what version of the logic should the manager workflows use.`,
 	)
 	WorkerControllerMinSignalIntervalNoSyncMatchMilliseconds = dynamicconfig.NewNamespaceIntSetting(


### PR DESCRIPTION
## What was changed
Changes the default version of the WCI workflow to 3. This turns on the change introduced in #109 on by default.
